### PR TITLE
CVE-2017-1000211: update upstream affected version for the issue

### DIFF
--- a/2017/1000xxx/CVE-2017-1000211.json
+++ b/2017/1000xxx/CVE-2017-1000211.json
@@ -17,7 +17,7 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "v2.8.8 and older"
+                                 "version_value" : "before 2.8.9dev.16"
                               }
                            ]
                         }
@@ -36,7 +36,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "Lynx version 2.8.8 and older is vulnerable to a use after free in the HTML parser resulting in memory disclosure."
+            "value" : "Lynx version before 2.8.9dev.16 is vulnerable to a use after free in the HTML parser resulting in memory disclosure."
          }
       ]
    },


### PR DESCRIPTION
The issue was adressed in upstream 2.8.9dev.16 version.

Signed-off-by: Salvatore Bonaccorso <carnil@debian.org>