### PR TITLE
Set of Cambium Networks vulns from Rapid7

### DIFF
--- a/2017/5xxx/CVE-2017-5254.json
+++ b/2017/5xxx/CVE-2017-5254.json
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "The non-administrative users 'installer' and 'home' have the capability of changing passwords for other accounts, including admin, after disabling a client-side protection mechanism."
+            "value" : "In version 3.5 and prior of Cambium Networks ePMP firmware, the non-administrative users 'installer' and 'home' have the capability of changing passwords for other accounts, including admin, after disabling a client-side protection mechanism."
          }
       ]
    },

--- a/2017/5xxx/CVE-2017-5254.json
+++ b/2017/5xxx/CVE-2017-5254.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "cve@rapid7.com",
       "ID" : "CVE-2017-5254",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "ePMP",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "3.5 and prior"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Cambium Networks"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "The non-administrative users 'installer' and 'home' have the capability of changing passwords for other accounts, including admin, after disabling a client-side protection mechanism."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-284 (Improper Access Control)"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/"
          }
       ]
    }

--- a/2017/5xxx/CVE-2017-5255.json
+++ b/2017/5xxx/CVE-2017-5255.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-5255",
-      "STATE" : "RESERVED"
+      "ASSIGNER" : "cve@rapid7.com",
+      "ID" : "CVE-2017-5254",
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "ePMP",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "3.5 and prior"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Cambium Networks"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "Due to a lack of input sanitation for certain parameters on the web management console, any authenticated user (including the otherwise low-privilege readonly user) can inject shell meta-characters as part of a specially-crafted POST request to the get_chart function and run OS-level commands, effectively as root."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-78 (Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection'))"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/"
          }
       ]
    }

--- a/2017/5xxx/CVE-2017-5255.json
+++ b/2017/5xxx/CVE-2017-5255.json
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "Due to a lack of input sanitation for certain parameters on the web management console, any authenticated user (including the otherwise low-privilege readonly user) can inject shell meta-characters as part of a specially-crafted POST request to the get_chart function and run OS-level commands, effectively as root."
+            "value" : "In version 3.5 and prior of Cambium Networks ePMP firmware, a lack of input sanitation for certain parameters on the web management console allows any authenticated user (including the otherwise low-privilege readonly user) to inject shell meta-characters as part of a specially-crafted POST request to the get_chart function and run OS-level commands, effectively as root."
          }
       ]
    },

--- a/2017/5xxx/CVE-2017-5255.json
+++ b/2017/5xxx/CVE-2017-5255.json
@@ -1,7 +1,7 @@
 {
    "CVE_data_meta" : {
       "ASSIGNER" : "cve@rapid7.com",
-      "ID" : "CVE-2017-5254",
+      "ID" : "CVE-2017-5255",
       "STATE" : "PUBLIC"
    },
    "affects" : {

--- a/2017/5xxx/CVE-2017-5256.json
+++ b/2017/5xxx/CVE-2017-5256.json
@@ -1,7 +1,7 @@
 {
    "CVE_data_meta" : {
       "ASSIGNER" : "cve@rapid7.com",
-      "ID" : "CVE-2017-5254",
+      "ID" : "CVE-2017-5256",
       "STATE" : "PUBLIC"
    },
    "affects" : {

--- a/2017/5xxx/CVE-2017-5256.json
+++ b/2017/5xxx/CVE-2017-5256.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-5256",
-      "STATE" : "RESERVED"
+      "ASSIGNER" : "cve@rapid7.com",
+      "ID" : "CVE-2017-5254",
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "ePMP",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "3.5 and prior"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Cambium Networks"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "All authenticated users have the ability to update the Device Name and System Description fields in the web administration console, and those fields are vulnerable to persistent cross-site scripting (XSS) injection."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-79 (Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting'))"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/"
          }
       ]
    }

--- a/2017/5xxx/CVE-2017-5256.json
+++ b/2017/5xxx/CVE-2017-5256.json
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "All authenticated users have the ability to update the Device Name and System Description fields in the web administration console, and those fields are vulnerable to persistent cross-site scripting (XSS) injection."
+            "value" : "In version 3.5 and prior of Cambium Networks ePMP firmware, all authenticated users have the ability to update the Device Name and System Description fields in the web administration console, and those fields are vulnerable to persistent cross-site scripting (XSS) injection."
          }
       ]
    },

--- a/2017/5xxx/CVE-2017-5257.json
+++ b/2017/5xxx/CVE-2017-5257.json
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "An attacker who knows (or guesses) the SNMP read/write (RW) community string can insert XSS strings in certain SNMP OIDs which will execute in the context of the currently-logged on user."
+            "value" : "In version 3.5 and prior of Cambium Networks ePMP firmware, an attacker who knows (or guesses) the SNMP read/write (RW) community string can insert XSS strings in certain SNMP OIDs which will execute in the context of the currently-logged on user."
          }
       ]
    },

--- a/2017/5xxx/CVE-2017-5257.json
+++ b/2017/5xxx/CVE-2017-5257.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-5257",
-      "STATE" : "RESERVED"
+      "ASSIGNER" : "cve@rapid7.com",
+      "ID" : "CVE-2017-5254",
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "ePMP",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "3.5 and prior"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Cambium Networks"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "An attacker who knows (or guesses) the SNMP read/write (RW) community string can insert XSS strings in certain SNMP OIDs which will execute in the context of the currently-logged on user."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-79 (Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting'))"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/"
          }
       ]
    }

--- a/2017/5xxx/CVE-2017-5257.json
+++ b/2017/5xxx/CVE-2017-5257.json
@@ -1,7 +1,7 @@
 {
    "CVE_data_meta" : {
       "ASSIGNER" : "cve@rapid7.com",
-      "ID" : "CVE-2017-5254",
+      "ID" : "CVE-2017-5257",
       "STATE" : "PUBLIC"
    },
    "affects" : {

--- a/2017/5xxx/CVE-2017-5258.json
+++ b/2017/5xxx/CVE-2017-5258.json
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "An attacker who knows or can guess the RW community string can provide a URL for a configuration file over SNMP with XSS strings in certain SNMP OIDs, serve it via HTTP, and the affected device will perform a configuration restore using the attacker’s supplied config file, including the inserted XSS strings."
+            "value" : "In version 3.5 and prior of Cambium Networks ePMP firmware, an attacker who knows or can guess the RW community string can provide a URL for a configuration file over SNMP with XSS strings in certain SNMP OIDs, serve it via HTTP, and the affected device will perform a configuration restore using the attacker’s supplied config file, including the inserted XSS strings."
          }
       ]
    },

--- a/2017/5xxx/CVE-2017-5258.json
+++ b/2017/5xxx/CVE-2017-5258.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-5258",
-      "STATE" : "RESERVED"
+      "ASSIGNER" : "cve@rapid7.com",
+      "ID" : "CVE-2017-5254",
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "ePMP",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "3.5 and prior"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Cambium Networks"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "An attacker who knows or can guess the RW community string can provide a URL for a configuration file over SNMP with XSS strings in certain SNMP OIDs, serve it via HTTP, and the affected device will perform a configuration restore using the attacker’s supplied config file, including the inserted XSS strings."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-79 (Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting'))"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/"
          }
       ]
    }

--- a/2017/5xxx/CVE-2017-5258.json
+++ b/2017/5xxx/CVE-2017-5258.json
@@ -1,7 +1,7 @@
 {
    "CVE_data_meta" : {
       "ASSIGNER" : "cve@rapid7.com",
-      "ID" : "CVE-2017-5254",
+      "ID" : "CVE-2017-5258",
       "STATE" : "PUBLIC"
    },
    "affects" : {

--- a/2017/5xxx/CVE-2017-5259.json
+++ b/2017/5xxx/CVE-2017-5259.json
@@ -15,7 +15,7 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "3.5 and prior"
+                                 "version_value" : "4.3.2-R4 and prior"
                               }
                            ]
                         }
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "An undocumented, root-privilege administration web shell is available using the HTTP path https://<device-ip-or-hostname>/adm/syscmd.asp."
+            "value" : "In versions 4.3.2-R4 and prior of Cambium Networks cnPilot firmware, an undocumented, root-privilege administration web shell is available using the HTTP path https://<device-ip-or-hostname>/adm/syscmd.asp."
          }
       ]
    },

--- a/2017/5xxx/CVE-2017-5259.json
+++ b/2017/5xxx/CVE-2017-5259.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-5259",
-      "STATE" : "RESERVED"
+      "ASSIGNER" : "cve@rapid7.com",
+      "ID" : "CVE-2017-5254",
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "cnPilot",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "3.5 and prior"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Cambium Networks"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "An undocumented, root-privilege administration web shell is available using the HTTP path https://<device-ip-or-hostname>/adm/syscmd.asp."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-489 (Leftover Debug Code)"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/"
          }
       ]
    }

--- a/2017/5xxx/CVE-2017-5259.json
+++ b/2017/5xxx/CVE-2017-5259.json
@@ -1,7 +1,7 @@
 {
    "CVE_data_meta" : {
       "ASSIGNER" : "cve@rapid7.com",
-      "ID" : "CVE-2017-5254",
+      "ID" : "CVE-2017-5259",
       "STATE" : "PUBLIC"
    },
    "affects" : {

--- a/2017/5xxx/CVE-2017-5260.json
+++ b/2017/5xxx/CVE-2017-5260.json
@@ -15,7 +15,7 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "3.5 and prior"
+                                 "version_value" : "4.3.2-R4 and prior"
                               }
                            ]
                         }
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "While the option to access the configuration file is not available in the normal web administrative console for the 'user' account, it is accessible via direct object reference (DRO) at http://<device-ip-or-hostname>/goform/down_cfg_file by the 'user' account."
+            "value" : "In versions 4.3.2-R4 and prior of Cambium Networks cnPilot firmware, although the option to access the configuration file is not available in the normal web administrative console for the 'user' account, the configuration file is accessible via direct object reference (DRO) at http://<device-ip-or-hostname>/goform/down_cfg_file by this otherwise low privilege 'user' account."
          }
       ]
    },

--- a/2017/5xxx/CVE-2017-5260.json
+++ b/2017/5xxx/CVE-2017-5260.json
@@ -1,7 +1,7 @@
 {
    "CVE_data_meta" : {
       "ASSIGNER" : "cve@rapid7.com",
-      "ID" : "CVE-2017-5254",
+      "ID" : "CVE-2017-5260",
       "STATE" : "PUBLIC"
    },
    "affects" : {

--- a/2017/5xxx/CVE-2017-5260.json
+++ b/2017/5xxx/CVE-2017-5260.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-5260",
-      "STATE" : "RESERVED"
+      "ASSIGNER" : "cve@rapid7.com",
+      "ID" : "CVE-2017-5254",
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "cnPilot",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "3.5 and prior"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Cambium Networks"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "While the option to access the configuration file is not available in the normal web administrative console for the 'user' account, it is accessible via direct object reference (DRO) at http://<device-ip-or-hostname>/goform/down_cfg_file by the 'user' account."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-472 (External Control of Assumed-Immutable Web Parameter)"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/"
          }
       ]
    }

--- a/2017/5xxx/CVE-2017-5261.json
+++ b/2017/5xxx/CVE-2017-5261.json
@@ -1,7 +1,7 @@
 {
    "CVE_data_meta" : {
       "ASSIGNER" : "cve@rapid7.com",
-      "ID" : "CVE-2017-5254",
+      "ID" : "CVE-2017-5261",
       "STATE" : "PUBLIC"
    },
    "affects" : {

--- a/2017/5xxx/CVE-2017-5261.json
+++ b/2017/5xxx/CVE-2017-5261.json
@@ -15,7 +15,7 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "3.5 and prior"
+                                 "version_value" : "4.3.2-R4 and prior"
                               }
                            ]
                         }
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "The 'ping' and 'traceroute' functions of the web administrative console expose a file path traversal vulnerability, accessible to all authenticated users."
+            "value" : "In versions 4.3.2-R4 and prior of Cambium Networks cnPilot firmware, the 'ping' and 'traceroute' functions of the web administrative console expose a file path traversal vulnerability, accessible to all authenticated users."
          }
       ]
    },

--- a/2017/5xxx/CVE-2017-5261.json
+++ b/2017/5xxx/CVE-2017-5261.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-5261",
-      "STATE" : "RESERVED"
+      "ASSIGNER" : "cve@rapid7.com",
+      "ID" : "CVE-2017-5254",
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "cnPilot",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "3.5 and prior"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Cambium Networks"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "The 'ping' and 'traceroute' functions of the web administrative console expose a file path traversal vulnerability, accessible to all authenticated users."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-472 (External Control of Assumed-Immutable Web Parameter)"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/"
          }
       ]
    }

--- a/2017/5xxx/CVE-2017-5262.json
+++ b/2017/5xxx/CVE-2017-5262.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-5262",
-      "STATE" : "RESERVED"
+      "ASSIGNER" : "cve@rapid7.com",
+      "ID" : "CVE-2017-5254",
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "cnPilot",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "3.5 and prior"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Cambium Networks"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "The SNMP read-only (RO) community string has access to sensitive information by OID reference."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-200 (Information Exposure)"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/"
          }
       ]
    }

--- a/2017/5xxx/CVE-2017-5262.json
+++ b/2017/5xxx/CVE-2017-5262.json
@@ -1,7 +1,7 @@
 {
    "CVE_data_meta" : {
       "ASSIGNER" : "cve@rapid7.com",
-      "ID" : "CVE-2017-5254",
+      "ID" : "CVE-2017-5262",
       "STATE" : "PUBLIC"
    },
    "affects" : {

--- a/2017/5xxx/CVE-2017-5262.json
+++ b/2017/5xxx/CVE-2017-5262.json
@@ -15,7 +15,7 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "3.5 and prior"
+                                 "version_value" : "4.3.2-R4 and prior"
                               }
                            ]
                         }
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "The SNMP read-only (RO) community string has access to sensitive information by OID reference."
+            "value" : "In versions 4.3.2-R4 and prior of Cambium Networks cnPilot firmware, the SNMP read-only (RO) community string has access to sensitive information by OID reference."
          }
       ]
    },

--- a/2017/5xxx/CVE-2017-5263.json
+++ b/2017/5xxx/CVE-2017-5263.json
@@ -15,7 +15,7 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "3.5 and prior"
+                                 "version_value" : "4.3.2-R4 and prior"
                               }
                            ]
                         }
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "cnPilot devices lack CSRF controls that can mitigate the effects of CSRF attacks, which are most typically implemented as randomized per-session tokens associated with any web application function, especially destructive ones."
+            "value" : "Versions 4.3.2-R4 and prior of Cambium Networks cnPilot firmware lack CSRF controls that can mitigate the effects of CSRF attacks, which are most typically implemented as randomized per-session tokens associated with any web application function, especially destructive ones."
          }
       ]
    },

--- a/2017/5xxx/CVE-2017-5263.json
+++ b/2017/5xxx/CVE-2017-5263.json
@@ -1,7 +1,7 @@
 {
    "CVE_data_meta" : {
       "ASSIGNER" : "cve@rapid7.com",
-      "ID" : "CVE-2017-5254",
+      "ID" : "CVE-2017-5263",
       "STATE" : "PUBLIC"
    },
    "affects" : {

--- a/2017/5xxx/CVE-2017-5263.json
+++ b/2017/5xxx/CVE-2017-5263.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-5263",
-      "STATE" : "RESERVED"
+      "ASSIGNER" : "cve@rapid7.com",
+      "ID" : "CVE-2017-5254",
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "cnPilot",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "3.5 and prior"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Cambium Networks"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "cnPilot devices lack CSRF controls that can mitigate the effects of CSRF attacks, which are most typically implemented as randomized per-session tokens associated with any web application function, especially destructive ones."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-352 (Cross-Site Request Forgery (CSRF))"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/"
          }
       ]
    }


### PR DESCRIPTION
Update for 10 CVEs assigned to the most recent set of vulnerabilities on Cambium Networks, disclosed by Rapid7, discovered by @juushya.
