### PR TITLE
ZDI assigns the following CVEs:

### DIFF
--- a/2017/10xxx/CVE-2017-10956.json
+++ b/2017/10xxx/CVE-2017-10956.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-10956",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the tile index member of SOT markers. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-4978."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-858"
          }
       ]
    }

--- a/2017/10xxx/CVE-2017-10957.json
+++ b/2017/10xxx/CVE-2017-10957.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-10957",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the arrowEnd attribute of Annotation objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-4979."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-859"
          }
       ]
    }

--- a/2017/10xxx/CVE-2017-10958.json
+++ b/2017/10xxx/CVE-2017-10958.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-10958",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the value attribute of Field objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-4980."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-860"
          }
       ]
    }

--- a/2017/10xxx/CVE-2017-10959.json
+++ b/2017/10xxx/CVE-2017-10959.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-10959",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the setAction method of Link objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-4981."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-861"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14818.json
+++ b/2017/14xxx/CVE-2017-14818.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14818",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of JPEG2000 images embedded in PDF files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-4982."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-862"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14819.json
+++ b/2017/14xxx/CVE-2017-14819.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14819",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the channel number member of the cdef box. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5011."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-863"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14820.json
+++ b/2017/14xxx/CVE-2017-14820.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14820",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the tile index of the SOT marker in JPEG2000 images. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5012."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-864"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14821.json
+++ b/2017/14xxx/CVE-2017-14821.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14821",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of the xTsiz member of SIZ markers. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5013."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-865"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14822.json
+++ b/2017/14xxx/CVE-2017-14822.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14822",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of the xOsiz member of SIZ markers. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5014."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-866"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14823.json
+++ b/2017/14xxx/CVE-2017-14823.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14823",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the signer method of XFA's Signature objects. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code in the context of the current process.  Was ZDI-CAN-5015."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-867"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14824.json
+++ b/2017/14xxx/CVE-2017-14824.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14824",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the insert method of XFAScriptObject objects. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5016."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-868"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14825.json
+++ b/2017/14xxx/CVE-2017-14825.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14825",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the remove method of XFAScriptObject objects. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5017."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-869"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14826.json
+++ b/2017/14xxx/CVE-2017-14826.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14826",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the formNodes method of XFA Node objects. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5018."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-870"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14827.json
+++ b/2017/14xxx/CVE-2017-14827.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14827",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the append method of XFA Node objects. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5019."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-871"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14828.json
+++ b/2017/14xxx/CVE-2017-14828.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14828",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the w method of XFA Layout objects. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5020."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-872"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14829.json
+++ b/2017/14xxx/CVE-2017-14829.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14829",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the openList method of XFAScriptObject objects. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this to execute code in the context of the current process.  Was ZDI-CAN-5021."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-873"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14830.json
+++ b/2017/14xxx/CVE-2017-14830.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14830",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the setFocus method of XFAScriptObject objects. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this to execute code in the context of the current process.  Was ZDI-CAN-5022."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-874"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14831.json
+++ b/2017/14xxx/CVE-2017-14831.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14831",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the author attribute of Circle Annotation objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5023."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-875"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14832.json
+++ b/2017/14xxx/CVE-2017-14832.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14832",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the style attribute of Caret Annotation objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5024."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-876"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14833.json
+++ b/2017/14xxx/CVE-2017-14833.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14833",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the style attribute of Text Annotation objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5025."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-877"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14834.json
+++ b/2017/14xxx/CVE-2017-14834.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14834",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the style attribute of FileAttachment annotation objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5026."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-878"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14835.json
+++ b/2017/14xxx/CVE-2017-14835.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14835",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the page method of XFA Layout objects. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this to execute code in the context of the current process.  Was ZDI-CAN-5027."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-879"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14836.json
+++ b/2017/14xxx/CVE-2017-14836.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14836",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the modDate attribute of Annotation objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5028."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-880"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14837.json
+++ b/2017/14xxx/CVE-2017-14837.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-14837",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the pageSpan method of XFA Layout objects. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this to execute code in the context of the current process.  Was ZDI-CAN-5029."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-881"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16571.json
+++ b/2017/16xxx/CVE-2017-16571.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16571",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of references to the app object from FormCalc. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this to execute code in the context of the current process.  Was ZDI-CAN-5072."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-882"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16572.json
+++ b/2017/16xxx/CVE-2017-16572.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16572",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within FormCalc's closeDoc method. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this to execute code in the context of the current process.  Was ZDI-CAN-5073."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-883"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16573.json
+++ b/2017/16xxx/CVE-2017-16573.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16573",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of LZWDecode filters. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5078."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-884"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16574.json
+++ b/2017/16xxx/CVE-2017-16574.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16574",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of Image filters. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5079."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-885"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16575.json
+++ b/2017/16xxx/CVE-2017-16575.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16575",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the XFA's bind element. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5091."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-886"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16576.json
+++ b/2017/16xxx/CVE-2017-16576.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16576",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within XFA's field element. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5092."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-887"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16577.json
+++ b/2017/16xxx/CVE-2017-16577.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16577",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the alignment attribute of Field objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5094."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-888"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16578.json
+++ b/2017/16xxx/CVE-2017-16578.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16578",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.2.25013"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.2.25013. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the picture elements within XFA forms. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5216."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-889"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16579.json
+++ b/2017/16xxx/CVE-2017-16579.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16579",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.2.25013"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.2.25013. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of JPEG2000 images. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5244."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-890"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16580.json
+++ b/2017/16xxx/CVE-2017-16580.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16580",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.2.25013"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.2.25013. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the ImageField node of XFA forms. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5281."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-891"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16581.json
+++ b/2017/16xxx/CVE-2017-16581.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16581",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.2.25013"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.2.25013. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the author attribute of the Document object. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5282."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-892"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16582.json
+++ b/2017/16xxx/CVE-2017-16582.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16582",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.2.25013"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.2.25013. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the clearItems XFA method. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5288."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-893"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16583.json
+++ b/2017/16xxx/CVE-2017-16583.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16583",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.2.25013"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.2.25013. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the datasets element of XFA forms. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5289."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-894"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16584.json
+++ b/2017/16xxx/CVE-2017-16584.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16584",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.2.25013"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.2.25013. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within util.printf. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5290."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-895"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16585.json
+++ b/2017/16xxx/CVE-2017-16585.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16585",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.2.25013"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.2.25013. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the app.response method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5294."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-896"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16586.json
+++ b/2017/16xxx/CVE-2017-16586.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16586",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.2.25013"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.2.25013. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the addAnnot method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5295."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-897"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16587.json
+++ b/2017/16xxx/CVE-2017-16587.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16587",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.2.25013"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.2.25013. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the removeField method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5296."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-898"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16588.json
+++ b/2017/16xxx/CVE-2017-16588.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16588",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of SOT markers. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-4976."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-856"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16589.json
+++ b/2017/16xxx/CVE-2017-16589.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16589",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.1.21155"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 8.3.1.21155. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of the yTsiz member of SIZ markers. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-4977."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-857"
          }
       ]
    }


### PR DESCRIPTION
Catching up hopefully
M  2017/10xxx/CVE-2017-10956.json
M  2017/10xxx/CVE-2017-10957.json
M  2017/10xxx/CVE-2017-10958.json
M  2017/10xxx/CVE-2017-10959.json
M  2017/14xxx/CVE-2017-14818.json
M  2017/14xxx/CVE-2017-14819.json
M  2017/14xxx/CVE-2017-14820.json
M  2017/14xxx/CVE-2017-14821.json
M  2017/14xxx/CVE-2017-14822.json
M  2017/14xxx/CVE-2017-14823.json
M  2017/14xxx/CVE-2017-14824.json
M  2017/14xxx/CVE-2017-14825.json
M  2017/14xxx/CVE-2017-14826.json
M  2017/14xxx/CVE-2017-14827.json
M  2017/14xxx/CVE-2017-14828.json
M  2017/14xxx/CVE-2017-14829.json
M  2017/14xxx/CVE-2017-14830.json
M  2017/14xxx/CVE-2017-14831.json
M  2017/14xxx/CVE-2017-14832.json
M  2017/14xxx/CVE-2017-14833.json
M  2017/14xxx/CVE-2017-14834.json
M  2017/14xxx/CVE-2017-14835.json
M  2017/14xxx/CVE-2017-14836.json
M  2017/14xxx/CVE-2017-14837.json
M  2017/16xxx/CVE-2017-16571.json
M  2017/16xxx/CVE-2017-16572.json
M  2017/16xxx/CVE-2017-16573.json
M  2017/16xxx/CVE-2017-16574.json
M  2017/16xxx/CVE-2017-16575.json
M  2017/16xxx/CVE-2017-16576.json
M  2017/16xxx/CVE-2017-16577.json
M  2017/16xxx/CVE-2017-16578.json
M  2017/16xxx/CVE-2017-16579.json
M  2017/16xxx/CVE-2017-16580.json
M  2017/16xxx/CVE-2017-16581.json
M  2017/16xxx/CVE-2017-16582.json
M  2017/16xxx/CVE-2017-16583.json
M  2017/16xxx/CVE-2017-16584.json
M  2017/16xxx/CVE-2017-16585.json
M  2017/16xxx/CVE-2017-16586.json
M  2017/16xxx/CVE-2017-16587.json
M  2017/16xxx/CVE-2017-16588.json
M  2017/16xxx/CVE-2017-16589.json