### PR TITLE
supersedes #137: ZDI assigns the following CVEs:

### DIFF
--- a/2017/16xxx/CVE-2017-16590.json
+++ b/2017/16xxx/CVE-2017-16590.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16590",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.699 build 1001"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to bypass authentication on vulnerable installations of NetGain Systems Enterprise Manager 7.2.699 build 1001. User interaction is required to exploit this vulnerability. The specific flaw exists within the MainFilter servlet. The issue results from the lack of proper string matching inside the doFilter method. An attacker can leverage this in conjunction with other vulnerabilities to execute arbitrary code in the context of Administrator.  Was ZDI-CAN-5099."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-289-Authentication Bypass by Alternate Name"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-955"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16591.json
+++ b/2017/16xxx/CVE-2017-16591.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16591",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.699 build 1001"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of NetGain Systems Enterprise Manager 7.2.699 build 1001. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.restore.download_005fdo_jsp servlet, which listens on TCP port 8081 by default. When parsing the filename parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of Administrator.  Was ZDI-CAN-5100."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-956"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16592.json
+++ b/2017/16xxx/CVE-2017-16592.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16592",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.restore.download_005fdo_jsp servlet, which listens on TCP port 8081 by default. When parsing the filename parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of Administrator.  Was ZDI-CAN-5103."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-957"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16592.json
+++ b/2017/16xxx/CVE-2017-16592.json
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.restore.download_005fdo_jsp servlet, which listens on TCP port 8081 by default. When parsing the filename parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of Administrator.  Was ZDI-CAN-5103."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the common.download_jsp servlet, which listens on TCP port 8081 by default. When parsing the filename parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of Administrator.  Was ZDI-CAN-5103."
          }
       ]
    },

--- a/2017/16xxx/CVE-2017-16593.json
+++ b/2017/16xxx/CVE-2017-16593.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16593",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to delete arbitrary files on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.restore.del_005fdo_jsp servlet, which listens on TCP port 8081 by default. When parsing the filenames parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this vulnerability to delete any files accessible to the Administrator user.  Was ZDI-CAN-5104."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-958"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16594.json
+++ b/2017/16xxx/CVE-2017-16594.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16594",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to create arbitrary files on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.db.save_005fimage_jsp servlet, which listens on TCP port 8081 by default. When parsing the id parameter, the process does not properly validate user-supplied data, which can allow for the upload of files. An attacker can leverage this vulnerability to execute code under the context of Administrator.  Was ZDI-CAN-5117."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-434-Unrestricted Upload of File with Dangerous Type"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-959"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16595.json
+++ b/2017/16xxx/CVE-2017-16595.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16595",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.reports.export_005fdownload_jsp servlet, which listens on TCP port 8081 by default. When parsing the filename parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of Administrator.  Was ZDI-CAN-5118."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-960"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16596.json
+++ b/2017/16xxx/CVE-2017-16596.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16596",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.designer.script_005fsamples_jsp servlet, which listens on TCP port 8081 by default. When parsing the type parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of Administrator.  Was ZDI-CAN-5119."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-961"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16597.json
+++ b/2017/16xxx/CVE-2017-16597.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16597",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Authentication is not required to exploit this vulnerability. The specific flaw exists within the processing of WRQ requests. When parsing the Filename field, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this vulnerability to execute code  under the context of Administrator.  Was ZDI-CAN-5137."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-962"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16598.json
+++ b/2017/16xxx/CVE-2017-16598.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16598",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute code by overwriting arbitrary files on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.tools.snmpwalk.snmpwalk_005fdo_jsp servlet, which listens on TCP port 8081 by default. When parsing the ip parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this vulnerability to execute code under the context of Administrator.  Was ZDI-CAN-5138."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-963"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16599.json
+++ b/2017/16xxx/CVE-2017-16599.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16599",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to delete arbitrary files on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.reports.templates.misc.sample_jsp servlet, which listens on TCP port 8081 by default. When parsing the type parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of Administrator.  Was ZDI-CAN-5190."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-964"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16600.json
+++ b/2017/16xxx/CVE-2017-16600.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16600",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to overwrite files on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.reports.templates.network.traffic_005freport_jsp servlet, which listens on TCP port 8081 by default. When parsing the filename parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this vulnerability to overwrite any files accessible to the Administrator.  Was ZDI-CAN-5191."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-965"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16601.json
+++ b/2017/16xxx/CVE-2017-16601.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16601",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to overwrite arbitrary files on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.reports.templates.service.service_005ffailures_jsp servlet, which listens on TCP port 8081 by default. When parsing the filename parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this vulnerability to overwrite any files accessible to the Administrator.  Was ZDI-CAN-5192."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-966"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16602.json
+++ b/2017/16xxx/CVE-2017-16602.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16602",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.tools.exec_jsp servlet, which listens on TCP port 8081 by default. When parsing the command parameter, the process does not properly validate a user-supplied string before using it to execute a system call. An attacker can leverage this vulnerability to execute code under the context of Administrator.  Was ZDI-CAN-5193."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-78-Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-967"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16603.json
+++ b/2017/16xxx/CVE-2017-16603.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16603",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute code by creating arbitrary files on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.settings.upload_005ffile_005fdo_jsp servlet, which listens on TCP port 8081 by default. When parsing the filename parameter, the process does not properly validate user-supplied data, which can allow for the upload of files. An attacker can leverage this vulnerability to execute code under the context of Administrator.  Was ZDI-CAN-5194."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-968"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16604.json
+++ b/2017/16xxx/CVE-2017-16604.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16604",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to overwrite arbitrary files on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.cnnic.asset.deviceReport.deviceReport_005fexport_005fdo_jsp servlet, which listens on TCP port 8081 by default. When parsing the filename parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this vulnerability to overwrite any files accessible to the Administrator.  Was ZDI-CAN-5195."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-969"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16605.json
+++ b/2017/16xxx/CVE-2017-16605.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16605",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to overwrite arbitrary files on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp.db.save_005fattrs_jsp servlet, which listens on TCP port 8081 by default. When parsing the id parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this vulnerability to overwrite any files accessible to the Administrator.  Was ZDI-CAN-5196."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-970"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16606.json
+++ b/2017/16xxx/CVE-2017-16606.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16606",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "7.2.730 build 1034"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute code by creating arbitrary files on vulnerable installations of NetGain Systems Enterprise Manager 7.2.730 build 1034. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the org.apache.jsp.u.jsp._3d.add_005f3d_005fview_005fdo_jsp servlet, which listens on TCP port 8081 by default. When parsing the filename parameter, the process does not properly validate a user-supplied path prior to using it in file operations. An attacker can leverage this vulnerability to execute code under the context of Administrator.  Was ZDI-CAN-5197."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-971"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16607.json
+++ b/2017/16xxx/CVE-2017-16607.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16607",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "v7.2.586 build 877"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Netgain Enterprise Manager. Authentication is not required to exploit this vulnerability. The specific flaw exists within heapdumps.jsp. The issue results from the lack of proper validation of a user-supplied string before using it to download heap memory dump. An attacker can leverage this in conjunction with other vulnerabilities to disclose sensitive information in the context of the current process.  Was ZDI-CAN-4718."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-200-Information Exposure"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-949"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16608.json
+++ b/2017/16xxx/CVE-2017-16608.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16608",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "v7.2.586 build 877"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Netgain Enterprise Manager. Authentication is not required to exploit this vulnerability. The specific flaw exists within exec.jsp. The issue results from the lack of proper validation of a user-supplied string before using it to execute a system call. An attacker can leverage this vulnerability to execute code under the context of the current user.  Was ZDI-CAN-4749."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-78-Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-950"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16609.json
+++ b/2017/16xxx/CVE-2017-16609.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16609",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "v7.2.586 build 877"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Netgain Enterprise Manager. Authentication is not required to exploit this vulnerability. The specific flaw exists within download.jsp. The issue results from the lack of proper validation of a user-supplied string before using it to download a file. An attacker can leverage this vulnerability to expose sensitive information.  Was ZDI-CAN-4750."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-39-Path Traversal: 'C:dirname'"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-951"
          }
       ]
    }

--- a/2017/16xxx/CVE-2017-16610.json
+++ b/2017/16xxx/CVE-2017-16610.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-16610",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "v7.2.586 build 877"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Netgain Enterprise Manager. Authentication is not required to exploit this vulnerability. The specific flaw exists within upload_save_do.jsp. The issue results from the lack of proper validation of a user-supplied path prior to using it in file operations. An attacker can leverage this vulnerability to execute code under the context of the current user.  Was ZDI-CAN-4751."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-22-Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-952"
          }
       ]
    }

--- a/2017/17xxx/CVE-2017-17406.json
+++ b/2017/17xxx/CVE-2017-17406.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-17406",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "v7.2.586 build 877"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Netgain Enterprise Manager. Authentication is not required to exploit this vulnerability. The specific flaw exists within an exposed RMI registry, which listens on TCP ports 1800 and 1850 by default. The issue results from the lack of proper validation of user-supplied data, which can result in deserialization of untrusted data. An attacker can leverage this vulnerability to execute arbitrary code under the context of the current process.  Was ZDI-CAN-4753."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-502-Deserialization of Untrusted Data"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-953"
          }
       ]
    }

--- a/2017/17xxx/CVE-2017-17407.json
+++ b/2017/17xxx/CVE-2017-17407.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2017-17407",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "NetGain Systems Enterprise Manager",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "v7.2.699 build 1001"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "NetGain Systems"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,26 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of NetGain Systems Enterprise Manager v7.2.699 build 1001 . Authentication is not required to exploit this vulnerability. The specific flaw exists within the handling of the content parameter provided to the script_test.jsp endpoint. A crafted content request parameter can trigger execution of a system call composed from a user-supplied string. An attacker can leverage this vulnerability to execute code under the context of the web service.  Was ZDI-CAN-5080."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-78-Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-17-954"
          }
       ]
    }


### PR DESCRIPTION
M  2017/16xxx/CVE-2017-16590.json
M  2017/16xxx/CVE-2017-16591.json
M  2017/16xxx/CVE-2017-16592.json
M  2017/16xxx/CVE-2017-16593.json
M  2017/16xxx/CVE-2017-16594.json
M  2017/16xxx/CVE-2017-16595.json
M  2017/16xxx/CVE-2017-16596.json
M  2017/16xxx/CVE-2017-16597.json
M  2017/16xxx/CVE-2017-16598.json
M  2017/16xxx/CVE-2017-16599.json
M  2017/16xxx/CVE-2017-16600.json
M  2017/16xxx/CVE-2017-16601.json
M  2017/16xxx/CVE-2017-16602.json
M  2017/16xxx/CVE-2017-16603.json
M  2017/16xxx/CVE-2017-16604.json
M  2017/16xxx/CVE-2017-16605.json
M  2017/16xxx/CVE-2017-16606.json
M  2017/16xxx/CVE-2017-16607.json
M  2017/16xxx/CVE-2017-16608.json
M  2017/16xxx/CVE-2017-16609.json
M  2017/16xxx/CVE-2017-16610.json
M  2017/17xxx/CVE-2017-17406.json
M  2017/17xxx/CVE-2017-17407.json