### PR TITLE
Add github link to patch for CVE-2017-3737

### DIFF
--- a/2017/3xxx/CVE-2017-3737.json
+++ b/2017/3xxx/CVE-2017-3737.json
@@ -60,6 +60,9 @@
             "url" : "https://www.openssl.org/news/secadv/20171207.txt"
          },
          {
+            "url" : "https://github.com/openssl/openssl/commit/898fb884b706aaeb283de4812340bb0bde8476dc"
+         },          
+         {
             "url" : "https://security.netapp.com/advisory/ntap-20171208-0001/"
          },
          {


### PR DESCRIPTION
First test of using github cvelist, make a small update to CVE-2017-3737 with a link to the official commit that fixed this issue.