### PR TITLE
Canonical CVE assignments from 2017

### DIFF
--- a/2017/14xxx/CVE-2017-14177.json
+++ b/2017/14xxx/CVE-2017-14177.json
@@ -1,17 +1,72 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-14177",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@ubuntu.com",
+      "DATE_PUBLIC": "2017-11-15T19:00:00.000Z",
+      "ID": "CVE-2017-14177",
+      "STATE": "PUBLIC"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Apport",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "through 2.20.7"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "n/a"
+            }
+         ]
+      }
+   },
+   "credit": [
+      "Sander Bos"
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Apport through 2.20.7 does not properly handle core dumps from setuid binaries allowing local users to create certain files as root which an attacker could leverage to perform a denial of service via resource exhaustion or possibly gain root privileges. NOTE: this vulnerability exists because of an incomplete fix for CVE-2015-1324."
+         }
+      ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of service via resource exhaustion and privilege escalation"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "url": "https://people.canonical.com/~ubuntu-security/cve/?cve=CVE-2017-14177"
+         },
+         {
+            "url": "https://launchpad.net/bugs/1726372"
+         },
+         {
+            "url": "https://bazaar.launchpad.net/~apport-hackers/apport/trunk/revision/3171"
+         },
+         {
+            "url": "https://usn.ubuntu.com/usn/usn-3480-1"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14178.json
+++ b/2017/14xxx/CVE-2017-14178.json
@@ -1,17 +1,69 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-14178",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@ubuntu.com",
+      "DATE_PUBLIC": "2017-11-09T00:00:00.000Z",
+      "ID": "CVE-2017-14178",
+      "STATE": "PUBLIC"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "snapd",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "2.27 through 2.29.2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "n/a"
+            }
+         ]
+      }
+   },
+   "credit": [
+      "Robert Ancell"
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "In snapd 2.27 through 2.29.2 the 'snap logs' command could be made to call journalctl without match arguments and therefore allow unprivileged, unauthenticated users to bypass systemd-journald's access restrictions."
+         }
+      ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Information leak"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "url": "https://people.canonical.com/~ubuntu-security/cve/2017/CVE-2017-14178.html"
+         },
+         {
+            "url": "https://launchpad.net/bugs/1730255"
+         },
+         {
+            "url": "https://github.com/snapcore/snapd/pull/4194"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14179.json
+++ b/2017/14xxx/CVE-2017-14179.json
@@ -1,17 +1,66 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-14179",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@ubuntu.com",
+      "DATE_PUBLIC": "2017-11-15T19:00:00.000Z",
+      "ID": "CVE-2017-14179",
+      "STATE": "PUBLIC"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Apport",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "before 2.13"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "n/a"
+            }
+         ]
+      }
+   },
+   "credit": [
+      "Sander Bos"
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Apport before 2.13 does not properly handle crashes originating from a PID namespace allowing local users to create certain files as root which an attacker could leverage to perform a denial of service via resource exhaustion, possibly gain root privileges, or escape from containers.\n"
+         }
+      ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of service via resource exhaustion, privilege escalation, and escape from containers"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "url": "https://people.canonical.com/~ubuntu-security/cve/?cve=CVE-2017-14179"
+         },
+         {
+            "url": "https://launchpad.net/bugs/1726372"
          }
       ]
    }

--- a/2017/14xxx/CVE-2017-14180.json
+++ b/2017/14xxx/CVE-2017-14180.json
@@ -1,17 +1,72 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-14180",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@ubuntu.com",
+      "DATE_PUBLIC": "2017-11-15T19:00:00.000Z",
+      "ID": "CVE-2017-14180",
+      "STATE": "PUBLIC"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Apport",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "2.13 through 2.20.7"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "na/"
+            }
+         ]
+      }
+   },
+   "credit": [
+      "Sander Bos"
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Apport 2.13 through 2.20.7 does not properly handle crashes originating from a PID namespace allowing local users to create certain files as root which an attacker could leverage to perform a denial of service via resource exhaustion or possibly gain root privileges, a different vulnerability than CVE-2017-14179."
+         }
+      ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of service via resource exhaustion and privilege escalation"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "url": "https://people.canonical.com/~ubuntu-security/cve/?cve=CVE-2017-14180"
+         },
+         {
+            "url": "https://launchpad.net/bugs/1726372"
+         },
+         {
+            "url": "https://bazaar.launchpad.net/~apport-hackers/apport/trunk/revision/3171"
+         },
+         {
+            "url": "https://usn.ubuntu.com/usn/usn-3480-1"
          }
       ]
    }


### PR DESCRIPTION
These are the remaining CVE assignments, made by Canonical, from 2017.