### PR TITLE
Add github references for patches for 2017 OpenSSL vulnerabilities

### DIFF
--- a/2017/3xxx/CVE-2017-3730.json
+++ b/2017/3xxx/CVE-2017-3730.json
@@ -83,6 +83,9 @@
             "url" : "https://www.openssl.org/news/secadv/20170126.txt"
          },
          {
+            "url" : "https://github.com/openssl/openssl/commit/efbe126e3ebb9123ac9d058aa2bb044261342aaa"
+         },
+         {
             "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2017-3236626.html"
          },
          {

--- a/2017/3xxx/CVE-2017-3731.json
+++ b/2017/3xxx/CVE-2017-3731.json
@@ -113,6 +113,9 @@
             "url" : "https://www.openssl.org/news/secadv/20170126.txt"
          },
          {
+            "url" : "https://github.com/openssl/openssl/commit/00d965474b22b54e4275232bc71ee0c699c5cd21"
+         },
+         {
             "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2017-3236622.html"
          },
          {

--- a/2017/3xxx/CVE-2017-3732.json
+++ b/2017/3xxx/CVE-2017-3732.json
@@ -113,6 +113,9 @@
             "url" : "https://www.openssl.org/news/secadv/20170126.txt"
          },
          {
+            "url" : "https://github.com/openssl/openssl/commit/a59b90bf491410f1f2bc4540cc21f1980fd14c5b"
+         },
+         {
             "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2017-3236622.html"
          },
          {

--- a/2017/3xxx/CVE-2017-3733.json
+++ b/2017/3xxx/CVE-2017-3733.json
@@ -83,6 +83,9 @@
             "url" : "https://www.openssl.org/news/secadv/20170216.txt"
          },
          {
+            "url" : "https://github.com/openssl/openssl/commit/4ad93618d26a3ea23d36ad5498ff4f59eff3a4d2"
+         },
+         {
             "url" : "https://h20566.www2.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbgn03728en_us"
          },
          {

--- a/2017/3xxx/CVE-2017-3735.json
+++ b/2017/3xxx/CVE-2017-3735.json
@@ -60,6 +60,9 @@
             "url" : "https://lists.debian.org/debian-lts-announce/2017/11/msg00011.html"
          },
          {
+            "url" : "https://github.com/openssl/openssl/commit/068b963bb7afc57f5bdd723de0dd15e7795d5822"
+         },
+         {
             "url" : "https://www.openssl.org/news/secadv/20170828.txt"
          },
          {

--- a/2017/3xxx/CVE-2017-3736.json
+++ b/2017/3xxx/CVE-2017-3736.json
@@ -60,6 +60,9 @@
             "url" : "https://www.openssl.org/news/secadv/20171102.txt"
          },
          {
+            "url" : "https://github.com/openssl/openssl/commit/4443cf7aa0099e5ce615c18cee249fff77fb0871"
+         },
+         {
             "url" : "https://security.netapp.com/advisory/ntap-20171107-0002/"
          },
          {

--- a/2017/3xxx/CVE-2017-3738.json
+++ b/2017/3xxx/CVE-2017-3738.json
@@ -60,6 +60,9 @@
             "url" : "https://www.openssl.org/news/secadv/20171207.txt"
          },
          {
+            "url" : "https://github.com/openssl/openssl/commit/e502cc86df9dafded1694fceb3228ee34d11c11a"
+         },
+         {
             "url" : "https://security.netapp.com/advisory/ntap-20171208-0001/"
          },
          {


### PR DESCRIPTION
(This is a good excuse to make sure signing commits and doing it not via an organisational fork works)