### PR TITLE
Juniper Security Advisories for April plus updates

### DIFF
--- a/2018/0xxx/CVE-2018-0015.json
+++ b/2018/0xxx/CVE-2018-0015.json
@@ -1,108 +1,108 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "sirt@juniper.net",
-      "DATE_PUBLIC" : "2018-02-20T15:00:00.000Z",
-      "ID" : "CVE-2018-0015",
-      "STATE" : "PUBLIC",
-      "TITLE" : "AppFormix: Debug Shell Command Execution in AppFormix Agent"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-02-20T15:00:00.000Z",
+      "ID": "CVE-2018-0015",
+      "STATE": "PUBLIC",
+      "TITLE": "AppFormix: Debug Shell Command Execution in AppFormix Agent"
    },
-   "affects" : {
-      "vendor" : {
-         "vendor_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-               "product" : {
-                  "product_data" : [
+               "product": {
+                  "product_data": [
                      {
-                        "product_name" : "AppFormix",
-                        "version" : {
-                           "version_data" : [
+                        "product_name": "AppFormix",
+                        "version": {
+                           "version_data": [
                               {
-                                 "affected" : "=",
-                                 "version_name" : "2.7",
-                                 "version_value" : "2.7"
+                                 "affected": "<=",
+                                 "version_name": "2.7",
+                                 "version_value": "2.7.3"
                               },
                               {
-                                 "affected" : "<",
-                                 "version_name" : "2.11",
-                                 "version_value" : "2.11.3"
+                                 "affected": "<",
+                                 "version_name": "2.11",
+                                 "version_value": "2.11.3"
                               },
                               {
-                                 "affected" : "<",
-                                 "version_name" : "2.15",
-                                 "version_value" : "2.15.2"
+                                 "affected": "<",
+                                 "version_name": "2.15",
+                                 "version_value": "2.15.2"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "Juniper Networks"
+               "vendor_name": "Juniper Networks"
             }
          ]
       }
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "A malicious user with unrestricted access to the AppFormix application management platform may be able to access a Python debug console and execute system commands with root privilege. The AppFormix Agent exposes the debug console on a host where AppFormix Agent is executing. If the host is executing AppFormix Agent, an attacker may access the debug console and execute Python commands with root privilege. Affected AppFormix releases are: all versions of 2.7; 2.11 versions prior to 2.11.3; 2.15 versions prior to 2.15.2. Juniper SIRT is not aware of any malicious exploitation of this vulnerability, however, the issue has been seen in a production network. No other Juniper Networks products or platforms are affected by this issue."
+            "lang": "eng",
+            "value": "A malicious user with unrestricted access to the AppFormix application management platform may be able to access a Python debug console and execute system commands with root privilege.  The AppFormix Agent exposes the debug console on a host where AppFormix Agent is executing.  If the host is executing AppFormix Agent, an attacker may access the debug console and execute Python commands with root privilege.\n\nAffected AppFormix releases are:\nAll versions up to and including 2.7.3;\n2.11 versions prior to 2.11.3;\n2.15 versions prior to 2.15.2.\nJuniper SIRT is not aware of any malicious exploitation of this vulnerability, however, the issue has been seen in a production network.\n\nNo other Juniper Networks products or platforms are affected by this issue."
          }
       ]
    },
-   "impact" : {
-      "cvss" : {
-         "attackComplexity" : "LOW",
-         "attackVector" : "NETWORK",
-         "availabilityImpact" : "HIGH",
-         "baseScore" : 9.8,
-         "baseSeverity" : "CRITICAL",
-         "confidentialityImpact" : "HIGH",
-         "integrityImpact" : "HIGH",
-         "privilegesRequired" : "NONE",
-         "scope" : "UNCHANGED",
-         "userInteraction" : "NONE",
-         "vectorString" : "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-         "version" : "3.0"
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 9.8,
+         "baseSeverity": "CRITICAL",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+         "version": "3.0"
       }
    },
-   "problemtype" : {
-      "problemtype_data" : [
+   "problemtype": {
+      "problemtype_data": [
          {
-            "description" : [
+            "description": [
                {
-                  "lang" : "eng",
-                  "value" : "Unauthorized access"
+                  "lang": "eng",
+                  "value": "Unauthorized access"
                }
             ]
          }
       ]
    },
-   "references" : {
-      "reference_data" : [
+   "references": {
+      "reference_data": [
          {
-            "name" : "https://kb.juniper.net/JSA10843",
-            "refsource" : "CONFIRM",
-            "url" : "https://kb.juniper.net/JSA10843"
+            "name": "https://kb.juniper.net/JSA10843",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10843"
          }
       ]
    },
-   "solution" : [
+   "solution": [
       {
-         "lang" : "eng",
-         "value" : "The following software releases have been updated to resolve this specific issue: AppFormix v2.15.2, v2.11.3, and all subsequent releases."
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: AppFormix v2.11.3, v2.15.2, and all subsequent releases."
       }
    ],
-   "source" : {
-      "advisory" : "JSA10843",
-      "discovery" : "USER"
+   "source": {
+      "advisory": "JSA10843",
+      "discovery": "USER"
    },
-   "work_around" : [
+   "work_around": [
       {
-         "lang" : "eng",
-         "value" : "Follow security best current practices (BCPs) to limit the exploitable attack surface of critical infrastructure networking equipment. Use access lists or firewall filters to limit access to well known ports on the platform, and only from trusted, administrative networks or hosts."
+         "lang": "eng",
+         "value": "Follow security best current practices (BCPs) to limit the exploitable attack surface of critical infrastructure networking equipment. Use access lists or firewall filters to limit access to well known ports on the platform, and only from trusted, administrative networks or hosts."
       }
    ]
 }

--- a/2018/0xxx/CVE-2018-0016.json
+++ b/2018/0xxx/CVE-2018-0016.json
@@ -1,18 +1,123 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0016",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-04-11T16:00:00.000Z",
+      "ID": "CVE-2018-0016",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Kernel crash upon receipt of crafted CLNP datagrams"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1F5-S3, 15.1F6-S8, 15.1F7, 15.1R5"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D60"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D66, 15.1X53-D233, 15.1X53-D471"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "The following configuration is required:\n  set protocols isis clns-routing"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Receipt of a specially crafted Connectionless Network Protocol (CLNP) datagram destined to an interface of a Junos OS device may result in a kernel crash or lead to remote code execution.\n\nDevices are only vulnerable to the specially crafted CLNP datagram if 'clns-routing' or ES-IS is explicitly configured.  Devices with without CLNS enabled are not vulnerable to this issue.  Devices with IS-IS configured on the interface are not vulnerable to this issue unless CLNS routing is also enabled.\n\nThis issue only affects devices running Junos OS 15.1.  Affected releases are Juniper Networks Junos OS:\n\n15.1 versions prior to 15.1F5-S3, 15.1F6-S8, 15.1F7, 15.1R5;\n15.1X49 versions prior to 15.1X49-D60;\n15.1X53 versions prior to 15.1X53-D66, 15.1X53-D233, 15.1X53-D471.\n\nEarlier releases are unaffected by this vulnerability, and the issue has been resolved in Junos OS 16.1R1 and all subsequent releases."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 9.8,
+         "baseSeverity": "CRITICAL",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of Service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10844",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10844"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 15.1F5-S3, 15.1F6-S8, 15.1F7, 15.1R5, 15.1X49-D60, 15.1X53-D66, 15.1X53-D233, 15.1X53-D471, 16.1R1, and all subsequent releases."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10844",
+      "defect": [
+         "1167683"
+      ],
+      "discovery": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Use access lists or firewall filters to limit access to the device via CLNP only from trusted hosts."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0017.json
+++ b/2018/0xxx/CVE-2018-0017.json
@@ -1,18 +1,120 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0017",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-04-11T16:00:00.000Z",
+      "ID": "CVE-2018-0017",
+      "STATE": "PUBLIC",
+      "TITLE": "SRX Series: Denial of service vulnerability in flowd daemon on devices configured with NAT-PT"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D76"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D55"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D90"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A vulnerability in the Network Address Translation - Protocol Translation (NAT-PT) feature of Junos OS on SRX series devices may allow a certain valid IPv6 packet to crash the flowd daemon. Repeated crashes of the flowd daemon can result in an extended denial of service condition for the SRX device.\nAffected releases are Juniper Networks Junos OS:\n12.1X46 versions prior to 12.1X46-D72;\n12.3X48 versions prior to 12.3X48-D55;\n15.1X49 versions prior to 15.1X49-D90."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 7.5,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "denial of service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10845",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10845"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 12.1X46-D76 (pending release), 12.3X48-D55, 15.1X49-D90, 17.3R1, and all subsequent releases."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10845",
+      "defect": [
+         "1261863"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "There are no viable workarounds for this issue."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0018.json
+++ b/2018/0xxx/CVE-2018-0018.json
@@ -1,18 +1,132 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0018",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-04-11T16:00:00.000Z",
+      "ID": "CVE-2018-0018",
+      "STATE": "PUBLIC",
+      "TITLE": "SRX Series: A crafted packet may lead to information disclosure and firewall rule bypass during compilation of IDP policies."
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D60"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D35"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D60"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "This issue only affects SRX Series devices with IDP configured."
+      }
+   ],
+   "credit": [
+      {
+         "lang": "eng",
+         "value": "Craig Dods, formerly of IBM Security"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "On SRX Series devices during compilation of IDP policies, an attacker sending specially crafted packets may be able to bypass firewall rules, leading to information disclosure which an attacker may use to gain control of the target device or other internal devices, systems or services protected by the SRX Series device.  This issue only applies to devices where IDP policies are applied to one or more rules.  Customers not using IDP policies are not affected.\n\nDepending on if the IDP updates are automatic or not, as well as the interval between available updates, an attacker may have more or less success in performing reconnaissance or bypass attacks on the victim SRX Series device or protected devices.\n\nScreenOS with IDP is not vulnerable to this issue.\n\nAffected releases are Juniper Networks Junos OS:\n12.1X46 versions prior to 12.1X46-D60 on SRX;\n12.3X48 versions prior to 12.3X48-D35 on SRX;\n15.1X49 versions prior to 15.1X49-D60 on SRX."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "HIGH",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "NONE",
+         "baseScore": 7.5,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "LOW",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "NONE",
+         "scope": "CHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:L/I:H/A:N",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Information disclosure\nfirewall bypass\nprotocol manipulation\nfirewall rule evasion\n"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10846",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10846"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 12.1X46-D60, 12.3X48-D35, 15.1X49-D60, 17.3R1, and all subsequent releases.  \n\nAdditionally, customers should download and apply the latest sigpack for IDP signatures."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10846",
+      "defect": [
+         "1151743"
+      ],
+      "discovery": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Customers using cluster configurations may break the cluster configuration, disable traffic on one node, update the IDP policy, reintroduce this updated node as a standalone device, directing all traffic to it, instead of the current standalone, and then do the same with the secondary node, and then reintroduce cluster configuration to both devices.  For this workaround to be most effective, customers should disable automatic updates and manually download IDP signature updates.\n\nAlternately, cluster customers using load balancers may break cluster, run individual side-by-side configurations, off load all traffic from one node via load balancers to another node, then update the IDP policy manually on the idle node, lastly, flip flop this operation, and then return to side-by-side or cluster mode operation.\n\nCustomers unable to utilize similar design scenarios as workarounds such as the above should instead take fixes where available.\n\n  \n\n\n"
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0019.json
+++ b/2018/0xxx/CVE-2018-0019.json
@@ -1,18 +1,178 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0019",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-04-11T16:00:00.000Z",
+      "ID": "CVE-2018-0019",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos: Denial of service vulnerability in SNMP MIB-II subagent daemon (mib2d)."
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D76"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "12.3",
+                                 "version_value": "12.3R12-S7, 12.3R13"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D65"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "14.1",
+                                 "version_value": "14.1R9"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D130"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1F2-S20, 15.1F6-S10, 15.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D130"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D233, 15.1X53-D471, 15.1X53-D472, 15.1X53-D58, 15.1X53-D66"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R5-S3, 16.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1X65",
+                                 "version_value": "16.1X65-D47"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1X70",
+                                 "version_value": "16.1X70-D10"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R1-S6, 16.2R2-S5, 16.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S6, 17.1R3"
+                              },
+                              {
+                                 "affected": "!>=",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "This issue only affects systems with SNMP mib2d enabled. SNMP is disabled by default on devices running Junos OS. "
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A vulnerability in Junos OS SNMP MIB-II subagent daemon (mib2d) may allow a remote network based attacker to cause the mib2d process to crash resulting in a denial of service condition (DoS) for the SNMP subsystem.\n\nWhile a mib2d process crash can disrupt the network monitoring via SNMP, it does not impact routing, switching or firewall functionalities.\n\nSNMP is disabled by default on devices running Junos OS.\n\nAffected releases are Juniper Networks Junos OS:\n12.1X46 versions prior to 12.1X46-D76;\n12.3 versions prior to 12.3R12-S7, 12.3R13;\n12.3X48 versions prior to 12.3X48-D65;\n14.1 versions prior to 14.1R9;\n14.1X53 versions prior to 14.1X53-D130;\n15.1 versions prior to 15.1F2-S20, 15.1F6-S10, 15.1R7;\n15.1X49 versions prior to 15.1X49-D130;\n15.1X53 versions prior to 15.1X53-D233, 15.1X53-D471, 15.1X53-D472, 15.1X53-D58, 15.1X53-D66;\n16.1 versions prior to 16.1R5-S3, 16.1R7;\n16.1X65 versions prior to 16.1X65-D47;\n16.1X70 versions prior to 16.1X70-D10;\n16.2 versions prior to 16.2R1-S6, 16.2R2-S5, 16.2R3;\n17.1 versions prior to 17.1R2-S6, 17.1R3;"
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "LOW",
+         "baseScore": 5.3,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "denial of service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10847",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10847"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue:12.3R12-S7, 12.3R13, 12.3X48-D65, 14.1R9, 14.1X53-D130, 15.1F2-S20, 15.1F6-S10, 15.1R7, 15.1X49-D130, 15.1X53-D233, 15.1X53-D471, 15.1X53-D472, 15.1X53-D58, 15.1X53-D66, 16.1R5-S3, 16.1R7, 16.1X65-D47, 16.1X70-D10, 16.2R1-S6, 16.2R2-S5, 16.2R3, 17.1R2-S6, 17.1R3, 17.2R1, and all subsequent releases."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10847",
+      "defect": [
+         "1241134"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Disable SNMP (disabled by default), utilize edge filtering with source-address validation (uRPF, etc.), access control lists (ACLs), and/or SNMPv3 authentication to limit access to the device only from trusted hosts."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0020.json
+++ b/2018/0xxx/CVE-2018-0020.json
@@ -1,18 +1,176 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0020",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-04-11T16:00:00.000Z",
+      "ID": "CVE-2018-0020",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: rpd daemon cores due to malformed BGP UPDATE packet"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D47"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1F6-S10, 15.1R4-S9, 15.1R6-S6, 15.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D130"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX10K",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D66"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "EX2300/EX3400",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D58"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5200/QFX5110",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D233"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "NFX",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D471"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R3-S8, 16.1R4-S9, 16.1R5-S3, 16.1R6-S3, 16.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1X65",
+                                 "version_value": "16.1X65-D47"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R1-S6, 16.2R2-S5, 16.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S3, 17.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R1-S3, 17.2R2-S1, 17.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2X75",
+                                 "version_value": "17.2X75-D70"
+                              },
+                              {
+                                 "affected": "!<",
+                                 "version_name": "all",
+                                 "version_value": "13.2R1"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "13.2",
+                                 "version_value": "13.2R1"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Junos OS may be impacted by the receipt of a malformed BGP UPDATE which can lead to a routing process daemon (rpd) crash and restart.  Receipt of a repeated malformed BGP UPDATEs can result in an extended denial of service condition for the device.\nThis malformed BGP UPDATE does not propagate to other BGP peers. \n\nAffected releases are Juniper Networks Junos OS:\n14.1X53 versions prior to 14.1X53-D47;\n15.1 versions prior to 15.1F6-S10, 15.1R4-S9, 15.1R6-S6, 15.1R7;\n15.1X49 versions prior to 15.1X49-D130 on SRX;\n15.1X53 versions prior to 15.1X53-D66 on QFX10K;\n15.1X53 versions prior to 15.1X53-D58 on EX2300/EX3400;\n15.1X53 versions prior to 15.1X53-D233 on QFX5200/QFX5110;\n15.1X53 versions prior to 15.1X53-D471 on NFX;\n16.1 versions prior to 16.1R3-S8, 16.1R4-S9, 16.1R5-S3, 16.1R6-S3, 16.1R7;\n16.1X65 versions prior to 16.1X65-D47;\n16.2 versions prior to 16.2R1-S6, 16.2R2-S5, 16.2R3;\n17.1 versions prior to 17.1R2-S3, 17.1R3;\n17.2 versions prior to 17.2R1-S3, 17.2R2-S1, 17.2R3;\n17.2X75 versions prior to 17.2X75-D70;\n13.2 versions above and including 13.2R1.\n\nVersions prior to 13.2R1 are not affected.\n\nJuniper SIRT is not aware of any malicious exploitation of this vulnerability.\n\nNo other Juniper Networks products or platforms are affected by this issue."
          }
       ]
-   }
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 7.5,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "denial of service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10848",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10848"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 14.1X53-D47, 15.1F6-S10, 15.1R4-S9, 15.1R6-S6, 15.1R7, 15.1X49-D130, 15.1X53-D233, 15.1X53-D471, 15.1X53-D58, 15.1X53-D66, 16.1R3-S8, 16.1R4-S9, 16.1R5-S3, 16.1R6-S3, 16.1R7, 16.1X65-D47, 16.2R1-S6, 16.2R2-S5, 16.2R3, 17.1R2-S3, 17.1R3, 17.2R1-S3, 17.2R2-S1, 17.2R3, 17.2X75-D70, 17.3R1 and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10848",
+      "defect": [
+         "1299199"
+      ],
+      "discovery": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "While there is no workaround, the risk associated with this issue can be mitigated by limiting BGP sessions only from trusted peers."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0021.json
+++ b/2018/0xxx/CVE-2018-0021.json
@@ -1,18 +1,148 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0021",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-04-11T16:00:00.000Z",
+      "ID": "CVE-2018-0021",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Short MacSec keys may allow man-in-the-middle attacks."
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "14.1",
+                                 "version_value": "14.1R10, 14.1R9"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D47"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R4-S9, 15.1R6-S6, 15.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D100"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D59"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R3-S8, 16.1R4-S8, 16.1R5"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R1-S6, 16.2R2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "If all 64 digits of the connectivity association name (CKN) key or all 32 digits of the connectivity association key (CAK) key are not configured, all remaining digits will be auto-configured to 0.\n\nHence, Juniper devices configured with short MacSec keys are at risk to an increased likelihood that an attacker will discover the secret passphrases configured for these keys through dictionary-based and brute-force-based attacks using spoofed packets.\n\nAffected releases are Juniper Networks Junos OS:\n14.1 versions prior to 14.1R10, 14.1R9;\n14.1X53 versions prior to 14.1X53-D47;\n15.1 versions prior to 15.1R4-S9, 15.1R6-S6, 15.1R7;\n15.1X49 versions prior to 15.1X49-D100;\n15.1X53 versions prior to 15.1X53-D59;\n16.1 versions prior to 16.1R3-S8, 16.1R4-S8, 16.1R5;\n16.2 versions prior to 16.2R1-S6, 16.2R2;\n17.1 versions prior to 17.1R2."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "ADJACENT_NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 8.8,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "NONE",
+         "scope": "CHANGED",
+         "userInteraction": "REQUIRED",
+         "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "weak encryption\nman-in-the-middle attack\nbrute force attack\ndictionary attack"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://www.juniper.net/documentation/en_US/junos/topics/task/configuration/macsec.html",
+            "refsource": "MISC",
+            "url": "https://www.juniper.net/documentation/en_US/junos/topics/task/configuration/macsec.html"
+         },
+         {
+            "name": "https://kb.juniper.net/JSA10854",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10854"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 14.1R9, 14.1X53-D47, 15.1R4-S9, 15.1R6-S6, 15.1R7, 15.1X49-D100, 15.1X53-D59, 16.1R3-S8, 16.1R4-S8, 16.1R5, 16.2R1-S6, 16.2R2, 17.1R2, 17.2R1 and all subsequent releases."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10854",
+      "defect": [
+         "1251909"
+      ],
+      "discovery": "INTERNAL",
+      "found_during": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Configure all 64 digits of a CKN.\nConfigure all 32 digits of a CAK.\n\nSee the junos task topic macsec for further information.\n"
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0022.json
+++ b/2018/0xxx/CVE-2018-0022.json
@@ -1,18 +1,191 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0022",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-04-11T16:00:00.000Z",
+      "ID": "CVE-2018-0022",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Mbuf leak due to processing MPLS packets in VPLS network."
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D76"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D66, 12.3X48-D70"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "14.1",
+                                 "version_value": "14.1R9"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D47"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "14.2",
+                                 "version_value": "14.2R8"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1F2-S19, 15.1F6-S10, 15.1R4-S9, 15.1R5-S7, 15.1R6-S4, 15.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D131, 15.1X49-D140"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "EX2300/EX3400",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D58"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5200/QFX5110",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D233"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "NFX",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D471"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX10",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D66"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R3-S8, 16.1R4-S6, 16.1R5"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R1-S6, 16.2R2-S5, 16.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R1-S7, 17.1R2-S6, 17.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R1-S5, 17.2R2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "This issue only affects IPv4.\n"
+      },
+      {
+         "lang": "eng",
+         "value": "This issue does not affect IPv6."
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A Junos device with VPLS routing-instances configured on one or more interfaces may be susceptible to an mbuf leak when processing a specific MPLS packet. \nApproximately 1 mbuf is leaked per each packet processed.\nThe number of mbufs is platform dependent.\nThe following command provides the number of mbufs that are currently in use and maximum number of mbufs that can be allocated on a platform:\n  > show system buffers    \n  2437/3143/5580 mbufs in use (current/cache/total)\n\n\nOnce the device runs out of mbufs it will become inaccessible and a restart will be required.\n\nThis issue only affects end devices, transit devices are not affected.\n\nAffected releases are Juniper Networks Junos OS with VPLS configured running:\n12.1X46 versions prior to 12.1X46-D76;\n12.3X48 versions prior to 12.3X48-D66, 12.3X48-D70;\n14.1 versions prior to 14.1R9;\n14.1X53 versions prior to 14.1X53-D47;\n14.2 versions prior to 14.2R8;\n15.1 versions prior to 15.1F2-S19, 15.1F6-S10, 15.1R4-S9, 15.1R5-S7, 15.1R6-S4, 15.1R7;\n15.1X49 versions prior to 15.1X49-D131, 15.1X49-D140;\n15.1X53 versions prior to 15.1X53-D58 on EX2300/EX3400;\n15.1X53 versions prior to 15.1X53-D233 on QFX5200/QFX5110;\n15.1X53 versions prior to 15.1X53-D471 on NFX;\n15.1X53 versions prior to 15.1X53-D66 on QFX10;\n16.1 versions prior to 16.1R3-S8, 16.1R4-S6, 16.1R5;\n16.2 versions prior to 16.2R1-S6, 16.2R2-S5, 16.2R3;\n17.1 versions prior to 17.1R1-S7, 17.1R2-S6, 17.1R3;\n17.2 versions prior to 17.2R1-S5, 17.2R2."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 7.5,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "denial of service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10855",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10855"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 12.1X46-D76, 12.3X48-D66, 12.3X48-D70, 14.1R9, 14.1X53-D47, 14.2R8, 15.1F2-S19, 15.1F6-S10, 15.1R4-S9, 15.1R5-S7, 15.1R6-S4, 15.1R7, 15.1X49-D131, 15.1X49-D140, 15.1X53-D233, 15.1X53-D471, 15.1X53-D58, 15.1X53-D66, 16.1R3-S8, 16.1R4-S6, 16.1R5, 16.2R1-S6, 16.2R2-S5, 16.2R3, 17.1R1-S7, 17.1R2-S6, 17.1R3, 17.2R1-S5, 17.2R2, 17.3R1 and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10855",
+      "defect": [
+         "1272898"
+      ],
+      "discovery": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "There is no viable workaround for this issue."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0023.json
+++ b/2018/0xxx/CVE-2018-0023.json
@@ -16,7 +16,11 @@
                         "product_name": "Junos Snapshot Administrator (JSNAPy)",
                         "version": {
                            "version_data": [
-                              {}
+                              {
+                                 "affected": "<",
+                                 "version_name": "all",
+                                 "version_value": "1.3.0"
+                              }
                            ]
                         }
                      }

--- a/2018/0xxx/CVE-2018-0023.json
+++ b/2018/0xxx/CVE-2018-0023.json
@@ -38,7 +38,7 @@
       "description_data": [
          {
             "lang": "eng",
-            "value": "JSNAPy is an open source python version of Junos Snapshot Administrator developed by Juniper available through github.\n\nThe default configuration and sample files of JSNAPy automation tool are created world writable. This insecure file and directory permission allows unprivileged local users to alter the files under this directory including inserting operations not intended by the package maintainer, system administrator, or other users.\n\nThis issue only affects users who downloaded and installed JSNAPy from github."
+            "value": "JSNAPy is an open source python version of Junos Snapshot Administrator developed by Juniper available through github.\n\nThe default configuration and sample files of JSNAPy automation tool versions prior to 1.3.0 are created world writable. This insecure file and directory permission allows unprivileged local users to alter the files under this directory including inserting operations not intended by the package maintainer, system administrator, or other users.\n\nThis issue only affects users who downloaded and installed JSNAPy from github."
          }
       ]
    },

--- a/2018/0xxx/CVE-2018-0023.json
+++ b/2018/0xxx/CVE-2018-0023.json
@@ -1,18 +1,103 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0023",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-04-11T16:00:00.000Z",
+      "ID": "CVE-2018-0023",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos Snapshot Administrator (JSNAPy) world writeable default configuration file permission"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos Snapshot Administrator (JSNAPy)",
+                        "version": {
+                           "version_data": [
+                              {}
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "JSNAPy is an open source python version of Junos Snapshot Administrator developed by Juniper available through github.\n\nThe default configuration and sample files of JSNAPy automation tool are created world writable. This insecure file and directory permission allows unprivileged local users to alter the files under this directory including inserting operations not intended by the package maintainer, system administrator, or other users.\n\nThis issue only affects users who downloaded and installed JSNAPy from github."
          }
       ]
-   }
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "LOCAL",
+         "availabilityImpact": "NONE",
+         "baseScore": 5.5,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "LOW",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "insecure file permission"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://github.com/Juniper/jsnapy/",
+            "refsource": "MISC",
+            "url": "https://github.com/Juniper/jsnapy/"
+         },
+         {
+            "name": "https://kb.juniper.net/JSA10856",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10856"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "This issue is resolved in 1.3.0 and subsequent releases.\nFixed JSNAPy releases can be downloaded from https://github.com/Juniper/jsnapy/releases.\n"
+      },
+      {
+         "lang": "eng",
+         "value": "Upgrading to the fixed release is not sufficient to resolve the issue, modifying file permission after upgrade as described in the workaround section is required.\nThis issue is fixed for fresh/new installation."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10856",
+      "discovery": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "The workaround is to change the related files and directory to group/world to readable, but not writable:\n  # sudo chmod -R og-w /etc/jsnapy\n  # ls -l /etc/jsnapy/\n  total 20\n  -rwxr-xr-x 1 root root  387 Aug  9  2016 jsnapy.cfg \n  -rwxr-xr-x 1 root root 1695 Aug  9  2016 logging.yml \n  drwxr-xr-x 2 root root 4096 Aug 26  2016 samples \n  drwxr-xr-x 2 root root 4096 Aug 26  2016 snapshots \n  drwxr-xr-x 2 root root 4096 Aug 26  2016 testfiles"
+      }
+   ]
 }


### PR DESCRIPTION
CVEs assigned in Juniper Security Advisories for April (CVE-2018-0016 to CVE-2018-0023) plus update CVE-2018-0015.