### PR TITLE
Add CVE updates from Debian for 20180326 ping

### DIFF
--- a/2016/9xxx/CVE-2016-9646.json
+++ b/2016/9xxx/CVE-2016-9646.json
@@ -1,18 +1,75 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2016-9646",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@debian.org",
+      "DATE_PUBLIC": "2016-12-29T19:29:00.000Z",
+      "ID": "CVE-2016-9646",
+      "STATE": "PUBLIC",
+      "TITLE": "Commit metadata forgery via CGI::FormBuilder context-dependent APIs"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "ikiwiki",
+                        "version": {
+                           "version_data": [
+                              {
+				 "version_value" : "before 3.20161229"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "ikiwiki"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "ikiwiki incorrectly before 3.20161229 incorrectly called the CGI::FormBuilder->field method (similar to the CGI->param API that led to Bugzilla's CVE-2014-1572), which can be abused to lead to commit metadata forgery."
          }
       ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "commit metadata forgery"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "url": "https://ikiwiki.info/security/#cve-2016-9646"
+         },
+         {
+            "url": "https://www.debian.org/security/2017/dsa-3760"
+         },
+         {
+            "url": "https://marc.info/?l=oss-security&m=148304341511854&w=2"
+         },
+         {
+            "url": "https://security-tracker.debian.org/tracker/CVE-2016-9646"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "https://ikiwiki.info/security/#cve-2016-9646",
+      "discovery": "UNKNOWN"
    }
 }

--- a/2017/0xxx/CVE-2017-0356.json
+++ b/2017/0xxx/CVE-2017-0356.json
@@ -1,18 +1,72 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-0356",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@debian.org",
+      "DATE_PUBLIC": "2017-01-11T23:51:00.000Z",
+      "ID": "CVE-2017-0356",
+      "STATE": "PUBLIC",
+      "TITLE": "Authentication bypass via repeated parameters"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "ikiwiki",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "before 3.20170111"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "ikiwiki"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A flaw, similar to to CVE-2016-9646, exists in ikiwiki, in the passwordauth plugin's use of CGI::FormBuilder, allowing an attacker to bypass authentication via repeated parameters."
          }
       ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "authentication bypass"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "url": "https://marc.info/?l=oss-security&m=148418234314276&w=2"
+         },
+         {
+            "url": "https://www.debian.org/security/2017/dsa-3760"
+         },
+         {
+            "url": "https://ikiwiki.info/security/#cve-2017-0356"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "https://ikiwiki.info/security/#cve-2017-0356",
+      "discovery": "UNKNOWN"
    }
 }

--- a/2017/0xxx/CVE-2017-0357.json
+++ b/2017/0xxx/CVE-2017-0357.json
@@ -1,18 +1,69 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-0357",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@debian.org",
+      "DATE_PUBLIC": "2017-01-12T23:00:00.000Z",
+      "ID": "CVE-2017-0357",
+      "STATE": "PUBLIC",
+      "TITLE": "iucode-tool: heap buffer overflow on -tr loader"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "iucode-tool",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "starting with v1.4; before v2.1.1"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "iucode-tool"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A heap-overflow flaw exists in the -tr loader of iucode-tool, potentially leading to SIGSEGV, or heap corruption."
          }
       ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "heap-buffer overflow"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "url": "https://security-tracker.debian.org/tracker/CVE-2017-0357"
+         },
+         {
+            "url": "https://gitlab.com/iucode-tool/iucode-tool/issues/3"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "https://gitlab.com/iucode-tool/iucode-tool/issues/3",
+      "discovery": "UNKNOWN"
    }
 }

--- a/2017/0xxx/CVE-2017-0358.json
+++ b/2017/0xxx/CVE-2017-0358.json
@@ -1,18 +1,78 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-0358",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@debian.org",
+      "DATE_PUBLIC": "2017-02-01T05:44:00.000Z",
+      "ID": "CVE-2017-0358",
+      "STATE": "PUBLIC",
+      "TITLE": "ntfs-3g: Modprobe influence vulnerability via environment variables"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "ntfs-3g",
+                        "version": {
+                           "version_data": [
+                              {
+				 "version_value" : "n/a"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "ntfs-3g"
+            }
+         ]
+      }
+   },
+   "credit": [
+      {
+         "lang": "eng",
+         "value": "Jann Horn of Google Project Zero"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Jann Horn of Google Project Zero discovered that NTFS-3G, a read-write NTFS driver for FUSE, does not scrub the environment before executing modprobe with elevated privileges. A local user can take advantage of this flaw for local root privilege escalation."
          }
       ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "privilege escalation"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "url": "https://security-tracker.debian.org/tracker/DSA-3780-1"
+         },
+         {
+            "url": "https://marc.info/?l=oss-security&m=148594671929354&w=2"
+         },
+         {
+            "url": "http://www.openwall.com/lists/oss-security/2017/02/04/1"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "https://marc.info/?l=oss-security&m=148594671929354&w=2",
+      "discovery": "UNKNOWN"
    }
 }


### PR DESCRIPTION
Add some update from the MITRE ping from 20180326 regarding public bust still reserved CVEs.