### PR TITLE
Add CVE details for CVE-2018-0737

### DIFF
--- a/2018/0xxx/CVE-2018-0737.json
+++ b/2018/0xxx/CVE-2018-0737.json
@@ -1,18 +1,90 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0737",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "CVE_data_meta": {
+        "ASSIGNER": "openssl-security@openssl.org", 
+        "DATE_PUBLIC": "2018-04-16", 
+        "ID": "CVE-2018-0737", 
+        "STATE": "PUBLIC", 
+        "TITLE": "Cache timing vulnerability in RSA Key Generation"
+    }, 
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "OpenSSL", 
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "Fixed in OpenSSL 1.1.0i-dev (Affected 1.1.0-1.1.0h)"
+                                        }, 
+                                        {
+                                            "version_value": "Fixed in OpenSSL 1.0.2p-dev (Affected 1.0.2b-1.0.2o)"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }, 
+                    "vendor_name": "OpenSSL"
+                }
+            ]
+        }
+    }, 
+    "credit": [
+        {
+            "lang": "eng", 
+            "value": "Alejandro Cabrera Aldaya, Billy Brumley, Cesar Pereida Garcia and Luis Manuel Alvarez Tapia"
+        }
+    ], 
+    "data_format": "MITRE", 
+    "data_type": "CVE", 
+    "data_version": "4.0", 
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng", 
+                "value": "The OpenSSL RSA Key generation algorithm has been shown to be vulnerable to a cache timing side channel attack. An attacker with sufficient access to mount cache timing attacks during the RSA key generation process could recover the private key. Fixed in OpenSSL 1.1.0i-dev (Affected 1.1.0-1.1.0h). Fixed in OpenSSL 1.0.2p-dev (Affected 1.0.2b-1.0.2o)."
+            }
+        ]
+    }, 
+    "impact": [
+        {
+            "lang": "eng", 
+            "url": "https://www.openssl.org/policies/secpolicy.html#Low", 
+            "value": "Low"
+        }
+    ], 
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng", 
+                        "value": "Constant time issue"
+                    }
+                ]
+            }
+        ]
+    }, 
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.openssl.org/news/secadv/20180416.txt", 
+                "refsource": "CONFIRM", 
+                "url": "https://www.openssl.org/news/secadv/20180416.txt"
+            }, 
+            {
+                "name": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6939eab03a6e23d2bd2c3f5e34fe1d48e542e787", 
+                "refsource": "CONFIRM", 
+                "url": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6939eab03a6e23d2bd2c3f5e34fe1d48e542e787"
+            }, 
+            {
+                "name": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=349a41da1ad88ad87825414752a8ff5fdd6a6c3f", 
+                "refsource": "CONFIRM", 
+                "url": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=349a41da1ad88ad87825414752a8ff5fdd6a6c3f"
+            }
+        ]
+    }
 }


### PR DESCRIPTION
OpenSSL: Cache timing vulnerability in RSA Key Generation