### PR TITLE
jpcert20180416: fixed typo

### DIFF
--- a/2018/0xxx/CVE-2018-0550.json
+++ b/2018/0xxx/CVE-2018-0550.json
@@ -14,7 +14,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Cybozu Garoon 3.5.0 to 4.6.1 allows remote authenticated attackers to bypass access restriction to view the closed title of \"Space\" via unspecified vectors."
+                "value": "Cybozu Garoon 3.5.0 to 4.6.1 allows remote authenticated attackers to bypass access restriction to view the closed title of \"Cabinet\" via unspecified vectors."
             }
         ]
     },


### PR DESCRIPTION
#431 Thank you for the confirmation. We fixed the typo about the application name in CVE-2018-0550.json