### PR TITLE
ZDI assigns the following CVEs for Foxit Reader:

### DIFF
--- a/2018/10xxx/CVE-2018-10473.json
+++ b/2018/10xxx/CVE-2018-10473.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10473",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D CLOD Base Mesh Continuation structures. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5392."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-787-Out-of-bounds Write"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-383"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10474.json
+++ b/2018/10xxx/CVE-2018-10474.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10474",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Shading objects. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5393."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-787-Out-of-bounds Write"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-384"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10475.json
+++ b/2018/10xxx/CVE-2018-10475.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10475",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Light Node structures. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5394."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-385"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10476.json
+++ b/2018/10xxx/CVE-2018-10476.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10476",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Model Node structures. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5395."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-386"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10477.json
+++ b/2018/10xxx/CVE-2018-10477.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10477",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Chain Index objects. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5396."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-787-Out-of-bounds Write"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-387"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10478.json
+++ b/2018/10xxx/CVE-2018-10478.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10478",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Texture Coord Dimensions objects. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5397."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-388"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10479.json
+++ b/2018/10xxx/CVE-2018-10479.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10479",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Key Frame structures. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated data structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5399."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-389"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10480.json
+++ b/2018/10xxx/CVE-2018-10480.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10480",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the U3D Node Name buffer. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated buffer. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5401."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-390"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10481.json
+++ b/2018/10xxx/CVE-2018-10481.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10481",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of U3D Texture Resource structures. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated data structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5408."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-391"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10482.json
+++ b/2018/10xxx/CVE-2018-10482.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10482",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the U3D Texture Image Format object. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5409."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-392"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10483.json
+++ b/2018/10xxx/CVE-2018-10483.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10483",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Clod Progressive Mesh objects. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5410."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-787-Out-of-bounds Write"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-393"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10484.json
+++ b/2018/10xxx/CVE-2018-10484.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10484",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Node objects. The issue results from the lack of proper initialization of a pointer prior to accessing it. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5411."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-665-Improper Initialization"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-394"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10485.json
+++ b/2018/10xxx/CVE-2018-10485.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10485",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within U3D Texture Height structures. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated data structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5412."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-395"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10486.json
+++ b/2018/10xxx/CVE-2018-10486.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10486",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of the U3D Image Index. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5418."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-396"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10487.json
+++ b/2018/10xxx/CVE-2018-10487.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10487",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D files embedded inside PDF documents. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5419."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-397"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10488.json
+++ b/2018/10xxx/CVE-2018-10488.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10488",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Texture Width structures. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a fixed-length, heap-based buffer. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5420."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-122-Heap-based Buffer Overflow"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-398"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10489.json
+++ b/2018/10xxx/CVE-2018-10489.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10489",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Clod Progressive Mesh Declaration structures. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5421."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-787-Out-of-bounds Write"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-399"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10490.json
+++ b/2018/10xxx/CVE-2018-10490.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10490",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of JPEG images embedded inside U3D files. The issue results from the lack of proper validation of user-supplied data, which can result in a memory access past the end of an allocated data structure. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5422."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-119-Improper Restriction of Operations within the Bounds of a Memory Buffer"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-400"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10491.json
+++ b/2018/10xxx/CVE-2018-10491.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10491",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Bone Weight Modifier structures. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5423."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-787-Out-of-bounds Write"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-401"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10492.json
+++ b/2018/10xxx/CVE-2018-10492.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10492",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D Clod Progressive Mesh Continuation structures. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5424."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-402"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10493.json
+++ b/2018/10xxx/CVE-2018-10493.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10493",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of the U3D Final Maximum Resolution attribute. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5426."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-403"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10494.json
+++ b/2018/10xxx/CVE-2018-10494.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10494",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D 3DView objects. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a fixed-length stack-based buffer. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5493."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-121-Stack-based Buffer Overflow"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-404"
          }
       ]
    }

--- a/2018/10xxx/CVE-2018-10495.json
+++ b/2018/10xxx/CVE-2018-10495.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-10495",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of PDF documents. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5586."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-405"
          }
       ]
    }

--- a/2018/1xxx/CVE-2018-1173.json
+++ b/2018/1xxx/CVE-2018-1173.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-1173",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the XFA borderColor attribute. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5436."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-311"
          }
       ]
    }

--- a/2018/1xxx/CVE-2018-1174.json
+++ b/2018/1xxx/CVE-2018-1174.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-1174",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the bitmapDPI attribute of PrintParams objects. The issue results from the lack of proper initialization of memory prior to accessing it. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5437."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-665-Improper Initialization"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-312"
          }
       ]
    }

--- a/2018/1xxx/CVE-2018-1175.json
+++ b/2018/1xxx/CVE-2018-1175.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-1175",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the interactive attribute of PrintParams objects. The issue results from the lack of proper initialization of memory prior to accessing it. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5438."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-665-Improper Initialization"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-313"
          }
       ]
    }

--- a/2018/1xxx/CVE-2018-1176.json
+++ b/2018/1xxx/CVE-2018-1176.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-1176",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of ePub files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5442."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-787-Out-of-bounds Write"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-314"
          }
       ]
    }

--- a/2018/1xxx/CVE-2018-1177.json
+++ b/2018/1xxx/CVE-2018-1177.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-1177",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the addAnnot method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5488."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-315"
          }
       ]
    }

--- a/2018/1xxx/CVE-2018-1178.json
+++ b/2018/1xxx/CVE-2018-1178.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-1178",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the addField method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5489."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-316"
          }
       ]
    }

--- a/2018/1xxx/CVE-2018-1179.json
+++ b/2018/1xxx/CVE-2018-1179.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-1179",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of DataSubBlock structures in GIF images. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated data structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5490."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-317"
          }
       ]
    }

--- a/2018/1xxx/CVE-2018-1180.json
+++ b/2018/1xxx/CVE-2018-1180.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-1180",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the AFSimple_Calculate method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5491."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-318"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9935.json
+++ b/2018/9xxx/CVE-2018-9935.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9935",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "8.3.2.25013"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 8.3.2.25013. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the addField method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5312."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-319"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9936.json
+++ b/2018/9xxx/CVE-2018-9936.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9936",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of field elements. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5370."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-704-Incorrect Type Conversion or Cast"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-320"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9937.json
+++ b/2018/9xxx/CVE-2018-9937.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9937",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of subform elements. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5371."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-704-Incorrect Type Conversion or Cast"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-321"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9938.json
+++ b/2018/9xxx/CVE-2018-9938.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9938",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the absPageSpan method. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5372."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-704-Incorrect Type Conversion or Cast"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-322"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9939.json
+++ b/2018/9xxx/CVE-2018-9939.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9939",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of layout elements. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5373."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-704-Incorrect Type Conversion or Cast"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-323"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9940.json
+++ b/2018/9xxx/CVE-2018-9940.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9940",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the layout sheet attribute. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5374."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-704-Incorrect Type Conversion or Cast"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-324"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9941.json
+++ b/2018/9xxx/CVE-2018-9941.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9941",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the record append method. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5375."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-704-Incorrect Type Conversion or Cast"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-325"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9942.json
+++ b/2018/9xxx/CVE-2018-9942.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9942",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the record remove method. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5376."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-704-Incorrect Type Conversion or Cast"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-326"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9943.json
+++ b/2018/9xxx/CVE-2018-9943.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9943",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the openList method. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5377."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-704-Incorrect Type Conversion or Cast"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-327"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9944.json
+++ b/2018/9xxx/CVE-2018-9944.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9944",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the addLink method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5379."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-328"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9945.json
+++ b/2018/9xxx/CVE-2018-9945.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9945",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getField method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5382."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-329"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9946.json
+++ b/2018/9xxx/CVE-2018-9946.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9946",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the setTimeOut method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5471."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-330"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9947.json
+++ b/2018/9xxx/CVE-2018-9947.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9947",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of BMP images. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a fixed-length, heap-based buffer. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5472."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-122-Heap-based Buffer Overflow"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-331"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9948.json
+++ b/2018/9xxx/CVE-2018-9948.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9948",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of typed arrays. The issue results from the lack of proper initialization of a pointer prior to accessing it. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5380."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-824-Access of Uninitialized Pointer"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-332"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9949.json
+++ b/2018/9xxx/CVE-2018-9949.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9949",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of TIFF files. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a fixed-length, heap-based buffer. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5473."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-122-Heap-based Buffer Overflow"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-333"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9950.json
+++ b/2018/9xxx/CVE-2018-9950.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9950",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of PDF documents. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5413."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-334"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9951.json
+++ b/2018/9xxx/CVE-2018-9951.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9951",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of CPDF_Object objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5414."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-335"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9952.json
+++ b/2018/9xxx/CVE-2018-9952.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9952",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of XFA Button elements. When setting the formattedValue attribute, the process does not properly validate the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5527."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-336"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9953.json
+++ b/2018/9xxx/CVE-2018-9953.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9953",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the XFA resolveNodes method of Button elements. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5528."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-337"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9954.json
+++ b/2018/9xxx/CVE-2018-9954.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9954",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of XFA Button elements. When setting the y attribute, the process does not properly validate the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5529."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-338"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9955.json
+++ b/2018/9xxx/CVE-2018-9955.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9955",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the XFA resolveNode method of Button elements. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5531."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-339"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9956.json
+++ b/2018/9xxx/CVE-2018-9956.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9956",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of XFA Button elements. When setting the title attribute, the process does not properly validate the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5617."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-340"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9957.json
+++ b/2018/9xxx/CVE-2018-9957.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9957",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of XFA Button elements. When parsing arguments passed to the resetData method, the process does not properly validate the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5618."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-341"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9958.json
+++ b/2018/9xxx/CVE-2018-9958.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9958",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of Text Annotations. When setting the point attribute, the process does not properly validate the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5620."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-342"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9959.json
+++ b/2018/9xxx/CVE-2018-9959.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9959",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of the pageNum document attribute. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5432."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-343"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9960.json
+++ b/2018/9xxx/CVE-2018-9960.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9960",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of the textColor Field attribute. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5433."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-344"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9961.json
+++ b/2018/9xxx/CVE-2018-9961.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9961",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of the rect Field attribute. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5434."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-345"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9962.json
+++ b/2018/9xxx/CVE-2018-9962.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9962",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of Annotation's author attribute. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5435."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-346"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9963.json
+++ b/2018/9xxx/CVE-2018-9963.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9963",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of JPEG2000 images. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5549."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-347"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9964.json
+++ b/2018/9xxx/CVE-2018-9964.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9964",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of the name attribute of OCG objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5568."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-348"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9965.json
+++ b/2018/9xxx/CVE-2018-9965.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9965",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the setAction method of Link objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5569."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-349"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9966.json
+++ b/2018/9xxx/CVE-2018-9966.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9966",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of Calculate actions of TextBox objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5570."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-350"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9967.json
+++ b/2018/9xxx/CVE-2018-9967.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9967",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of Format actions of TextBox objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5571."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-351"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9968.json
+++ b/2018/9xxx/CVE-2018-9968.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9968",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of Keystroke actions of TextBox objects. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5572."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-352"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9969.json
+++ b/2018/9xxx/CVE-2018-9969.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9969",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the XFA boundItem method of Button elements. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5579."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-353"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9970.json
+++ b/2018/9xxx/CVE-2018-9970.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9970",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the XFA execEvent method of Button elements. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5580."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-354"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9971.json
+++ b/2018/9xxx/CVE-2018-9971.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9971",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.104"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.1.104. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within ConvertToPDF_x86.dll. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute arbitrary code in the context of the current process.  Was ZDI-CAN-5754."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-355"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9972.json
+++ b/2018/9xxx/CVE-2018-9972.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9972",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within ConvertToPDF_x86.dll. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute arbitrary code in the context of the current process.  Was ZDI-CAN-5755."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-356"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9973.json
+++ b/2018/9xxx/CVE-2018-9973.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9973",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of ePub files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated buffer. An attacker can leverage this in conjunction with other vulnerabilities to execute arbitrary code in the context of the current process.  Was ZDI-CAN-5758."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-357"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9974.json
+++ b/2018/9xxx/CVE-2018-9974.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9974",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within ConvertToPDF_x86.dll. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a heap-based buffer. An attacker can leverage this vulnerability to execute code in the context of the current process.  Was ZDI-CAN-5895."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-122-Heap-based Buffer Overflow"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-358"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9975.json
+++ b/2018/9xxx/CVE-2018-9975.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9975",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of shift events. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5762."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-359"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9976.json
+++ b/2018/9xxx/CVE-2018-9976.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9976",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of Texture objects in U3D files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5425."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-374"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9977.json
+++ b/2018/9xxx/CVE-2018-9977.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9977",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of Modifier Chain objects in U3D files. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5427."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-375"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9978.json
+++ b/2018/9xxx/CVE-2018-9978.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9978",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the context process.  Was ZDI-CAN-5428."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-376"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9979.json
+++ b/2018/9xxx/CVE-2018-9979.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9979",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of Texture Continuation objects in U3D files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5429."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-377"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9980.json
+++ b/2018/9xxx/CVE-2018-9980.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9980",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5430."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-378"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9981.json
+++ b/2018/9xxx/CVE-2018-9981.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9981",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D files. The issue results from the lack of proper initialization of a pointer prior to accessing it. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5431."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-824-Access of Uninitialized Pointer"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-379"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9982.json
+++ b/2018/9xxx/CVE-2018-9982.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9982",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of the Texture Width in U3D files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5483."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-787-Out-of-bounds Write"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-380"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9983.json
+++ b/2018/9xxx/CVE-2018-9983.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9983",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of U3D files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated data structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the context process.  Was ZDI-CAN-5494."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-381"
          }
       ]
    }

--- a/2018/9xxx/CVE-2018-9984.json
+++ b/2018/9xxx/CVE-2018-9984.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-9984",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of Texture Image Channels objects in U3D files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process.  Was ZDI-CAN-5495."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-382"
          }
       ]
    }


### PR DESCRIPTION
BTW, somebody should get Foxit to become a CNA, this is ridiculous

M  2018/10xxx/CVE-2018-10473.json
M  2018/10xxx/CVE-2018-10474.json
M  2018/10xxx/CVE-2018-10475.json
M  2018/10xxx/CVE-2018-10476.json
M  2018/10xxx/CVE-2018-10477.json
M  2018/10xxx/CVE-2018-10478.json
M  2018/10xxx/CVE-2018-10479.json
M  2018/10xxx/CVE-2018-10480.json
M  2018/10xxx/CVE-2018-10481.json
M  2018/10xxx/CVE-2018-10482.json
M  2018/10xxx/CVE-2018-10483.json
M  2018/10xxx/CVE-2018-10484.json
M  2018/10xxx/CVE-2018-10485.json
M  2018/10xxx/CVE-2018-10486.json
M  2018/10xxx/CVE-2018-10487.json
M  2018/10xxx/CVE-2018-10488.json
M  2018/10xxx/CVE-2018-10489.json
M  2018/10xxx/CVE-2018-10490.json
M  2018/10xxx/CVE-2018-10491.json
M  2018/10xxx/CVE-2018-10492.json
M  2018/10xxx/CVE-2018-10493.json
M  2018/10xxx/CVE-2018-10494.json
M  2018/10xxx/CVE-2018-10495.json
M  2018/1xxx/CVE-2018-1173.json
M  2018/1xxx/CVE-2018-1174.json
M  2018/1xxx/CVE-2018-1175.json
M  2018/1xxx/CVE-2018-1176.json
M  2018/1xxx/CVE-2018-1177.json
M  2018/1xxx/CVE-2018-1178.json
M  2018/1xxx/CVE-2018-1179.json
M  2018/1xxx/CVE-2018-1180.json
M  2018/9xxx/CVE-2018-9935.json
M  2018/9xxx/CVE-2018-9936.json
M  2018/9xxx/CVE-2018-9937.json
M  2018/9xxx/CVE-2018-9938.json
M  2018/9xxx/CVE-2018-9939.json
M  2018/9xxx/CVE-2018-9940.json
M  2018/9xxx/CVE-2018-9941.json
M  2018/9xxx/CVE-2018-9942.json
M  2018/9xxx/CVE-2018-9943.json
M  2018/9xxx/CVE-2018-9944.json
M  2018/9xxx/CVE-2018-9945.json
M  2018/9xxx/CVE-2018-9946.json
M  2018/9xxx/CVE-2018-9947.json
M  2018/9xxx/CVE-2018-9948.json
M  2018/9xxx/CVE-2018-9949.json
M  2018/9xxx/CVE-2018-9950.json
M  2018/9xxx/CVE-2018-9951.json
M  2018/9xxx/CVE-2018-9952.json
M  2018/9xxx/CVE-2018-9953.json
M  2018/9xxx/CVE-2018-9954.json
M  2018/9xxx/CVE-2018-9955.json
M  2018/9xxx/CVE-2018-9956.json
M  2018/9xxx/CVE-2018-9957.json
M  2018/9xxx/CVE-2018-9958.json
M  2018/9xxx/CVE-2018-9959.json
M  2018/9xxx/CVE-2018-9960.json
M  2018/9xxx/CVE-2018-9961.json
M  2018/9xxx/CVE-2018-9962.json
M  2018/9xxx/CVE-2018-9963.json
M  2018/9xxx/CVE-2018-9964.json
M  2018/9xxx/CVE-2018-9965.json
M  2018/9xxx/CVE-2018-9966.json
M  2018/9xxx/CVE-2018-9967.json
M  2018/9xxx/CVE-2018-9968.json
M  2018/9xxx/CVE-2018-9969.json
M  2018/9xxx/CVE-2018-9970.json
M  2018/9xxx/CVE-2018-9971.json
M  2018/9xxx/CVE-2018-9972.json
M  2018/9xxx/CVE-2018-9973.json
M  2018/9xxx/CVE-2018-9974.json
M  2018/9xxx/CVE-2018-9975.json
M  2018/9xxx/CVE-2018-9976.json
M  2018/9xxx/CVE-2018-9977.json
M  2018/9xxx/CVE-2018-9978.json
M  2018/9xxx/CVE-2018-9979.json
M  2018/9xxx/CVE-2018-9980.json
M  2018/9xxx/CVE-2018-9981.json
M  2018/9xxx/CVE-2018-9982.json
M  2018/9xxx/CVE-2018-9983.json
M  2018/9xxx/CVE-2018-9984.json