### PR TITLE
New CVE assignment for CVE-2018-6552 from Canonical

### DIFF
--- a/2018/6xxx/CVE-2018-6552.json
+++ b/2018/6xxx/CVE-2018-6552.json
@@ -1,9 +1,52 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "security@ubuntu.com",
+      "DATE_PUBLIC": "2018-05-30T18:00:00.000Z",
       "ID" : "CVE-2018-6552",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC",
+      "TITLE": "Apport treats the container PID as the global PID when /proc/<global_pid>/  is missing"
    },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Apport",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "Ubuntu 18.04",
+                                 "version_value": "2.20.9-0ubuntu7.1"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "Ubuntu 16.04",
+                                 "version_value": "2.20.1-0ubuntu2.18"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "Ubuntu 17.10",
+                                 "version_value": "2.20.7-0ubuntu3.9"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "n/a"
+            }
+         ]
+      }
+   },
+   "credit": [
+      {
+         "lang": "eng",
+         "value": "Sander Bos"
+      }
+   ],
    "data_format" : "MITRE",
    "data_type" : "CVE",
    "data_version" : "4.0",
@@ -11,8 +54,39 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "Apport does not properly handle crashes originating from a PID namespace allowing local users to create certain files as root which an attacker could leverage to perform a denial of service via resource exhaustion, possibly gain root privileges, or escape from containers.\n\nThis flaw was introduced by the fix for bug 1733366. The is_same_ns() function returns True when /proc/<global pid>/ does not exist in order to indicate that the crash should be handled in the global namespace rather than inside of a container. However, the portion of the data/apport code that decides whether or not to forward a crash to a container does not always replace sys.argv[1] with the value stored in the host_pid variable when /proc/<global pid>/ does not exist which results in the container pid being used in the global namespace."
          }
       ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of service via resource exhaustion, privilege escalation, and escape from containers"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "UBUNTU",
+            "url": "https://usn.ubuntu.com/usn/usn-3664-1"
+         },
+         {
+            "refsource": "UBUNTU",
+            "url": "https://bugs.launchpad.net/ubuntu/+source/apport/+bug/1746668"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "USN-3664-1",
+      "defect": [
+         "1746668"
+      ],
+      "discovery": "EXTERNAL"
    }
 }

--- a/2018/6xxx/CVE-2018-6552.json
+++ b/2018/6xxx/CVE-2018-6552.json
@@ -17,14 +17,29 @@
                         "version": {
                            "version_data": [
                               {
+                                 "affected": ">=",
+                                 "platform": "Ubuntu 18.04",
+                                 "version_value": "2.20.8-0ubuntu4"
+                              },
+                              {
                                  "affected": "<",
                                  "platform": "Ubuntu 18.04",
                                  "version_value": "2.20.9-0ubuntu7.1"
                               },
                               {
+                                 "affected": ">=",
+                                 "platform": "Ubuntu 16.04",
+                                 "version_value": "2.20.1-0ubuntu2.15"
+                              },
+                              {
                                  "affected": "<",
                                  "platform": "Ubuntu 16.04",
                                  "version_value": "2.20.1-0ubuntu2.18"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "platform": "Ubuntu 17.10",
+                                 "version_value": "2.20.7-0ubuntu3.7"
                               },
                               {
                                  "affected": "<",
@@ -54,7 +69,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "Apport does not properly handle crashes originating from a PID namespace allowing local users to create certain files as root which an attacker could leverage to perform a denial of service via resource exhaustion, possibly gain root privileges, or escape from containers.\n\nThis flaw was introduced by the fix for bug 1733366. The is_same_ns() function returns True when /proc/<global pid>/ does not exist in order to indicate that the crash should be handled in the global namespace rather than inside of a container. However, the portion of the data/apport code that decides whether or not to forward a crash to a container does not always replace sys.argv[1] with the value stored in the host_pid variable when /proc/<global pid>/ does not exist which results in the container pid being used in the global namespace."
+            "value" : "Apport does not properly handle crashes originating from a PID namespace allowing local users to create certain files as root which an attacker could leverage to perform a denial of service via resource exhaustion, possibly gain root privileges, or escape from containers.\n\nThe is_same_ns() function returns True when /proc/<global pid>/ does not exist in order to indicate that the crash should be handled in the global namespace rather than inside of a container. However, the portion of the data/apport code that decides whether or not to forward a crash to a container does not always replace sys.argv[1] with the value stored in the host_pid variable when /proc/<global pid>/ does not exist which results in the container pid being used in the global namespace.\n\nThis flaw affects versions 2.20.8-0ubuntu4 through 2.20.9-0ubuntu7, 2.20.7-0ubuntu3.7, 2.20.7-0ubuntu3.8, and 2.20.1-0ubuntu2.15 through 2.20.1-0ubuntu2.17."
          }
       ]
    },
@@ -74,11 +89,8 @@
       "reference_data": [
          {
             "refsource": "UBUNTU",
+            "name": "USN-3664-1",
             "url": "https://usn.ubuntu.com/usn/usn-3664-1"
-         },
-         {
-            "refsource": "UBUNTU",
-            "url": "https://bugs.launchpad.net/ubuntu/+source/apport/+bug/1746668"
          }
       ]
    },


### PR DESCRIPTION
CVE-2018-6552 from the range allocated to Canonical was assigned to apport and made public today.