### PR TITLE
CVE-2017-7654

### DIFF
--- a/2017/7xxx/CVE-2017-7654.json
+++ b/2017/7xxx/CVE-2017-7654.json
@@ -1,18 +1,64 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-7654",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "CVE_data_meta": {
+        "ASSIGNER": "emo@eclipse.org", 
+        "ID": "CVE-2017-7654", 
+        "STATE": "PUBLIC"
+    }, 
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Eclipse Mosquitto", 
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=", 
+                                            "version_value": "1.4.15"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }, 
+                    "vendor_name": "The Eclipse Foundation"
+                }
+            ]
+        }
+    }, 
+    "data_format": "MITRE", 
+    "data_type": "CVE", 
+    "data_version": "4.0", 
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng", 
+                "value": "A Memory Leak vulnerability was found within the Mosquitto Broker. Unauthenticated clients can send crafted CONNECT packets which could cause a denial of service in the Mosquitto Broker."
+            }
+        ]
+    }, 
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng", 
+                        "value": "CWE-401: Improper Release of Memory Before Removing Last Reference"
+                    }
+                ]
+            }
+        ]
+    }, 
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=533493", 
+                "refsource": "CONFIRM", 
+                "url": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=533493"
+            }
+        ]
+    }
 }
+


### PR DESCRIPTION
A Memory Leak vulnerability was found within the Mosquitto Broker.
Unauthenticated clients can send crafted CONNECT packets which could
cause a denial of service in the Mosquitto Broker.