### PR TITLE
CVE-2017-7653

### DIFF
--- a/2017/7xxx/CVE-2017-7653.json
+++ b/2017/7xxx/CVE-2017-7653.json
@@ -1,18 +1,63 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-7653",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "CVE_data_meta": {
+        "ASSIGNER": "emo@eclipse.org", 
+        "ID": "CVE-2017-7653", 
+        "STATE": "PUBLIC"
+    }, 
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Eclipse Mosquitto", 
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=", 
+                                            "version_value": "1.4.15"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }, 
+                    "vendor_name": "The Eclipse Foundation"
+                }
+            ]
+        }
+    }, 
+    "data_format": "MITRE", 
+    "data_type": "CVE", 
+    "data_version": "4.0", 
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng", 
+                "value": "The Mosquitto broker up to version 1.4.15 does not reject strings that are not valid UTF-8. A malicious client could cause other clients that do reject invalid UTF-8 strings to disconnect themselves from the broker by sending a topic string which is not valid UTF-8, and so cause a denial of service for the clients."
+            }
+        ]
+    }, 
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng", 
+                        "value": "CWE-20: Improper Input Validation"
+                    }
+                ]
+            }
+        ]
+    }, 
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=532113", 
+                "refsource": "CONFIRM", 
+                "url": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=532113"
+            }
+        ]
+    }
 }


### PR DESCRIPTION
The Mosquitto broker up to version 1.4.15 does not reject strings that
are not valid UTF-8. A malicious client could cause other clients that
do reject invalid UTF-8 strings to disconnect themselves from the broker
by sending a topic string which is not valid UTF-8, and so cause a
denial of service for the clients.