### PR TITLE
Updates to CVE to show that Ubuntu 14.04 was also affected

### DIFF
--- a/2018/6xxx/CVE-2018-6552.json
+++ b/2018/6xxx/CVE-2018-6552.json
@@ -45,6 +45,11 @@
                                  "affected" : "<",
                                  "platform" : "Ubuntu 17.10",
                                  "version_value" : "2.20.7-0ubuntu3.9"
+                              },
+                              {
+                                 "affected" : "=",
+                                 "platform" : "Ubuntu 14.04",
+                                 "version_value" : "2.14.1-0ubuntu3.28"
                               }
                            ]
                         }
@@ -69,7 +74,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "Apport does not properly handle crashes originating from a PID namespace allowing local users to create certain files as root which an attacker could leverage to perform a denial of service via resource exhaustion, possibly gain root privileges, or escape from containers. The is_same_ns() function returns True when /proc/<global pid>/ does not exist in order to indicate that the crash should be handled in the global namespace rather than inside of a container. However, the portion of the data/apport code that decides whether or not to forward a crash to a container does not always replace sys.argv[1] with the value stored in the host_pid variable when /proc/<global pid>/ does not exist which results in the container pid being used in the global namespace. This flaw affects versions 2.20.8-0ubuntu4 through 2.20.9-0ubuntu7, 2.20.7-0ubuntu3.7, 2.20.7-0ubuntu3.8, and 2.20.1-0ubuntu2.15 through 2.20.1-0ubuntu2.17."
+            "value" : "Apport does not properly handle crashes originating from a PID namespace allowing local users to create certain files as root which an attacker could leverage to perform a denial of service via resource exhaustion, possibly gain root privileges, or escape from containers. The is_same_ns() function returns True when /proc/<global pid>/ does not exist in order to indicate that the crash should be handled in the global namespace rather than inside of a container. However, the portion of the data/apport code that decides whether or not to forward a crash to a container does not always replace sys.argv[1] with the value stored in the host_pid variable when /proc/<global pid>/ does not exist which results in the container pid being used in the global namespace. This flaw affects versions 2.20.8-0ubuntu4 through 2.20.9-0ubuntu7, 2.20.7-0ubuntu3.7, 2.20.7-0ubuntu3.8, 2.20.1-0ubuntu2.15 through 2.20.1-0ubuntu2.17, and 2.14.1-0ubuntu3.28."
          }
       ]
    },


### PR DESCRIPTION
Update the CVE to show that Ubuntu 14.04 was also affected. The matching USN was already added.