### PR TITLE
CVE-2017-7656

### DIFF
--- a/2017/7xxx/CVE-2017-7656.json
+++ b/2017/7xxx/CVE-2017-7656.json
@@ -1,8 +1,48 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "emo@eclipse.org",
       "ID" : "CVE-2017-7656",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Eclipse Jetty",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "<=",
+                                 "version_value" : "9.2.0"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "9.3.0"
+                              },
+                              {
+                                 "version_affected" : "<",
+                                 "version_value" : "9.3.24"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "9.4.0"
+                              },
+                              {
+                                 "version_affected" : "<",
+                                 "version_value" : "9.4.11"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "The Eclipse Foundation"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +51,28 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "In Eclipse Jetty, versions 9.2.x and older, 9.3.x (all configurations), and 9.4.x (non-default configuration with RFC2616 compliance enabled), HTTP/0.9 is handled poorly. A HTTP/1 style request line (ie method space URI space version) that declares a version of HTTP/0.9 was accepted and treated as a 0.9 request. If deployed behind an intermediary that also accepted and passed through the 0.9 version (but did not act on it), then the response sent could be interpreted by the intermediary as HTTP/1 headers. This could be used to poison the cache if the server allowed the origin client to generate arbitrary content in the response."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-444: Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "name" : "https://bugs.eclipse.org/bugs/show_bug.cgi?id=535667",
+            "refsource" : "CONFIRM",
+            "url" : "https://bugs.eclipse.org/bugs/show_bug.cgi?id=535667"
          }
       ]
    }


### PR DESCRIPTION
The version range is a little complicated on this one. I reviewed the documentation, and scanned a bunch of existing records to come to what I have here. I think that it makes sense.