### PR TITLE
Corrected errors in the initial Spotfire release.

### DIFF
--- a/2018/5xxx/CVE-2018-5435.json
+++ b/2018/5xxx/CVE-2018-5435.json
@@ -2,6 +2,7 @@
    "CVE_data_meta" : {
       "ASSIGNER" : "security@tibco.com",
       "DATE_PUBLIC" : "2018-06-26T16:00:00.000Z",
+      "UPDATED": "2018-06-28T18:00:00.000Z",
       "ID" : "CVE-2018-5435",
       "STATE" : "PUBLIC",
       "TITLE" : "TIBCO Spotfire Product Family Remote Code Execution Vulnerability"
@@ -49,17 +50,6 @@
                      },
                      {
                         "product_name" : "TIBCO Spotfire Analytics Platform for AWS Marketplace",
-                        "version" : {
-                           "version_data" : [
-                              {
-                                 "affected" : "<=",
-                                 "version_value" : "7.12.0"
-                              }
-                           ]
-                        }
-                     },
-                     {
-                        "product_name" : "TIBCO Spotfire Automation Services",
                         "version" : {
                            "version_data" : [
                               {
@@ -184,7 +174,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "The TIBCO Spotfire Client and TIBCO Spotfire Web Player Client components of TIBCO Software Inc.'s ; TIBCO Spotfire Analyst, TIBCO Spotfire Analytics Platform for AWS Marketplace, TIBCO Spotfire Automation Services, TIBCO Spotfire Deployment Kit, TIBCO Spotfire Desktop, and TIBCO Spotfire Desktop Language Packs contain multiple vulnerabilities that may allow for remote code execution. Affected releases are TIBCO Software Inc.'s TIBCO Spotfire Analyst: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0; 7.12.0, TIBCO Spotfire Analytics Platform for AWS Marketplace: versions up to and including 7.12.0, TIBCO Spotfire Automation Services: versions up to and including 7.12.0, TIBCO Spotfire Deployment Kit: versions up to and including 7.8.0; 7.9.0;7.9.1;7.10.0;7.10.1;7.11.0; 7.12.0, TIBCO Spotfire Desktop: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0;7.12.0, TIBCO Spotfire Desktop Language Packs: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0."
+            "value" : "The TIBCO Spotfire Client and TIBCO Spotfire Web Player Client components of TIBCO Software Inc.'s TIBCO Spotfire Analyst, TIBCO Spotfire Analytics Platform for AWS Marketplace, TIBCO Spotfire Deployment Kit, TIBCO Spotfire Desktop, and TIBCO Spotfire Desktop Language Packs contain multiple vulnerabilities that may allow for remote code execution.\nAffected releases are TIBCO Software Inc.'s\nTIBCO Spotfire Analyst: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0; 7.12.0,\nTIBCO Spotfire Analytics Platform for AWS Marketplace: versions up to and including 7.12.0,\nTIBCO Spotfire Deployment Kit: versions up to and including 7.8.0; 7.9.0;7.9.1;7.10.0;7.10.1;7.11.0; 7.12.0,\nTIBCO Spotfire Desktop: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0;7.12.0,\nTIBCO Spotfire Desktop Language Packs: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0."
          }
       ]
    },
@@ -233,7 +223,7 @@
    "solution" : [
       {
          "lang" : "eng",
-         "value" : "TIBCO has released updated versions of the affected components which address these issues. For each affected system, update to the corresponding software versions:\n\nTIBCO Spotfire Analyst versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Analyst versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Analyst versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Analyst version 7.11.0 update to version 7.11.1\nTIBCO Spotfire Analyst version 7.12.0 update to version 7.13.0\nTIBCO Spotfire Analytics Platform for AWS Marketplace versions 7.12.0 and below update to version 7.13.0 or higher\nTIBCO Spotfire Automation Services versions 7.12.0 and below update to version 7.13.0 or higher\nTIBCO Spotfire Deployment Kit versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Deployment Kit versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Deployment Kit versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Deployment Kit version 7.11.0 update to version 7.11.1 or higher\nTIBCO Spotfire Deployment Kit version 7.12.0 update to version 7.13.0 or higher\nTIBCO Spotfire Desktop versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Desktop versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Desktop versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Desktop version 7.11.0 update to version 7.11.1 or higher\nTIBCO Spotfire Desktop version 7.12.0 update to version 7.13.0 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Desktop Language Packs version 7.11.0 update to version 7.11.1 or higher\n"
+         "value" : "TIBCO has released updated versions of the affected components which address these issues. For each affected system, update to the corresponding software versions:\n\nTIBCO Spotfire Analyst versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Analyst versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Analyst versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Analyst version 7.11.0 update to version 7.11.1\nTIBCO Spotfire Analyst version 7.12.0 update to version 7.13.0\nTIBCO Spotfire Analytics Platform for AWS Marketplace versions 7.12.0 and below update to version 7.13.0 or higher\nTIBCO Spotfire Deployment Kit versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Deployment Kit versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Deployment Kit versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Deployment Kit version 7.11.0 update to version 7.11.1 or higher\nTIBCO Spotfire Deployment Kit version 7.12.0 update to version 7.13.0 or higher\nTIBCO Spotfire Desktop versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Desktop versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Desktop versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Desktop version 7.11.0 update to version 7.11.1 or higher\nTIBCO Spotfire Desktop version 7.12.0 update to version 7.13.0 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Desktop Language Packs version 7.11.0 update to version 7.11.1 or higher\n"
       }
    ],
    "source" : {

--- a/2018/5xxx/CVE-2018-5437.json
+++ b/2018/5xxx/CVE-2018-5437.json
@@ -2,6 +2,7 @@
    "CVE_data_meta" : {
       "ASSIGNER" : "security@tibco.com",
       "DATE_PUBLIC" : "2018-06-26T16:00:00.000Z",
+      "UPDATED" : "2018-06-28T18:00:00.000Z",
       "ID" : "CVE-2018-5437",
       "STATE" : "PUBLIC",
       "TITLE" : "TIBCO Spotfire Product Family Information Disclosure Vulnerability"
@@ -49,17 +50,6 @@
                      },
                      {
                         "product_name" : "TIBCO Spotfire Analytics Platform for AWS Marketplace",
-                        "version" : {
-                           "version_data" : [
-                              {
-                                 "affected" : "<=",
-                                 "version_value" : "7.12.0"
-                              }
-                           ]
-                        }
-                     },
-                     {
-                        "product_name" : "TIBCO Spotfire Automation Services",
                         "version" : {
                            "version_data" : [
                               {
@@ -184,7 +174,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "The TIBCO Spotfire Client and TIBCO Spotfire Web Player Client components of TIBCO Software Inc.'s ; TIBCO Spotfire Analyst, TIBCO Spotfire Analytics Platform for AWS Marketplace, TIBCO Spotfire Automation Services, TIBCO Spotfire Deployment Kit, TIBCO Spotfire Desktop, and TIBCO Spotfire Desktop Language Packs contain multiple vulnerabilities that may allow for unauthorized information disclosure. Affected releases are TIBCO Software Inc.'s TIBCO Spotfire Analyst: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0; 7.12.0, TIBCO Spotfire Analytics Platform for AWS Marketplace: versions up to and including 7.12.0, TIBCO Spotfire Automation Services: versions up to and including 7.12.0, TIBCO Spotfire Deployment Kit: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0; 7.12.0, TIBCO Spotfire Desktop: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0; 7.12.0, TIBCO Spotfire Desktop Language Packs: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0."
+            "value" : "The TIBCO Spotfire Client and TIBCO Spotfire Web Player Client components of TIBCO Software Inc.'s TIBCO Spotfire Analyst, TIBCO Spotfire Analytics Platform for AWS Marketplace, TIBCO Spotfire Deployment Kit, TIBCO Spotfire Desktop, and TIBCO Spotfire Desktop Language Packs contain multiple vulnerabilities that may allow for unauthorized information disclosure.\n\nAffected releases are TIBCO Software Inc.'s\nTIBCO Spotfire Analyst: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0; 7.12.0,\nTIBCO Spotfire Analytics Platform for AWS Marketplace: versions up to and including 7.12.0,\nTIBCO Spotfire Deployment Kit: versions up to and including 7.8.0; 7.9.0;7.9.1;7.10.0;7.10.1;7.11.0; 7.12.0,\nTIBCO Spotfire Desktop: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0;7.12.0,\nTIBCO Spotfire Desktop Language Packs: versions up to and including 7.8.0; 7.9.0; 7.9.1; 7.10.0; 7.10.1; 7.11.0."
          }
       ]
    },
@@ -233,7 +223,7 @@
    "solution" : [
       {
          "lang" : "eng",
-         "value" : "TIBCO has released updated versions of the affected components which address these issues. When upgrading to one of the new versions some previously working functionality will be disabled by default and require configuration. Please review the README and other documentation for further information. For each affected system, update to the corresponding software versions:\n\nTIBCO Spotfire Analyst versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Analyst versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Analyst versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Analyst version 7.11.0 update to version 7.11.1\nTIBCO Spotfire Analyst version 7.12.0 update to version 7.13.0\nTIBCO Spotfire Analytics Platform for AWS Marketplace versions 7.12.0 and below update to version 7.13.0 or higher\nTIBCO Spotfire Automation Services versions 7.12.0 and below update to version 7.13.0 or higher\nTIBCO Spotfire Deployment Kit versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Deployment Kit versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Deployment Kit versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Deployment Kit version 7.11.0 update to version 7.11.1 or higher\nTIBCO Spotfire Deployment Kit version 7.12.0 update to version 7.13.0 or higher\nTIBCO Spotfire Desktop versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Desktop versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Desktop versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Desktop version 7.11.0 update to version 7.11.1 or higher\nTIBCO Spotfire Desktop version 7.12.0 update to version 7.13.0 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Desktop Language Packs version 7.11.0 update to version 7.11.1 or higher\n"
+         "value" : "TIBCO has released updated versions of the affected components which address these issues. When upgrading to one of the new versions some previously working functionality will be disabled by default and require configuration. Please review the README and other documentation for further information. For each affected system, update to the corresponding software versions:\n\nTIBCO Spotfire Analyst versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Analyst versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Analyst versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Analyst version 7.11.0 update to version 7.11.1\nTIBCO Spotfire Analyst version 7.12.0 update to version 7.13.0\nTIBCO Spotfire Analytics Platform for AWS Marketplace versions 7.12.0 and below update to version 7.13.0 or higher\nTIBCO Spotfire Deployment Kit versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Deployment Kit versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Deployment Kit versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Deployment Kit version 7.11.0 update to version 7.11.1 or higher\nTIBCO Spotfire Deployment Kit version 7.12.0 update to version 7.13.0 or higher\nTIBCO Spotfire Desktop versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Desktop versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Desktop versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Desktop version 7.11.0 update to version 7.11.1 or higher\nTIBCO Spotfire Desktop version 7.12.0 update to version 7.13.0 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.8.0 and below update to version 7.8.1 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.9.0 and 7.9.1 update to version 7.9.2 or higher\nTIBCO Spotfire Desktop Language Packs versions 7.10.0 and 7.10.1 update to version 7.10.2 or higher\nTIBCO Spotfire Desktop Language Packs version 7.11.0 update to version 7.11.1 or higher\n"
       }
    ],
    "source" : {


### PR DESCRIPTION
Listed one product too many in our original announcement.