### PR TITLE
CVE-2017-15097.json

### DIFF
--- a/2017/15xxx/CVE-2017-15097.json
+++ b/2017/15xxx/CVE-2017-15097.json
@@ -1,18 +1,71 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2017-15097",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "data_type": "CVE",
+    "data_format": "MITRE",
+    "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2017-15097",
+        "ASSIGNER": "anemec@redhat.com"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Red Hat",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "postgresql init script",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "all"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-59"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2017-15097",
+                "name": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2017-15097",
+                "refsource": "CONFIRM"
+            }
+        ]
+    },
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "Privilege escalation flaws were found in the Red Hat initialization scripts of PostgreSQL. An attacker with access to the postgres user account could use these flaws to obtain root access on the server machine."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": [
+            [
+                {
+                    "vectorString": "6.5/CVSS:3.0/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+                    "version": "3.0"
+                }
+            ]
+        ]
+    }
 }


### PR DESCRIPTION
I have intentionally not put a version to the description, as this was present in all postgresql init scripts in Red Hat postgresql, and we don't bump the version numbers for patching.