### PR TITLE
ZDI assigns the following CVEs for Foxit:

### DIFF
--- a/2018/11xxx/CVE-2018-11617.json
+++ b/2018/11xxx/CVE-2018-11617.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-11617",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of Format events for ComboBox fields. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5415."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-694"
          }
       ]
    }

--- a/2018/11xxx/CVE-2018-11618.json
+++ b/2018/11xxx/CVE-2018-11618.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-11618",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the resetForm method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5416."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-695"
          }
       ]
    }

--- a/2018/11xxx/CVE-2018-11619.json
+++ b/2018/11xxx/CVE-2018-11619.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-11619",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.0.29935"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.0.29935. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the setFocus method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5417."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-696"
          }
       ]
    }

--- a/2018/11xxx/CVE-2018-11620.json
+++ b/2018/11xxx/CVE-2018-11620.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-11620",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within ConvertToPDF_x86.dll. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute arbitrary code in the context of the current process.  Was ZDI-CAN-5756."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-697"
          }
       ]
    }

--- a/2018/11xxx/CVE-2018-11621.json
+++ b/2018/11xxx/CVE-2018-11621.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-11621",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within ConvertToPDF_x86.dll. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute arbitrary code in the context of the current process.  Was ZDI-CAN-5896."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-698"
          }
       ]
    }

--- a/2018/11xxx/CVE-2018-11622.json
+++ b/2018/11xxx/CVE-2018-11622.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-11622",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within ConvertToPDF_x86.dll. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated object. An attacker can leverage this vulnerability to execute code in the context of the current process.  Was ZDI-CAN-5873."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-787-Out-of-bounds Write"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-699"
          }
       ]
    }

--- a/2018/11xxx/CVE-2018-11623.json
+++ b/2018/11xxx/CVE-2018-11623.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-11623",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the addAdLayer method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. The attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6003."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-700"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14241.json
+++ b/2018/14xxx/CVE-2018-14241.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14241",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the addAnnot method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6004."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-701"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14242.json
+++ b/2018/14xxx/CVE-2018-14242.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14242",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the addField method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6005."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-702"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14243.json
+++ b/2018/14xxx/CVE-2018-14243.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14243",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the addPageOpenJSMessage method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. The attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6006."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-703"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14244.json
+++ b/2018/14xxx/CVE-2018-14244.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14244",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the calculateNow method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6007."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-704"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14245.json
+++ b/2018/14xxx/CVE-2018-14245.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14245",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the closeDoc method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. The attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6008."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-705"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14246.json
+++ b/2018/14xxx/CVE-2018-14246.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14246",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the convertTocPDF method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. The attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6009."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-706"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14247.json
+++ b/2018/14xxx/CVE-2018-14247.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14247",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the exportAsFDF method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6010."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-707"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14248.json
+++ b/2018/14xxx/CVE-2018-14248.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14248",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the exportAsXFDF method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6011."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-708"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14249.json
+++ b/2018/14xxx/CVE-2018-14249.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14249",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the exportDataObject method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6012."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-709"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14250.json
+++ b/2018/14xxx/CVE-2018-14250.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14250",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getAnnot method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6013."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-710"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14251.json
+++ b/2018/14xxx/CVE-2018-14251.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14251",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getDataObject method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6014."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-711"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14252.json
+++ b/2018/14xxx/CVE-2018-14252.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14252",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getField method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6015."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-712"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14253.json
+++ b/2018/14xxx/CVE-2018-14253.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14253",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getIcon method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6016."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-713"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14254.json
+++ b/2018/14xxx/CVE-2018-14254.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14254",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getLinks method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6017."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-714"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14255.json
+++ b/2018/14xxx/CVE-2018-14255.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14255",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getNthFieldName method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6018."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-715"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14256.json
+++ b/2018/14xxx/CVE-2018-14256.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14256",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getOCGs method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6019."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-716"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14257.json
+++ b/2018/14xxx/CVE-2018-14257.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14257",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getPageBox method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6020."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-717"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14258.json
+++ b/2018/14xxx/CVE-2018-14258.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14258",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getPageNthWord method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6021."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-718"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14259.json
+++ b/2018/14xxx/CVE-2018-14259.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14259",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getPageNthWordQuads method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6022."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-719"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14260.json
+++ b/2018/14xxx/CVE-2018-14260.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14260",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getPageRotation method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6023."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-720"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14261.json
+++ b/2018/14xxx/CVE-2018-14261.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14261",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getTemplate method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6024."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-721"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14262.json
+++ b/2018/14xxx/CVE-2018-14262.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14262",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getURL method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6025."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-722"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14263.json
+++ b/2018/14xxx/CVE-2018-14263.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14263",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getVersionID method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6026."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-723"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14264.json
+++ b/2018/14xxx/CVE-2018-14264.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14264",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the importAnFDF method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6027."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-724"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14265.json
+++ b/2018/14xxx/CVE-2018-14265.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14265",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the importAnXFDX method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6028."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-725"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14266.json
+++ b/2018/14xxx/CVE-2018-14266.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14266",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the importDataObject method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6029."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-726"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14267.json
+++ b/2018/14xxx/CVE-2018-14267.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14267",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the importTextData method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6030."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-727"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14268.json
+++ b/2018/14xxx/CVE-2018-14268.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14268",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the mailForm method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6031."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-728"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14269.json
+++ b/2018/14xxx/CVE-2018-14269.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14269",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the print method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6032."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-729"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14270.json
+++ b/2018/14xxx/CVE-2018-14270.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14270",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the removeDataObject method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6033."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-730"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14271.json
+++ b/2018/14xxx/CVE-2018-14271.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14271",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the removeField method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6034."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-731"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14272.json
+++ b/2018/14xxx/CVE-2018-14272.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14272",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the removeIcon method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6035."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-732"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14273.json
+++ b/2018/14xxx/CVE-2018-14273.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14273",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the removeTemplate method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6036."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-733"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14274.json
+++ b/2018/14xxx/CVE-2018-14274.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14274",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the scroll method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6037."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-734"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14275.json
+++ b/2018/14xxx/CVE-2018-14275.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14275",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the spawnPageFromTemplate method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6038."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-735"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14276.json
+++ b/2018/14xxx/CVE-2018-14276.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14276",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the submitForm method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6039."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-736"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14277.json
+++ b/2018/14xxx/CVE-2018-14277.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14277",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the mailDoc method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6059."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-737"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14278.json
+++ b/2018/14xxx/CVE-2018-14278.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14278",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the getPageNumWords method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6058."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-738"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14279.json
+++ b/2018/14xxx/CVE-2018-14279.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14279",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the resetForm method. By performing actions in JavaScript, an attacker can trigger a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6060."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-739"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14280.json
+++ b/2018/14xxx/CVE-2018-14280.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14280",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the exportAsFDF XFA function. The issue results from the lack of proper validation of user-supplied data, which can lead to writing arbitrary files into attacker controlled locations. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5619."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-693-Protection Mechanism Failure"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-740"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14281.json
+++ b/2018/14xxx/CVE-2018-14281.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14281",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the exportData XFA function. The issue results from the lack of proper validation of user-supplied data, which can lead to writing arbitrary files into attacker controlled locations. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5757."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-693-Protection Mechanism Failure"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-741"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14282.json
+++ b/2018/14xxx/CVE-2018-14282.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14282",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of FlateDecode streams. The issue results from the lack of proper initialization of a pointer prior to accessing it. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5763."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-665-Improper Initialization"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-742"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14283.json
+++ b/2018/14xxx/CVE-2018-14283.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14283",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader  9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the highlightMode attribute. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5771."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-743"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14284.json
+++ b/2018/14xxx/CVE-2018-14284.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14284",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the newDoc function. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5773."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-744"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14285.json
+++ b/2018/14xxx/CVE-2018-14285.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14285",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the oneOfChild attribute. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5774."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-745"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14286.json
+++ b/2018/14xxx/CVE-2018-14286.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14286",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of arguments passed to the mailDoc function. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5770."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-746"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14287.json
+++ b/2018/14xxx/CVE-2018-14287.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14287",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of arguments passed to the instanceManager.nodes.append function. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5641."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-747"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14288.json
+++ b/2018/14xxx/CVE-2018-14288.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14288",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.1049"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.1049. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of arguments passed to the setFocus function. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-5642."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-748"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14289.json
+++ b/2018/14xxx/CVE-2018-14289.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14289",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of PDF documents. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute arbitrary code in the context of the current process.  Was ZDI-CAN-6221."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-749"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14290.json
+++ b/2018/14xxx/CVE-2018-14290.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14290",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of PDF documents. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a heap-based buffer. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6222."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-122-Heap-based Buffer Overflow"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-750"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14291.json
+++ b/2018/14xxx/CVE-2018-14291.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14291",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of PDF documents. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6231."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-751"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14292.json
+++ b/2018/14xxx/CVE-2018-14292.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14292",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of PDF documents. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6232."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-752"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14293.json
+++ b/2018/14xxx/CVE-2018-14293.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14293",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.1.0.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.1.0.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the parsing of PDF documents. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6233."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-753"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14294.json
+++ b/2018/14xxx/CVE-2018-14294.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14294",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of FileAttachment annotations. By manipulating a document's elements an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6211."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-754"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14295.json
+++ b/2018/14xxx/CVE-2018-14295.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14295",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit PhantomPDF",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "Phantom PDF 9.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit PhantomPDF Phantom PDF 9.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of PDF documents. When parsing shading patterns, the process does not properly validate user-supplied data, which can result in an integer overflow before allocating a buffer. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6223."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "NO_CWE"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-755"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14296.json
+++ b/2018/14xxx/CVE-2018-14296.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14296",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of Circle annotations. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6212."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-756"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14297.json
+++ b/2018/14xxx/CVE-2018-14297.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14297",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of FreeText annotations. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6213."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-757"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14298.json
+++ b/2018/14xxx/CVE-2018-14298.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14298",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of Ink annotations. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6214."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-758"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14299.json
+++ b/2018/14xxx/CVE-2018-14299.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14299",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of Line annotations. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6215."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-759"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14300.json
+++ b/2018/14xxx/CVE-2018-14300.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14300",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of Polygon annotations. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6216."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-760"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14301.json
+++ b/2018/14xxx/CVE-2018-14301.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14301",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of Sound annotations. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6217."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-761"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14302.json
+++ b/2018/14xxx/CVE-2018-14302.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14302",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of Square annotations. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6218."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-762"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14303.json
+++ b/2018/14xxx/CVE-2018-14303.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14303",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of StrikeOut annotations. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6219."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-763"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14304.json
+++ b/2018/14xxx/CVE-2018-14304.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14304",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of Text annotations. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6220."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-764"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14305.json
+++ b/2018/14xxx/CVE-2018-14305.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14305",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of PolyLine annotations. By manipulating a document's elements an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6265."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-765"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14306.json
+++ b/2018/14xxx/CVE-2018-14306.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14306",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of button objects. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6266."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-766"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14307.json
+++ b/2018/14xxx/CVE-2018-14307.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14307",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of Link objects. By manipulating a document's elements, an attacker can cause a pointer to be reused after it has been freed. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6267."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-767"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14308.json
+++ b/2018/14xxx/CVE-2018-14308.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14308",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the valueAsString function. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code in the context of the current process.  Was ZDI-CAN-6326."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-768"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14309.json
+++ b/2018/14xxx/CVE-2018-14309.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14309",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.1.0.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.1.0.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the SeedValue Generic Object parameter provided to the signatureSetSeedValue function. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code under the context of the current process.  Was ZDI-CAN-6329."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-769"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14310.json
+++ b/2018/14xxx/CVE-2018-14310.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14310",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.1.0.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.1.0.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of events. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code in the context of the current process.  Was ZDI-CAN-6330."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-770"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14311.json
+++ b/2018/14xxx/CVE-2018-14311.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14311",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit ActiveX Pro SDK",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.1.0.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of XFA events. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code in the context of the current process.  Was ZDI-CAN-6331."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-771"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14312.json
+++ b/2018/14xxx/CVE-2018-14312.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14312",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of the exportAsFDF function. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code in the context of the current process.  Was ZDI-CAN-6332."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-772"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14313.json
+++ b/2018/14xxx/CVE-2018-14313.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14313",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of PDF files. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code in the context of the current process.  Was ZDI-CAN-6362."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-843-Access of Resource Using Incompatible Type ('Type Confusion')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-773"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14314.json
+++ b/2018/14xxx/CVE-2018-14314.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14314",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of annotations. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code in the context of the current process.  Was ZDI-CAN-6327."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-774"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14315.json
+++ b/2018/14xxx/CVE-2018-14315.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14315",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the handling of annotations. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code in the context of the current process.  Was ZDI-CAN-6328."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-416-Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-775"
          }
       ]
    }

--- a/2018/14xxx/CVE-2018-14316.json
+++ b/2018/14xxx/CVE-2018-14316.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "zdi-disclosures@trendmicro.com",
       "ID" : "CVE-2018-14316",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Foxit Reader",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "9.0.1.5096"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Foxit"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "This vulnerability allows remote attackers to disclose sensitive information on vulnerable installations of Foxit Reader 9.0.1.5096. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The specific flaw exists within the processing of PDF documents. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated buffer. An attacker can leverage this vulnerability to execute code in the context of the current process.  Was ZDI-CAN-6351."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-125-Out-of-bounds Read"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://www.foxitsoftware.com/support/security-bulletins.php"
+         },
+         {
+            "url" : "https://zerodayinitiative.com/advisories/ZDI-18-776"
          }
       ]
    }


### PR DESCRIPTION
M  2018/11xxx/CVE-2018-11617.json
M  2018/11xxx/CVE-2018-11618.json
M  2018/11xxx/CVE-2018-11619.json
M  2018/11xxx/CVE-2018-11620.json
M  2018/11xxx/CVE-2018-11621.json
M  2018/11xxx/CVE-2018-11622.json
M  2018/11xxx/CVE-2018-11623.json
M  2018/14xxx/CVE-2018-14241.json
M  2018/14xxx/CVE-2018-14242.json
M  2018/14xxx/CVE-2018-14243.json
M  2018/14xxx/CVE-2018-14244.json
M  2018/14xxx/CVE-2018-14245.json
M  2018/14xxx/CVE-2018-14246.json
M  2018/14xxx/CVE-2018-14247.json
M  2018/14xxx/CVE-2018-14248.json
M  2018/14xxx/CVE-2018-14249.json
M  2018/14xxx/CVE-2018-14250.json
M  2018/14xxx/CVE-2018-14251.json
M  2018/14xxx/CVE-2018-14252.json
M  2018/14xxx/CVE-2018-14253.json
M  2018/14xxx/CVE-2018-14254.json
M  2018/14xxx/CVE-2018-14255.json
M  2018/14xxx/CVE-2018-14256.json
M  2018/14xxx/CVE-2018-14257.json
M  2018/14xxx/CVE-2018-14258.json
M  2018/14xxx/CVE-2018-14259.json
M  2018/14xxx/CVE-2018-14260.json
M  2018/14xxx/CVE-2018-14261.json
M  2018/14xxx/CVE-2018-14262.json
M  2018/14xxx/CVE-2018-14263.json
M  2018/14xxx/CVE-2018-14264.json
M  2018/14xxx/CVE-2018-14265.json
M  2018/14xxx/CVE-2018-14266.json
M  2018/14xxx/CVE-2018-14267.json
M  2018/14xxx/CVE-2018-14268.json
M  2018/14xxx/CVE-2018-14269.json
M  2018/14xxx/CVE-2018-14270.json
M  2018/14xxx/CVE-2018-14271.json
M  2018/14xxx/CVE-2018-14272.json
M  2018/14xxx/CVE-2018-14273.json
M  2018/14xxx/CVE-2018-14274.json
M  2018/14xxx/CVE-2018-14275.json
M  2018/14xxx/CVE-2018-14276.json
M  2018/14xxx/CVE-2018-14277.json
M  2018/14xxx/CVE-2018-14278.json
M  2018/14xxx/CVE-2018-14279.json
M  2018/14xxx/CVE-2018-14280.json
M  2018/14xxx/CVE-2018-14281.json
M  2018/14xxx/CVE-2018-14282.json
M  2018/14xxx/CVE-2018-14283.json
M  2018/14xxx/CVE-2018-14284.json
M  2018/14xxx/CVE-2018-14285.json
M  2018/14xxx/CVE-2018-14286.json
M  2018/14xxx/CVE-2018-14287.json
M  2018/14xxx/CVE-2018-14288.json
M  2018/14xxx/CVE-2018-14289.json
M  2018/14xxx/CVE-2018-14290.json
M  2018/14xxx/CVE-2018-14291.json
M  2018/14xxx/CVE-2018-14292.json
M  2018/14xxx/CVE-2018-14293.json
M  2018/14xxx/CVE-2018-14294.json
M  2018/14xxx/CVE-2018-14295.json
M  2018/14xxx/CVE-2018-14296.json
M  2018/14xxx/CVE-2018-14297.json
M  2018/14xxx/CVE-2018-14298.json
M  2018/14xxx/CVE-2018-14299.json
M  2018/14xxx/CVE-2018-14300.json
M  2018/14xxx/CVE-2018-14301.json
M  2018/14xxx/CVE-2018-14302.json
M  2018/14xxx/CVE-2018-14303.json
M  2018/14xxx/CVE-2018-14304.json
M  2018/14xxx/CVE-2018-14305.json
M  2018/14xxx/CVE-2018-14306.json
M  2018/14xxx/CVE-2018-14307.json
M  2018/14xxx/CVE-2018-14308.json
M  2018/14xxx/CVE-2018-14309.json
M  2018/14xxx/CVE-2018-14310.json
M  2018/14xxx/CVE-2018-14311.json
M  2018/14xxx/CVE-2018-14312.json
M  2018/14xxx/CVE-2018-14313.json
M  2018/14xxx/CVE-2018-14314.json
M  2018/14xxx/CVE-2018-14315.json
M  2018/14xxx/CVE-2018-14316.json