### PR TITLE
Correction on version affected for CVE-2018-1258

### DIFF
--- a/2018/1xxx/CVE-2018-1258.json
+++ b/2018/1xxx/CVE-2018-1258.json
@@ -16,7 +16,8 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "prior to 5.0.6."
+                                 "affected": "=",
+                                 "version_value" : "5.0.5"
                               }
                            ]
                         }
@@ -35,7 +36,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "Spring Security in combination with Spring Framework versions prior to 5.0.6 contains an authorization bypass when using method security. An unauthorized malicious user can gain unauthorized access to methods that should be restricted."
+            "value" : "Spring Framework version 5.0.5 when used in combination with any versions of Spring Security contains an authorization bypass when using method security. An unauthorized malicious user can gain unauthorized access to methods that should be restricted."
          }
       ]
    },


### PR DESCRIPTION
The affected version is only 5.0.5, not all versions prior to 5.0.6.