### PR TITLE
Add CVE-2016-4975

### DIFF
--- a/2016/4xxx/CVE-2016-4975.json
+++ b/2016/4xxx/CVE-2016-4975.json
@@ -1,18 +1,85 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2016-4975",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "CVE_data_meta": {
+        "ASSIGNER": "security@apache.org", 
+        "DATE_PUBLIC": "2018-08-14", 
+        "ID": "CVE-2016-4975", 
+        "STATE": "PUBLIC", 
+        "TITLE": "mod_userdir CRLF injection"
+    }, 
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Apache HTTP Server", 
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "Fixed in Apache HTTP Server 2.4.25 (Affected 2.4.1-2.4.23)"
+                                        }, 
+                                        {
+                                            "version_value": "Fixed in Apache HTTP Server 2.2.32 (Affected 2.2.0-2.2.31)"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }, 
+                    "vendor_name": "Apache Software Foundation"
+                }
+            ]
+        }
+    }, 
+    "credit": [
+        {
+            "lang": "eng", 
+            "value": "The issue was discovered by Sergey Bobrov"
+        }
+    ], 
+    "data_format": "MITRE", 
+    "data_type": "CVE", 
+    "data_version": "4.0", 
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng", 
+                "value": " Possible CRLF injection allowing HTTP response splitting attacks for sites which use mod_userdir. This issue was mitigated by changes made in 2.4.25 and 2.2.32 which prohibit CR or LF injection into the \"Location\" or other outbound header key or value. Fixed in Apache HTTP Server 2.4.25 (Affected 2.4.1-2.4.23). Fixed in Apache HTTP Server 2.2.32 (Affected 2.2.0-2.2.31)."
+            }
+        ]
+    }, 
+    "impact": [
+        {
+            "lang": "eng", 
+            "url": "https://httpd.apache.org/security/impact_levels.html#moderate", 
+            "value": "moderate"
+        }
+    ], 
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng", 
+                        "value": "(undefined)"
+                    }
+                ]
+            }
+        ]
+    }, 
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://httpd.apache.org/security/vulnerabilities_24.html#CVE-2016-4975", 
+                "refsource": "CONFIRM", 
+                "url": "https://httpd.apache.org/security/vulnerabilities_24.html#CVE-2016-4975"
+            }, 
+            {
+                "name": "https://httpd.apache.org/security/vulnerabilities_22.html#CVE-2016-4975", 
+                "refsource": "CONFIRM", 
+                "url": "https://httpd.apache.org/security/vulnerabilities_22.html#CVE-2016-4975"
+            }
+        ]
+    }
 }


### PR DESCRIPTION
Note this was originally a Red Hat CNA CVE that was given to Apache before Apache was a CNA.  (This is actually the last remaining Red Hat CVE with this status).  I represent both the Red Hat CNA and Apache in this request (as I gave the name to myself at Apache in 2016)