### PR TITLE
CVE-2018-14624

### DIFF
--- a/2018/14xxx/CVE-2018-14624.json
+++ b/2018/14xxx/CVE-2018-14624.json
@@ -1,18 +1,71 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-14624",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "data_type": "CVE",
+    "data_format": "MITRE",
+    "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2018-14624",
+        "ASSIGNER": "sfowler@redhat.com"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "[UNKNOWN]",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "389-ds-base",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "n/a"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-20"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2018-14624",
+                "name": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2018-14624",
+                "refsource": "CONFIRM"
+            }
+        ]
+    },
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "A vulnerability was discovered in 389-ds-base through version 1.4.0.16. The lock controlling the error log was not correctly used when re-opening the log file in log__error_emergency(). An attacker could send a flood of modifications to a very large DN, which would cause slapd to crash."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": [
+            [
+                {
+                    "vectorString": "7.5/CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "version": "3.0"
+                }
+            ]
+        ]
+    }
 }

--- a/2018/14xxx/CVE-2018-14624.json
+++ b/2018/14xxx/CVE-2018-14624.json
@@ -18,7 +18,16 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "n/a"
+                                            "affected": "<=",
+                                            "version_value": "1.4.0.16"
+                                        },
+                                        {
+                                            "affected": "<=",
+                                            "version_value": "1.3.8.8"
+                                        },
+                                        {
+                                            "affected": "<=",
+                                            "version_value": "1.3.7.10"
                                         }
                                     ]
                                 }
@@ -47,6 +56,10 @@
                 "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2018-14624",
                 "name": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2018-14624",
                 "refsource": "CONFIRM"
+            },
+            {
+                "url": "https://pagure.io/389-ds-base/issue/49937",
+                "refsource": "CONFIRM"
             }
         ]
     },
@@ -54,7 +67,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A vulnerability was discovered in 389-ds-base through version 1.4.0.16. The lock controlling the error log was not correctly used when re-opening the log file in log__error_emergency(). An attacker could send a flood of modifications to a very large DN, which would cause slapd to crash."
+                "value": "A vulnerability was discovered in 389-ds-base through versions 1.3.7.10, 1.3.8.8 and 1.4.0.16. The lock controlling the error log was not correctly used when re-opening the log file in log__error_emergency(). An attacker could send a flood of modifications to a very large DN, which would cause slapd to crash."
             }
         ]
     },


### PR DESCRIPTION
Upstream has not been patched yet, 1.4.0.16 is the latest version.