### PR TITLE
CVE-2018-6554 and CVE-2018-6555

### DIFF
--- a/2018/6xxx/CVE-2018-6554.json
+++ b/2018/6xxx/CVE-2018-6554.json
@@ -1,18 +1,69 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-6554",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@ubuntu.com",
+      "DATE_PUBLIC": "2018-09-04T15:00:00.000Z",
+      "ID": "CVE-2018-6554",
+      "STATE": "PUBLIC"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Linux Kernel",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "before 4.17"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Linux Kernel"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Memory leak in the irda_bind function in net/irda/af_irda.c and later in drivers/staging/irda/net/af_irda.c in the Linux kernel before 4.17 allows local users to cause a denial of service (memory consumption) by repeatedly binding an AF_IRDA socket."
          }
       ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')"
+               }
+            ]
+         }
+      ]
+   },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "https://www.spinics.net/lists/stable/msg255034.html"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://www.spinics.net/lists/stable/msg255030.html"
+      }
+    ]
+  },
+   "source": {
+      "discovery": "UNKNOWN"
    }
 }

--- a/2018/6xxx/CVE-2018-6555.json
+++ b/2018/6xxx/CVE-2018-6555.json
@@ -1,18 +1,69 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-6555",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@ubuntu.com",
+      "DATE_PUBLIC": "2018-09-04T15:00:00.000Z",
+      "ID": "CVE-2018-6555",
+      "STATE": "PUBLIC"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Linux Kernel",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "before 4.17"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Linux Kernel"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "The irda_setsockopt function in net/irda/af_irda.c and later in drivers/staging/irda/net/af_irda.c in the Linux kernel before 4.17 allows local users to cause a denial of service (ias_object use-after-free and system crash) or possibly have unspecified other impact via an AF_IRDA socket.\n"
          }
       ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "CWE-416: Use After Free"
+               }
+            ]
+         }
+      ]
+   },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "https://www.spinics.net/lists/stable/msg255035.html"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://www.spinics.net/lists/stable/msg255031.html"
+      }
+    ]
+  },
+   "source": {
+      "discovery": "UNKNOWN"
    }
 }


### PR DESCRIPTION
CVEs assigned by Canonical for issues in the IRDA subsystem of the Linux kernel.