### PR TITLE
Add mediawiki assignments from Debian

### DIFF
--- a/2018/0xxx/CVE-2018-0503.json
+++ b/2018/0xxx/CVE-2018-0503.json
@@ -1,18 +1,70 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0503",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@debian.org",
+      "DATE_PUBLIC": "2018-09-20T21:18:00.000Z",
+      "ID": "CVE-2018-0503",
+      "STATE": "PUBLIC",
+      "TITLE": "$wgRateLimits entry for 'user' overrides 'newbie'"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "mediawiki",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "before 1.31.1, 1.30.1, 1.29.3 and 1.27.5"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "mediawiki"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Mediawiki 1.31 before 1.31.1, 1.30.1, 1.29.3 and 1.27.5 contains a flaw where contrary to the documentation, $wgRateLimits entry for 'user' overrides that for 'newbie'."
          }
       ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Improper imlementation of documentation / spec"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "CONFIRM",
+            "url": "https://lists.wikimedia.org/pipermail/wikitech-l/2018-September/090849.html"
+         },
+         {
+            "refsource": "CONFIRM",
+            "url": "https://phabricator.wikimedia.org/T169545"
+         }
+      ]
+   },
+   "source": {
+      "discovery": "UNKNOWN"
    }
 }

--- a/2018/0xxx/CVE-2018-0504.json
+++ b/2018/0xxx/CVE-2018-0504.json
@@ -1,18 +1,70 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0504",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@debian.org",
+      "DATE_PUBLIC": "2018-09-20T21:18:00.000Z",
+      "ID": "CVE-2018-0504",
+      "STATE": "PUBLIC",
+      "TITLE": "Information disclosure in Special:Redirect/logid"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "mediawiki",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "before 1.31.1, 1.30.1, 1.29.3 and 1.27.5"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "mediawiki"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Mediawiki 1.31 before 1.31.1, 1.30.1, 1.29.3 and 1.27.5 contains an information disclosure flaw in the Special:Redirect/logid"
          }
       ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Information disclosure"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "CONFIRM",
+            "url": "https://lists.wikimedia.org/pipermail/wikitech-l/2018-September/090849.html"
+         },
+         {
+            "refsource": "CONFIRM",
+            "url": "https://phabricator.wikimedia.org/T187638"
+         }
+      ]
+   },
+   "source": {
+      "discovery": "UNKNOWN"
    }
 }

--- a/2018/0xxx/CVE-2018-0505.json
+++ b/2018/0xxx/CVE-2018-0505.json
@@ -1,18 +1,70 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0505",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@debian.org",
+      "DATE_PUBLIC": "2018-09-20T21:18:00.000Z",
+      "ID": "CVE-2018-0505",
+      "STATE": "PUBLIC",
+      "TITLE": "BotPasswords can bypass CentralAuth's account lock"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "mediawiki",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "before 1.31.1, 1.30.1, 1.29.3 and 1.27.5"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "mediawiki"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Mediawiki 1.31 before 1.31.1, 1.30.1, 1.29.3 and 1.27.5 contains a flaw where BotPasswords can bypass CentralAuth's account lock"
          }
       ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Authentication bypass"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "CONFIRM",
+            "url": "https://lists.wikimedia.org/pipermail/wikitech-l/2018-September/090849.html"
+         },
+         {
+            "refsource": "CONFIRM",
+            "url": "https://phabricator.wikimedia.org/T194605"
+         }
+      ]
+   },
+   "source": {
+      "discovery": "UNKNOWN"
    }
 }

--- a/2018/13xxx/CVE-2018-13258.json
+++ b/2018/13xxx/CVE-2018-13258.json
@@ -1,18 +1,70 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-13258",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "security@debian.org",
+      "DATE_PUBLIC": "2018-09-20T21:18:00.000Z",
+      "ID": "CVE-2018-13258",
+      "STATE": "PUBLIC",
+      "TITLE": " Tarball was missing .htaccess files"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "mediawiki",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_value": "1.31 before 1.31.1"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "mediawiki"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Mediawiki 1.31 before 1.31.1 misses .htaccess files in the provided tarball used to protect some directories that shouldn't be web accessible."
          }
       ]
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "missing .htaccess files in release tarball used to protect directories that shouldn't be web accessible."
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "CONFIRM",
+            "url": "https://lists.wikimedia.org/pipermail/wikitech-l/2018-September/090849.html"
+         },
+         {
+            "refsource": "CONFIRM",
+            "url": "https://phabricator.wikimedia.org/T199029"
+         }
+      ]
+   },
+   "source": {
+      "discovery": "UNKNOWN"
    }
 }


### PR DESCRIPTION
This pull request adds the CVE information for the recent mediawiki CVEs (assigned from the Debian pool) and which are CVE-2018-13258, CVE-2018-0505, CVE-2018-0504 and CVE-2018-0503.

https://www.debian.org/security/2018/dsa-4301