### PR TITLE
Adding Cisco CVE-2018-0405

### DIFF
--- a/2018/0xxx/CVE-2018-0405.json
+++ b/2018/0xxx/CVE-2018-0405.json
@@ -36,7 +36,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A vulnerability in the web framework code for Cisco RV180W Wireless-N Multifunction VPN Router and Small Business RV Series RV220W Wireless Network Security Firewall could allow an unauthenticated,	remote attacker to conduct a directory path traversal attack on a targeted device. The issue is due to improper sanitization of user-supplied input in HTTP request parameters that describe filenames. An attacker could exploit this vulnerability by using directory traversal techniques to submit a path to a desired file location."
+                "value": "A vulnerability in the web framework code for Cisco RV180W Wireless-N Multifunction VPN Router and Small Business RV Series RV220W Wireless Network Security Firewall could allow an unauthenticated, remote attacker to conduct a directory path traversal attack on a targeted device. The issue is due to improper sanitization of user-supplied input in HTTP request parameters that describe filenames. An attacker could exploit this vulnerability by using directory traversal techniques to submit a path to a desired file location."
             }
         ]
     },

--- a/2018/0xxx/CVE-2018-0405.json
+++ b/2018/0xxx/CVE-2018-0405.json
@@ -1,18 +1,79 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0405",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "CVE_data_meta": {
+        "ASSIGNER": "psirt@cisco.com",
+        "DATE_PUBLIC": "2018-10-03T16:00:00-0500",
+        "ID": "CVE-2018-0405",
+        "STATE": "PUBLIC",
+        "TITLE": "Cisco RV180W Wireless-N Multifunction VPN Router Directory Path Traversal Vulnerability"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Cisco RV180W Wireless-N Multifunction VPN Router",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "n/a"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Cisco"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "A vulnerability in the web framework code for Cisco RV180W Wireless-N Multifunction VPN Router and Small Business RV Series RV220W Wireless Network Security Firewall could allow an unauthenticated,	remote attacker to conduct a directory path traversal attack on a targeted device. The issue is due to improper sanitization of user-supplied input in HTTP request parameters that describe filenames. An attacker could exploit this vulnerability by using directory traversal techniques to submit a path to a desired file location."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "baseScore": "7.5",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-22"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "20181003 Cisco RV180W Wireless-N Multifunction VPN Router Path Traversal Vulnerability",
+                "refsource": "CISCO",
+                "url": "https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvk28019"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "CSCvk28019",
+        "defect": [
+            [
+                "CSCvk28019"
+            ]
+        ],
+        "discovery": "UNKNOWN"
+    }
 }


### PR DESCRIPTION
Adding Cisco CVE-2018-0405 for Cisco RV180W Wireless-N Multifunction VPN Router Directory Path Traversal Vulnerability and correcting validation error.