### PR TITLE
CVE IDs assigned in Juniper Security Advisory Bundle for Oct 2018

### DIFF
--- a/2018/0xxx/CVE-2018-0043.json
+++ b/2018/0xxx/CVE-2018-0043.json
@@ -1,18 +1,221 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0043",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0043",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: RPD daemon crashes upon receipt of specific MPLS packet"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D77"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "12.3",
+                                 "version_value": "12.3R12-S10"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D75"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX/EX Series",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D47"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFabric Series",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D130"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1F6",
+                                 "version_value": "15.1F6-S10"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R4-S9 15.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D140"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "EX2300/EX3400 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D59 "
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX10K Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D67"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5200/QFX5110 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D233"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "NFX Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D471 15.1X53-D490"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R3-S8 16.1R4-S8 16.1R5-S4 16.1R6-S4 16.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1X65",
+                                 "version_value": "16.1X65-D48"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R1-S6 16.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R1-S7 17.1R2-S6 17.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R1-S6 17.2R2-S3 17.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2X75",
+                                 "version_value": "17.2X75-D100 17.2X75-D42 17.2X75-D91"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R1-S4 17.3R2-S2 17.3R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R1-S3 17.4R2 "
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "This issue may occurs when the Junos OS device is configured with:\n  [protocols mpls interface]"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Receipt of a specific MPLS packet may cause the routing protocol daemon (RPD) process to crash and restart or may lead to remote code execution.\nBy continuously sending specific MPLS packets, an attacker can repeatedly crash the RPD process causing a sustained Denial of Service.\n\nThis issue affects both IPv4 and IPv6.\n\nThis issue can only be exploited from within the MPLS domain.\nEnd-users connected to the CE device cannot cause this crash.\nAffected releases are Juniper Networks Junos OS:\n12.1X46 versions prior to 12.1X46-D77 on SRX Series;\n12.3 versions prior to 12.3R12-S10;\n12.3X48 versions prior to 12.3X48-D75 on SRX Series;\n14.1X53 versions prior to 14.1X53-D47 on QFX/EX Series;\n14.1X53 versions prior to 14.1X53-D130 on QFabric Series;\n15.1F6 versions prior to 15.1F6-S10;\n15.1 versions prior to 15.1R4-S9 15.1R7;\n15.1X49 versions prior to 15.1X49-D140 on SRX Series;\n15.1X53 versions prior to 15.1X53-D59  on EX2300/EX3400 Series;\n15.1X53 versions prior to 15.1X53-D67 on QFX10K Series;\n15.1X53 versions prior to 15.1X53-D233 on QFX5200/QFX5110 Series;\n15.1X53 versions prior to 15.1X53-D471 15.1X53-D490 on NFX Series;\n16.1 versions prior to 16.1R3-S8 16.1R4-S8 16.1R5-S4 16.1R6-S4 16.1R7;\n16.1X65 versions prior to 16.1X65-D48;\n16.2 versions prior to 16.2R1-S6 16.2R3;\n17.1 versions prior to 17.1R1-S7 17.1R2-S6 17.1R3;\n17.2 versions prior to 17.2R1-S6 17.2R2-S3 17.2R3;\n17.2X75 versions prior to 17.2X75-D100 17.2X75-D42 17.2X75-D91;\n17.3 versions prior to 17.3R1-S4 17.3R2-S2 17.3R3;\n17.4 versions prior to 17.4R1-S3 17.4R2 .\nNo other Juniper Networks products or platforms are affected by this issue."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "ADJACENT_NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 8.8,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of Service\n"
+               },
+               {
+                  "lang": "eng",
+                  "value": "Remote Code Execution"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10877",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10877"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 12.1X46-D77, 12.3R12-S10, 12.3X48-D75, 14.1X53-D130, 14.1X53-D47, 15.1F6-S10, 15.1R4-S9, 15.1R7, 15.1X49-D140, 15.1X53-D233, 15.1X53-D471, 15.1X53-D490, 15.1X53-D59, 15.1X53-D67, 16.1R3-S8, 16.1R4-S8, 16.1R5-S4, 16.1R6-S4, 16.1R7, 16.1X65-D48, 16.2R1-S6, 16.2R2-S6, 16.2R3, 17.1R1-S7, 17.1R2-S6, 17.1R3, 17.2R1-S6, 17.2R2-S3, 17.2R3, 17.2X75-D100, 17.2X75-D42, 17.2X75-D91, 17.3R1-S4, 17.3R2-S2, 17.3R3, 17.4R1-S3, 17.4R2, 18.1R1, 18.2R1, 18.2X75-D5  and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10877",
+      "defect": [
+         "1328058"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "There are no known workarounds for this issue."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0044.json
+++ b/2018/0xxx/CVE-2018-0044.json
@@ -1,18 +1,118 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0044",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0044",
+      "STATE": "PUBLIC",
+      "TITLE": "NFX Series: Insecure sshd configuration in Juniper Device Manager (JDM) and host OS"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "NFX Series",
+                                 "version_name": "18.1",
+                                 "version_value": "18.1R4"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "This issue is only exploitable when there are user or system accounts with blank or empty passwords configured on JDM or host OS. "
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "An insecure SSHD configuration in Juniper Device Manager (JDM) and host OS on Juniper NFX Series devices may allow remote unauthenticated access if any of the passwords on the system are empty. The affected SSHD configuration has the PermitEmptyPasswords option set to \"yes\".\nAffected releases are Juniper Networks Junos OS:\n18.1 versions prior to 18.1R4 on NFX Series."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 9.8,
+         "baseSeverity": "CRITICAL",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Insecure default configuration"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10878",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10878"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "PermitEmptyPasswords option has been set to no by default in the fixed versions of Junos OS.\n\nThe following software releases have been updated to resolve this specific issue: 18.1R4, 18.2R1 and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10878",
+      "defect": [
+         "1344176"
+      ],
+      "discovery": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Ensure all the accounts on the JDM and host OS are configured with a password."
+      },
+      {
+         "lang": "eng",
+         "value": "Ensure that /etc/ssh/sshd_config file on JDM and host OS have the configuration\n  PermitEmptyPasswords no"
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0045.json
+++ b/2018/0xxx/CVE-2018-0045.json
@@ -1,18 +1,200 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0045",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0045",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: RPD daemon crashes due to receipt of specific Draft-Rosen MVPN control packet in Draft-Rosen MVPN configuration"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D77"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "12.3",
+                                 "version_value": "12.3R12-S10"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D70"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R4-S9, 15.1R6-S6, 15.1R7"
+                              },
+                              {
+                                 "affected": "=",
+                                 "version_name": "15.1F6",
+                                 "version_value": "15.1F6"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D140"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "EX2300/EX3400 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D59"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX10K Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D67 "
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5200/QFX5110 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D233 "
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "NFX Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D471, 15.1X53-D490"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R4-S9, 16.1R5-S4, 16.1R6-S3, 16.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R1-S6, 16.2R2-S6, 16.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R1-S7, 17.1R2-S7, 17.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R2-S4, 17.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R2-S2, 17.3R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R1-S3, 17.4R2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "18.1",
+                                 "version_value": "18.1R2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "This issue may occurs when the Junos OS device is configured with:\n  [routing-instances <name> protocols pim mvpn] \n  [routing-instances <name> provider-tunnel pim-*]\n"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Receipt of a specific Draft-Rosen MVPN control packet may cause the routing protocol daemon (RPD) process to crash and restart or may lead to remote code execution. By continuously sending the same specific Draft-Rosen MVPN control packet, an attacker can repeatedly crash the RPD process causing a prolonged denial of service. \n\nThis issue may occur when the Junos OS device is configured for Draft-Rosen multicast virtual private network (MVPN). The VPN is multicast-enabled and configured to use Protocol Independent Multicast (PIM) protocol within the VPN. \n\nThis issue can only be exploited from the PE device within the MPLS domain which is capable of forwarding IP multicast traffic in core. \nEnd-users connected to the CE device cannot cause this crash.\n\nAffected releases are Juniper Networks Junos OS:\n12.1X46 versions prior to 12.1X46-D77 on SRX Series;\n12.3 versions prior to 12.3R12-S10;\n12.3X48 versions prior to 12.3X48-D70 on SRX Series;\n15.1 versions prior to 15.1R4-S9, 15.1R6-S6, 15.1R7;\n15.1F6;\n15.1X49 versions prior to 15.1X49-D140 on SRX Series;\n15.1X53 versions prior to 15.1X53-D59 on EX2300/EX3400 Series;\n15.1X53 versions prior to 15.1X53-D67  on QFX10K Series;\n15.1X53 versions prior to 15.1X53-D233  on QFX5200/QFX5110 Series;\n15.1X53 versions prior to 15.1X53-D471, 15.1X53-D490 on NFX Series;\n16.1 versions prior to 16.1R4-S9, 16.1R5-S4, 16.1R6-S3, 16.1R7;\n16.2 versions prior to 16.2R1-S6, 16.2R2-S6, 16.2R3;\n17.1 versions prior to 17.1R1-S7, 17.1R2-S7, 17.1R3;\n17.2 versions prior to 17.2R2-S4, 17.2R3;\n17.3 versions prior to 17.3R2-S2, 17.3R3;\n17.4 versions prior to 17.4R1-S3, 17.4R2;\n18.1 versions prior to 18.1R2.\n No other Juniper Networks products or platforms are affected by this issue."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "ADJACENT_NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 8.8,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10879",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10879"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 12.1X46-D77, 12.3R12-S10, 12.3X48-D70, 15.1R4-S9, 15.1R6-S6, 15.1R7, 15.1X49-D140, 15.1X53-D233, 15.1X53-D471, 15.1X53-D490, 15.1X53-D59, 15.1X53-D67, 16.1R4-S9, 16.1R5-S4, 16.1R6-S3, 16.1R7, 16.2R1-S6, 16.2R2-S6, 16.2R3, 17.1R1-S7, 17.1R2-S7, 17.1R3, 17.2R2-S4, 17.2R3, 17.3R2-S2, 17.3R3, 17.4R1-S3, 17.4R2, 18.1R2, 18.2R1, 18.2X75-D5 and all subsequent releases."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10879",
+      "defect": [
+         "1339567"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "There are no known workarounds for this issue."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0046.json
+++ b/2018/0xxx/CVE-2018-0046.json
@@ -1,18 +1,117 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0046",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0046",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos Space: Reflected Cross-site Scripting vulnerability in OpenNMS"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos Space",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_value": "18.2R1"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "credit": [
+      {
+         "lang": "eng",
+         "value": "Marcel Bilal of IT-Dienstleistungszentrum Berlin"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A reflected cross-site scripting vulnerability in OpenNMS included with Juniper Networks Junos Space may allow the stealing of sensitive information or session credentials from Junos Space administrators or perform administrative actions.\nThis issue affects Juniper Networks Junos Space versions prior to 18.2R1."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 8.8,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "REQUIRED",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Reflected cross-site scripting vulnerability"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10880",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10880"
+         },
+         {
+            "name": "https://github.com/OpenNMS/opennms/commit/8710463077c10034fcfa06556a98fb1a1a64fd0d",
+            "refsource": "CONFIRM",
+            "url": "https://github.com/OpenNMS/opennms/commit/8710463077c10034fcfa06556a98fb1a1a64fd0d"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: Junos Space 18.2R1, and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10880",
+      "defect": [
+         "1337619"
+      ],
+      "discovery": "EXTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "There are no viable workarounds for this issue."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0047.json
+++ b/2018/0xxx/CVE-2018-0047.json
@@ -1,18 +1,112 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0047",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0047",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos Space Security Director: XSS vulnerability in web administration"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos Space Security Director",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<=",
+                                 "version_value": "17.2R2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "credit": [
+      {
+         "lang": "eng",
+         "value": "Marcel Bilal of IT-Dienstleistungszentrum Berlin"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A persistent cross-site scripting vulnerability in the UI framework used by Junos Space Security Director may allow authenticated users to inject persistent and malicious scripts. This may allow stealing of information or performing actions as a different user when other users access the Security Director web interface.\nThis issue affects all versions of Juniper Networks Junos Space Security Director prior to 17.2R2.\n"
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 8,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "LOW",
+         "scope": "UNCHANGED",
+         "userInteraction": "REQUIRED",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Persistent Cross-Site Scripting Vulnerability"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10881",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10881"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: Junos Space Security Director 17.2R2, and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10881",
+      "defect": [
+         "1337620"
+      ],
+      "discovery": "EXTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Restrict access to the Junos Space Security Director dashboard to trusted users."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0048.json
+++ b/2018/0xxx/CVE-2018-0048.json
@@ -1,18 +1,127 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0048",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0048",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Memory exhaustion denial of service vulnerability in Routing Protocols Daemon (RPD) with Juniper Extension Toolkit (JET) support."
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R1-S7, 17.2R2-S6, 17.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2X75",
+                                 "version_value": "17.2X75-D102, 17.2X75-D110"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R2-S4, 17.3R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R1-S5, 17.4R2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "18.1",
+                                 "version_value": "18.1R2-S3, 18.1R3"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A vulnerability in the Routing Protocols Daemon (RPD) with Juniper Extension Toolkit (JET) support can allow a network based unauthenticated attacker to cause a severe memory exhaustion condition on the device. This can have an adverse impact on the system performance and availability.\n\nThis issue only affects devices with JET support running Junos OS 17.2R1 and subsequent releases. Other versions of Junos OS are unaffected by this vulnerability.\n\nAffected releases are Juniper Networks Junos OS:\n17.2 versions prior to 17.2R1-S7, 17.2R2-S6, 17.2R3;\n17.2X75 versions prior to 17.2X75-D102, 17.2X75-D110;\n17.3 versions prior to 17.3R2-S4, 17.3R3;\n17.4 versions prior to 17.4R1-S5, 17.4R2;\n18.1 versions prior to 18.1R2-S3, 18.1R3;"
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 7.5,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "CWE-400 Uncontrolled Resource Consumption"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10882",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10882"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 17.2R1-S7, 17.2R2-S6, 17.2R3, 17.2X75-D102, 17.2X75-D110, 17.3R2-S4, 17.3R3, 17.4R1-S5, 17.4R2, 18.1R2-S3, 18.1R3, 18.2R1, 18.2X75-D10, 18.3R1, and all subsequent releases."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10882",
+      "defect": [
+         "1344177"
+      ],
+      "discovery": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "There are no viable workarounds for this issue."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0049.json
+++ b/2018/0xxx/CVE-2018-0049.json
@@ -1,18 +1,412 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0049",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0049",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Receipt of a specifically crafted malicious MPLS packet leads to a Junos kernel crash."
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": ">=",
+                                 "platform": "SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D76"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D81"
+                              },
+                              {
+                                 "affected": "=",
+                                 "version_name": "12.3",
+                                 "version_value": "12.3R12-S10"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "platform": "SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D66"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D75"
+                              },
+                              {
+                                 "affected": "=",
+                                 "platform": "EX2200/VC, EX3200, EX3300/VC, EX4200, EX4300, EX4550/VC, EX4600, EX6200, EX8200/VC (XRE), QFX3500, QFX3600, QFX5100",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D47"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "platform": "QFabric System",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D115"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFabric System",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D130"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1F6-S10"
+                              },
+                              {
+                                 "affected": "=",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R4-S9"
+                              },
+                              {
+                                 "affected": "=",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R6-S6"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R7-S2"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "platform": "SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D131"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D150"
+                              },
+                              {
+                                 "affected": ">",
+                                 "platform": "QFX5200/QFX5110",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D233"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5200/QFX5110",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D235"
+                              },
+                              {
+                                 "affected": "<=",
+                                 "platform": "NFX150, NFX250",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D471"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "NFX150, NFX250",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D590"
+                              },
+                              {
+                                 "affected": "=",
+                                 "platform": "QFX10000 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D67"
+                              },
+                              {
+                                 "affected": "=",
+                                 "platform": "EX2300/EX3400",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D59"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R3-S8"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R4-S9"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R4-S12"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R5-S4"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R6-S3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R6-S6"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R7-S2"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R1-S6"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R2-S5"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R2-S7"
+                              },
+                              {
+                                 "affected": "=",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R1-S7"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S9"
+                              },
+                              {
+                                 "affected": "=",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R1-S6"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R2-S4"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R2-S6"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "17.2X75",
+                                 "version_value": "17.2X75-D100"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2X75",
+                                 "version_value": "17.2X75-D101, 17.2X75-D110"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "platform": "All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R1-S4"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "platform": "All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R2-S2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R2-S4"
+                              },
+                              {
+                                 "affected": "=",
+                                 "platform": "All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R3"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "platform": "All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R1-S3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R1-S5"
+                              },
+                              {
+                                 "affected": "=",
+                                 "platform": "All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R2"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "platform": "All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "18.1",
+                                 "version_value": "18.1R2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "18.1",
+                                 "version_value": "18.1R2-S3, 18.1R3"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "platform": "All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "18.2",
+                                 "version_value": "18.2R1"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX",
+                                 "version_name": "18.2",
+                                 "version_value": "18.2R1-S2, 18.2R1-S3, 18.2R2"
+                              },
+                              {
+                                 "affected": ">=",
+                                 "version_name": "18.2X75",
+                                 "version_value": "18.2X75-D5"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "18.2X75",
+                                 "version_value": "18.2X75-D20"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "The following minimal protocols configuration is required:\n\n  [protocols mpls interface]"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A NULL Pointer Dereference vulnerability in Juniper Networks Junos OS allows an attacker to cause the Junos OS kernel to crash. Continued receipt of this specifically crafted malicious MPLS packet will cause a sustained Denial of Service condition.\n\nThis issue require it to be received on an interface configured to receive this type of traffic.\n\nAffected releases are Juniper Networks Junos OS:\n12.1X46 versions above and including 12.1X46-D76 prior to 12.1X46-D81 on SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX;\n12.3R12-S10;\n12.3X48 versions above and including 12.3X48-D66 prior to 12.3X48-D75 on SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX;\n14.1X53-D47 on EX2200/VC, EX3200, EX3300/VC, EX4200, EX4300, EX4550/VC, EX4600, EX6200, EX8200/VC (XRE), QFX3500, QFX3600, QFX5100;\n14.1X53 versions above and including 14.1X53-D115 prior to 14.1X53-D130 on QFabric System;\n15.1 versions above and including 15.1F6-S10;\n15.1R4-S9;\n15.1R6-S6;\n15.1 versions above and including 15.1R7 prior to 15.1R7-S2;\n15.1X49 versions above and including 15.1X49-D131 prior to 15.1X49-D150 on SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX;\n15.1X53 versions above 15.1X53-D233 prior to 15.1X53-D235 on QFX5200/QFX5110;\n15.1X53 versions up to and including 15.1X53-D471 prior to 15.1X53-D590 on NFX150, NFX250;\n15.1X53-D67 on QFX10000 Series;\n15.1X53-D59 on EX2300/EX3400;\n16.1 versions above and including 16.1R3-S8;\n16.1 versions above and including 16.1R4-S9 prior to 16.1R4-S12;\n16.1 versions above and including 16.1R5-S4;\n16.1 versions above and including 16.1R6-S3 prior to 16.1R6-S6;\n16.1 versions above and including 16.1R7 prior to 16.1R7-S2;\n16.2 versions above and including 16.2R1-S6;\n16.2 versions above and including 16.2R2-S5 prior to 16.2R2-S7;\n17.1R1-S7;\n17.1 versions above and including 17.1R2-S7 prior to 17.1R2-S9;\n17.2R1-S6;\n17.2 versions above and including 17.2R2-S4 prior to 17.2R2-S6;\n17.2X75 versions above and including 17.2X75-D100 prior to X17.2X75-D101, 17.2X75-D110;\n17.3 versions above and including 17.3R1-S4 on All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX;\n17.3 versions above and including 17.3R2-S2 prior to 17.3R2-S4 on All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX;\n17.3R3 on All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX;\n17.4 versions above and including 17.4R1-S3 prior to 17.4R1-S5 on All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX;\n17.4R2 on All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX;\n18.1 versions above and including 18.1R2 prior to 18.1R2-S3, 18.1R3 on All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX;\n18.2 versions above and including 18.2R1 prior to 18.2R1-S2, 18.2R1-S3, 18.2R2 on All non-SRX Series and SRX100, SRX110, SRX210, SRX220, SRX240m, SRX550m SRX650, SRX300, SRX320, SRX340, SRX345, SRX1500, SRX4100, SRX4200, SRX4600 and vSRX;\n18.2X75 versions above and including 18.2X75-D5 prior to 18.2X75-D20."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is aware of possible malicious network probing which may have triggered this issue, but not aware of any malicious exploitation of this vulnerability.\n"
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 7.5,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "NULL Pointer Dereference"
+               }
+            ]
+         },
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of Service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10883",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10883"
+         },
+         {
+            "name": "https://kb.juniper.net/KB30092",
+            "refsource": "MISC",
+            "url": "https://kb.juniper.net/KB30092"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 12.1X46-D81, 12.3R12-S11, 12.3X48-D75, 14.1X53-D130, 14.1X53-D48, 15.1R7-S2, 15.1X49-D150, 5.1X53-D235, 15.1X53-D495, 15.1X53-D68, 15.1X53-D590, 16.1R4-S12, 16.1R6-S6, 16.1R7-S2, 16.1X65-D48, 16.2R2-S7, 16.2R3, 17.1R2-S9, 17.1R3, 17.2R1-S7, 17.2R2-S6, 17.2R3, 17.2X75-D101, 17.2X75-D110, 17.3R2-S4, 17.3R3-S1, 17.3R4, 17.4R1-S5, 17.4R2-S1, 17.4R3, 18.1R2-S3, 18.1R3, 18.2R1-S2, 18.2R1-S3, 18.2R2, 18.2X75-D20, 18.3R1, and all subsequent releases.\n\nAdditionally, the following software releases have been re-released to the Juniper download pages to resolve this specific issue:\n12.1X46-D76.1, 12.3X48-D70.4, 14.1X53-D47.6, 15.1F6-S10.11, 15.1R6-S6.2, 15.1R7.9, 15.1X49-D140.3, 15.1X53-D233.2, 15.1X53-D59.4, 15.1X53-D67.6, 16.1R6-S3.2, 16.1R7-S1.2, 16.1R7.8, 17.2X75-D100.6, 17.3R2-S2.2, 17.3R3.10, 17.4R1-S3.4, 18.1R2.6.\n\nNote: The final \".xy\" numeric entry, for example the .4 in 12.3X48-D70.4, on a release in this notice is the respin release number.  Customer's should check the respin release number on the version of Junos OS to confirm vulnerability.\n\n\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10883",
+      "defect": [
+         "1380862"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Remove MPLS configuration stanza from interfaces at risk.\nThere are no other available workarounds for this issue."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0050.json
+++ b/2018/0xxx/CVE-2018-0050.json
@@ -1,18 +1,138 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0050",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0050",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Receipt of a malformed MPLS RSVP packet leads to a Routing Protocols Daemon (RPD) crash."
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "14.1",
+                                 "version_value": "14.1R8-S5, 14.1R9"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX Switching",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D48"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFabric System",
+                                 "version_name": "14.2",
+                                 "version_value": "14.1X53-D130"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "14.2",
+                                 "version_value": "14.2R4"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "The following minimal protocols configurations are required:\n\n  [protocols rsvp]\n  [protocols mpls interface]\n"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "An error handling vulnerability in Routing Protocols Daemon (RPD) of Juniper Networks Junos OS allows an attacker to cause RPD to crash.  Continued receipt of this malformed MPLS RSVP packet will cause a sustained Denial of Service condition.\n\nAffected releases are Juniper Networks Junos OS:\n14.1 versions prior to 14.1R8-S5, 14.1R9;\n14.1X53 versions prior to 14.1X53-D48 on QFX Switching;\n14.2 versions prior to 14.1X53-D130 on QFabric System;\n14.2 versions prior to 14.2R4.\n\nThis issue does not affect versions of Junos OS before 14.1R1.\n\n\nJunos OS RSVP only supports IPv4. IPv6 is not affected by this issue.\nThis issue require it to be received on an interface configured to receive this type of traffic."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 7.5,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Error Handling\n"
+               }
+            ]
+         },
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of Service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10884",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10884"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 14.1R8-S5, 14.1R9, 14.1X53-D130, 14.1X53-D48, 14.2R4, 15.1R1, and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10884",
+      "defect": [
+         "1087100"
+      ],
+      "discovery": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Remove MPLS configuration stanzas from interface configurations that are at risk.\nNo other workarounds exist for this issue. "
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0051.json
+++ b/2018/0xxx/CVE-2018-0051.json
@@ -1,18 +1,160 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0051",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0051",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Denial of Service vulnerability in MS-PIC, MS-MIC, MS-MPC, MS-DPC and SRX flow daemon (flowd) related to SIP ALG"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D77"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D70"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R4-S9, 15.1R7-S1"
+                              },
+                              {
+                                 "affected": "=",
+                                 "version_name": "15.1F6",
+                                 "version_value": "15.1F6"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D140"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R4-S9, 16.1R6-S1, 16.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R2-S7, 16.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S7, 17.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R1-S6, 17.2R2-S4, 17.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R1-S5, 17.3R2-S2, 17.3R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A Denial of Service vulnerability in the SIP application layer gateway (ALG) component of Junos OS based platforms allows an attacker to crash MS-PIC, MS-MIC, MS-MPC, MS-DPC or SRX flow daemon (flowd) process.\nThis issue affects Junos OS devices with NAT or stateful firewall configuration in combination with the SIP ALG enabled.\n\nSIP ALG is enabled by default on SRX Series devices except for SRX-HE devices. SRX-HE devices have SIP ALG disabled by default.\n\nThe status of ALGs in SRX device can be obtained by executing the command:\n  show security alg status\nAffected releases are Juniper Networks Junos OS:\n12.1X46 versions prior to 12.1X46-D77;\n12.3X48 versions prior to 12.3X48-D70;\n15.1X49 versions prior to 15.1X49-D140;\n15.1 versions prior to 15.1R4-S9, 15.1R7-S1;\n15.1F6;\n16.1 versions prior to 16.1R4-S9, 16.1R6-S1, 16.1R7;\n16.2 versions prior to 16.2R2-S7, 16.2R3;\n17.1 versions prior to 17.1R2-S7, 17.1R3;\n17.2 versions prior to 17.2R1-S6, 17.2R2-S4, 17.2R3;\n17.3 versions prior to 17.3R1-S5, 17.3R2-S2, 17.3R3;\n17.4 versions prior to 17.4R2.\n No other Juniper Networks products or platforms are affected by this issue."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 7.5,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of Service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10885",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10885"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve these specific issues: 12.1X46-D77, 12.3X48-D70, 12.3X48-D75, 14.1X53-D47, 15.1R4-S9, 15.1R7-S1, 15.1X49-D140, 15.1X53-D471, 15.1X53-D490, 15.1X53-D59, 15.1X53-D67, 16.1R4-S9, 16.1R6-S1, 16.1R7, 16.2R2-S7, 16.2R3, 17.1R2-S7, 17.1R3, 17.2R1-S6, 17.2R2-S4, 17.2R3, 17.3R1-S5, 17.3R2-S2, 17.3R3, 17.4R2, 18.1R1, 18.1X75-D10, 18.2R1, 18.2X75-D5, and all subsequent releases.\nThis fix has also been proactively committed into other releases that might not support SIP ALG configuration."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10885",
+      "defect": [
+         "1326394"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": " Disable the use of the SIP ALG feature if it is not needed. "
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0052.json
+++ b/2018/0xxx/CVE-2018-0052.json
@@ -1,18 +1,206 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0052",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0052",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Unauthenticated remote root access possible when RSH service is enabled"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D77"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "12.3",
+                                 "version_value": "12.3R12-S10"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D75"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX/EX Series",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D47"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R4-S9, 15.1R6-S6, 15.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D131, 15.1X49-D140"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "EX2300/EX3400 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D59"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX10K Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D67"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5200/QFX5110 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D233"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "NFX Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D471, 15.1X53-D490"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R3-S9, 16.1R4-S9, 16.1R5-S4, 16.1R6-S4, 16.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R2-S5"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R1-S7, 17.1R2-S7, 17.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R1-S6, 17.2R2-S4, 17.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2X75",
+                                 "version_value": "17.2X75-D110, 17.2X75-D91"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R1-S4, 17.3R2-S2, 17.3R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R1-S3, 17.4R2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "18.2X75",
+                                 "version_value": "18.2X75-D5"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "This issue only affects configurations where RSH service is enabled and the PAM authentication is disabled."
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "If RSH service is enabled on Junos OS and if the PAM authentication is disabled, a remote unauthenticated attacker can obtain root access to the device.\nRSH service is disabled by default on Junos. There is no documented CLI command to enable this service. However, an undocumented CLI command allows a privileged Junos user to enable RSH service and disable PAM, and hence expose the system to unauthenticated root access. \n\nWhen RSH is enabled, the device is listing to RSH connections on port 514.\n\nThis issue is not exploitable on platforms where Junos release is based on FreeBSD 10+. \nAffected releases are Juniper Networks Junos OS:\n12.1X46 versions prior to 12.1X46-D77 on SRX Series;\n12.3 versions prior to 12.3R12-S10;\n12.3X48 versions prior to 12.3X48-D75 on SRX Series;\n14.1X53 versions prior to 14.1X53-D47 on QFX/EX Series;\n15.1 versions prior to 15.1R4-S9, 15.1R6-S6, 15.1R7;\n15.1X49 versions prior to 15.1X49-D131, 15.1X49-D140 on SRX Series;\n15.1X53 versions prior to 15.1X53-D59 on EX2300/EX3400 Series;\n15.1X53 versions prior to 15.1X53-D67 on QFX10K Series;\n15.1X53 versions prior to 15.1X53-D233 on QFX5200/QFX5110 Series;\n15.1X53 versions prior to 15.1X53-D471, 15.1X53-D490 on NFX Series;\n16.1 versions prior to 16.1R3-S9, 16.1R4-S9, 16.1R5-S4, 16.1R6-S4, 16.1R7;\n16.2 versions prior to 16.2R2-S5;\n17.1 versions prior to 17.1R1-S7, 17.1R2-S7, 17.1R3;\n17.2 versions prior to 17.2R1-S6, 17.2R2-S4, 17.2R3;\n17.2X75 versions prior to 17.2X75-D110, 17.2X75-D91;\n17.3 versions prior to 17.3R1-S4, 17.3R2-S2, 17.3R3;\n17.4 versions prior to 17.4R1-S3, 17.4R2;\n18.2X75 versions prior to 18.2X75-D5."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 7.2,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "HIGH",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Unauthenticated remote root access"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10886",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10886"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "This CLI option has been removed from the fixed Junos releases.\n\nThe following software releases have been updated to resolve this specific issue: 12.1X46-D77, 12.3R12-S10, 12.3X48-D75, 14.1X53-D47, 15.1R4-S9, 15.1R6-S6, 15.1R7, 15.1X49-D131, 15.1X49-D140, 15.1X53-D233, 15.1X53-D471, 15.1X53-D490, 15.1X53-D59, 15.1X53-D67, 16.1R3-S9, 16.1R4-S9, 16.1R5-S4, 16.1R6-S4, 16.1R7, 16.2R2-S5, 17.1R1-S7, 17.1R2-S7, 17.1R3, 17.2R1-S6, 17.2R2-S4, 17.2R3, 17.2X75-D110, 17.2X75-D91, 17.3R1-S4, 17.3R2-S2, 17.3R3, 17.4R1-S3, 17.4R2, 18.1R1, 18.2R1, 18.2X75-D5, and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10886",
+      "defect": [
+         "1288932"
+      ],
+      "discovery": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Ensure there is no RSH service listening on port 514.\n\nUtilize common security BCPs to limit the exploitable surface by limiting access to network and device to trusted systems, administrators, networks and hosts."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0053.json
+++ b/2018/0xxx/CVE-2018-0053.json
@@ -1,18 +1,108 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0053",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0053",
+      "STATE": "PUBLIC",
+      "TITLE": "vSRX Series: A local authentication vulnerability may lead to full control of a vSRX instance while the system is booting."
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "vSRX Series",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D30"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "An authentication bypass vulnerability in the initial boot sequence of Juniper Networks Junos OS on vSRX Series may allow an attacker to gain full control of the system without authentication when the system is initially booted up.\n\nAffected releases are Juniper Networks Junos OS:\n15.1X49 versions prior to 15.1X49-D30 on vSRX."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability.\n"
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "PHYSICAL",
+         "availabilityImpact": "HIGH",
+         "baseScore": 6.8,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Authentication Bypass Using an Alternate Path or Channel\n"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10887",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10887"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: Junos OS 15.1X49-D30, and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10887",
+      "defect": [
+         "1078011"
+      ],
+      "discovery": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "There are no viable workarounds for this issue.\n\nMethods which may reduce, but not eliminate, the risk for exploitation of this problem, and which does not resolve the underlying problem include:\n\n• Restrict access to the hypervisor to only trusted administrators.\n• Disallow all access to the 'physical instance' of the vSRX instance while it is initially booting by disabling connectivity to devices hosting the instance; e.g. console servers, etc."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0054.json
+++ b/2018/0xxx/CVE-2018-0054.json
@@ -1,18 +1,172 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0054",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0054",
+      "STATE": "PUBLIC",
+      "TITLE": "QFX5000/EX4600 Series: Routing protocol flap upon receipt of high rate of Ethernet frames"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5000 Series and EX4600",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D47"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5000 Series and EX4600",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R7, 15.1R8"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5000 Series and EX4600",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D233"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5000 Series and EX4600",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5000 Series and EX4600",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5000 Series and EX4600",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S9, 17.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5000 Series and EX4600",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R2-S6, 17.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5000 Series and EX4600",
+                                 "version_name": "17.2X75",
+                                 "version_value": "17.2X75-D42"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5000 Series and EX4600",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5000 Series and EX4600",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5000 Series and EX4600",
+                                 "version_name": "18.1",
+                                 "version_value": "18.1R2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "On QFX5000 Series and EX4600 switches, a high rate of Ethernet pause frames or an ARP packet storm received on the management interface (fxp0) can cause egress interface congestion, resulting in routing protocol packet drops, such as BGP, leading to peering flaps.  The following log message may also be displayed:\n\n  fpc0 dcbcm_check_stuck_buffers: Buffers are stuck on queue 7 of port 45\n\nThis issue only affects the QFX5000 Series products (QFX5100, QFX5110, QFX5200, QFX5210) and the EX4600 switch.  No other platforms are affected by this issue.\n\nAffected releases are Juniper Networks Junos OS:\n14.1X53 versions prior to 14.1X53-D47 on QFX5000 Series and EX4600;\n15.1 versions prior to 15.1R7, 15.1R8 on QFX5000 Series and EX4600;\n15.1X53 versions prior to 15.1X53-D233 on QFX5000 Series and EX4600;\n16.1 versions prior to 16.1R7 on QFX5000 Series and EX4600;\n16.2 versions prior to 16.2R3 on QFX5000 Series and EX4600;\n17.1 versions prior to 17.1R2-S9, 17.1R3 on QFX5000 Series and EX4600;\n17.2 versions prior to 17.2R2-S6, 17.2R3 on QFX5000 Series and EX4600;\n17.2X75 versions prior to 17.2X75-D42 on QFX5000 Series and EX4600;\n17.3 versions prior to 17.3R3 on QFX5000 Series and EX4600;\n17.4 versions prior to 17.4R2 on QFX5000 Series and EX4600;\n18.1 versions prior to 18.1R2 on QFX5000 Series and EX4600."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "ADJACENT_NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 6.5,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10888",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10888"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 14.1X53-D47, 15.1R7, 15.1R8, 15.1X53-D233, 16.1R7, 16.2R3, 17.1R2-S9, 17.1R3, 17.2R2-S6, 17.2R3, 17.2X75-D42, 17.3R3, 17.4R2, 18.1R2, 18.2R1, 18.2X75-D5, and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10888",
+      "defect": [
+         "1343597"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "For BGP, configure 'ether-options no-flow-control' on the BGP interface.\n"
+      },
+      {
+         "lang": "eng",
+         "value": "Configure the lossless percentage of ingress shared buffer pool to be greater than the egress shared buffer pool.  For example:\n\n  [edit class-of-service shared-buffer]\n  user@switch# set ingress buffer-partition lossless percent <percent>\n  user@switch# set egress buffer-partition lossless percent <percent>\n"
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0055.json
+++ b/2018/0xxx/CVE-2018-0055.json
@@ -1,18 +1,162 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0055",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0055",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: jdhcpd process crash during processing of specially crafted DHCPv6 message"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R7-S2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D160"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D235, 15.1X53-D495"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R4-S11, 16.1R6-S6, 16.1R7-S2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R2-S7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S9"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R2-S6"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R3-S1"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R1-S5"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "18.1",
+                                 "version_value": "18.1R2-S3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "18.2",
+                                 "version_value": "18.2R1-S2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "18.2X75",
+                                 "version_value": "18.2X75-D20"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Receipt of a specially crafted DHCPv6 message destined to a Junos OS device configured as a DHCP server in a Broadband Edge (BBE) environment may result in a jdhcpd daemon crash.  The daemon automatically restarts without intervention, but a continuous receipt of crafted DHCPv6 packets could leaded to an extended denial of service condition.\n\nThis issue only affects Junos OS 15.1 and later.  Earlier releases are unaffected by this issue.\n\nDevices are only vulnerable to the specially crafted DHCPv6 message if DHCP services are configured. Devices not configured to act as a DHCP server are not vulnerable to this issue.\nAffected releases are Juniper Networks Junos OS:\n15.1 versions prior to 15.1R7-S2;\n15.1X49 versions prior to 15.1X49-D160;\n15.1X53 versions prior to 15.1X53-D235, 15.1X53-D495;\n16.1 versions prior to 16.1R4-S11, 16.1R6-S6, 16.1R7-S2;\n16.2 versions prior to 16.2R2-S7;\n17.1 versions prior to 17.1R2-S9;\n17.2 versions prior to 17.2R2-S6;\n17.3 versions prior to 17.3R3-S1;\n17.4 versions prior to 17.4R1-S5;\n18.1 versions prior to 18.1R2-S3;\n18.2 versions prior to 18.2R1-S2;\n18.2X75 versions prior to 18.2X75-D20."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "ADJACENT_NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 6.5,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of service\n"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10889",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10889"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 15.1R7-S2, 15.1X49-D160, 15.1X53-D235, 15.1X53-D495, 16.1R4-S11, 16.1R6-S6, 16.1R7-S2, 16.2R2-S7, 16.2R3, 17.1R2-S9, 17.1R3, 17.2R2-S6, 17.2R3, 17.3R3-S1, 17.4R1-S5, 17.4R2, 18.1R2-S3, 18.1R3, 18.2R1-S2, 18.2R2, 18.2X75-D20, 18.3R1, and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10889",
+      "defect": [
+         "1368377"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Disable DHCP services if they are not needed."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0056.json
+++ b/2018/0xxx/CVE-2018-0056.json
@@ -1,18 +1,150 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0056",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0056",
+      "STATE": "PUBLIC",
+      "TITLE": "MX Series: L2ALD daemon may crash if a duplicate MAC is learned by two different interfaces"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R7-S1"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R4-S12, 16.1R6-S6"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R2-S7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S9"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R1-S7, 17.2R2-S6"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R2-S4, 17.3R3-S1"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R1-S5"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "18.1",
+                                 "version_value": "18.1R2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "If a duplicate MAC address is learned by two different interfaces on an MX Series device, the MAC address learning function correctly flaps between the interfaces. However, the Layer 2 Address Learning Daemon (L2ALD) daemon might crash when attempting to delete the duplicate MAC address when the particular entry is not found in the internal MAC address table.\n\nThis issue only occurs on MX Series devices with l2-backhaul VPN configured.  No other products or platforms are affected by this issue.\n\nAffected releases are Juniper Networks Junos OS:\n15.1 versions prior to 15.1R7-S1 on MX Series;\n16.1 versions prior to 16.1R4-S12, 16.1R6-S6 on MX Series;\n16.2 versions prior to 16.2R2-S7 on MX Series;\n17.1 versions prior to 17.1R2-S9 on MX Series;\n17.2 versions prior to 17.2R1-S7, 17.2R2-S6 on MX Series;\n17.3 versions prior to 17.3R2-S4, 17.3R3-S1 on MX Series;\n17.4 versions prior to 17.4R1-S5 on MX Series;\n18.1 versions prior to 18.1R2 on MX Series."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "ADJACENT_NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 6.5,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10890",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10890"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 15.1R7-S1, 16.1R4-S12, 16.1R6-S6, 16.1R7, 16.2R2-S7, 16.2R3, 17.1R2-S9, 17.1R3, 17.2R1-S7, 17.2R2-S6, 17.2R3, 17.3R2-S4, 17.3R3-S1, 17.4R1-S5, 17.4R2, 18.1R2, 18.2R1, and all subsequent releases.\n\nThis fix has also been proactively committed into Junos OS: 15.1X49-D150, 15.1X53-D235, 15.1X53-D495, 15.1X53-D590, 15.1X53-D68, 18.2X75-D5, and all subsequent releases."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10890",
+      "defect": [
+         "1338688"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "There are no viable workarounds for this issue"
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0057.json
+++ b/2018/0xxx/CVE-2018-0057.json
@@ -1,18 +1,150 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0057",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0057",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: authd allows assignment of IP address requested by DHCP subscriber logging in with Option 50 (Requested IP Address)"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R7-S2, 15.1R8"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R4-S12, 16.1R7-S2, 16.1R8"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R2-S7, 16.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S9, 17.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R1-S7, 17.2R2-S6, 17.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R2-S4, 17.3R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "18.1",
+                                 "version_value": "18.1R2-S3, 18.1R3"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "On MX Series and M120/M320 platforms configured in a Broadband Edge (BBE) environment, subscribers logging in with DHCP Option 50 to request a specific IP address will be assigned the requested IP address, even if there is a static MAC to IP address binding in the access profile.  In the problem scenario, with a hardware-address and IP address configured under address-assignment pool, if a subscriber logging in with DHCP Option 50, the subscriber will not be assigned an available address from the matched pool, but will still get the requested IP address.\n\nA malicious DHCP subscriber may be able to utilize this vulnerability to create duplicate IP address assignments, leading to a denial of service for valid subscribers or unauthorized information disclosure via IP address assignment spoofing.\n\nAffected releases are Juniper Networks Junos OS:\n15.1 versions prior to 15.1R7-S2, 15.1R8;\n16.1 versions prior to 16.1R4-S12, 16.1R7-S2, 16.1R8;\n16.2 versions prior to 16.2R2-S7, 16.2R3;\n17.1 versions prior to 17.1R2-S9, 17.1R3;\n17.2 versions prior to 17.2R1-S7, 17.2R2-S6, 17.2R3;\n17.3 versions prior to 17.3R2-S4, 17.3R3;\n17.4 versions prior to 17.4R2;\n18.1 versions prior to 18.1R2-S3, 18.1R3."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "ADJACENT_NETWORK",
+         "availabilityImpact": "LOW",
+         "baseScore": 6.1,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "LOW",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "CHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:L",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Information disclosure"
+               }
+            ]
+         },
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10892",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10892"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 15.1R7-S2, 15.1R8, 16.1R4-S12, 16.1R7-S2, 16.1R8, 16.2R2-S7, 16.2R3, 17.1R2-S9, 17.1R3, 17.2R1-S7, 17.2R2-S6, 17.2R3, 17.3R2-S4, 17.3R3, 17.4R2, 18.1R2-S3, 18.1R3, 18.2R1, 18.3R1, and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10892",
+      "defect": [
+         "1351334"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "There are no viable workarounds for this issue"
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0058.json
+++ b/2018/0xxx/CVE-2018-0058.json
@@ -1,18 +1,167 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0058",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0058",
+      "STATE": "PUBLIC",
+      "TITLE": "MX Series: In BBE configurations, receipt of a crafted IPv6 exception packet causes a Denial of Service"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R7-S2, 15.1R8"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R4-S11, 16.1R7-S2, 16.1R8"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S9, 17.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R2-S6, 17.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R2-S4, 17.3R3-S2, 17.3R4"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "18.1",
+                                 "version_value": "18.1R2-S3, 18.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "MX Series",
+                                 "version_name": "18.2",
+                                 "version_value": "18.2R1-S1, 18.2R2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "set system services subscriber-management enable"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Receipt of a specially crafted IPv6 exception packet may be able to trigger a kernel crash (vmcore), causing the device to reboot.\n\nThe issue is specific to the processing of Broadband Edge (BBE) client route processing on MX Series subscriber management platforms, introduced by the Tomcat (Next Generation Subscriber Management) functionality in Junos OS 15.1.  This issue affects no other platforms or configurations.\n\nAffected releases are Juniper Networks Junos OS:\n15.1 versions prior to 15.1R7-S2, 15.1R8 on MX Series;\n16.1 versions prior to 16.1R4-S11, 16.1R7-S2, 16.1R8 on MX Series;\n16.2 versions prior to 16.2R3 on MX Series;\n17.1 versions prior to 17.1R2-S9, 17.1R3 on MX Series;\n17.2 versions prior to 17.2R2-S6, 17.2R3 on MX Series;\n17.3 versions prior to 17.3R2-S4, 17.3R3-S2, 17.3R4 on MX Series;\n17.4 versions prior to 17.4R2 on MX Series;\n18.1 versions prior to 18.1R2-S3, 18.1R3 on MX Series;\n18.2 versions prior to 18.2R1-S1, 18.2R2 on MX Series."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "HIGH",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 5.9,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10893",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10893"
+         },
+         {
+            "name": "https://kb.juniper.net/KB31899",
+            "refsource": "MISC",
+            "url": "https://kb.juniper.net/KB31899"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 15.1R7-S2, 15.1R8, 16.1R4-S11, 16.1R7-S2, 16.1R8, 16.2R3, 17.1R2-S9, 17.1R3, 17.2R2-S6, 17.2R3, 17.3R2-S4, 17.3R3-S2*, 17.3R4, 17.4R2, 18.1R2-S3, 18.1R3, 18.2R1-S1, 18.2R2, 18.3R1, and all subsequent releases.\n\n*Available November 2018"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10893",
+      "defect": [
+         "1368599"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "There are no viable workarounds for this issue"
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0059.json
+++ b/2018/0xxx/CVE-2018-0059.json
@@ -1,18 +1,117 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0059",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0059",
+      "STATE": "PUBLIC",
+      "TITLE": "ScreenOS: Stored Cross-Site Scripting (XSS) vulnerability"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "ScreenOS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "6.3.0",
+                                 "version_value": "6.3.0r26"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "credit": [
+      {
+         "lang": "eng",
+         "value": "Marcel Bilal from IT-Dienstleistungszentrum Berlin"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A persistent cross-site scripting vulnerability in the graphical user interface of ScreenOS may allow a remote authenticated user to inject web script or HTML and steal sensitive data and credentials from a web administration session, possibly tricking a follow-on administrative user to perform administrative actions on the device.\n\nAffected releases are Juniper Networks ScreenOS 6.3.0 versions prior to 6.3.0r26."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "NONE",
+         "baseScore": 5.4,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "LOW",
+         "integrityImpact": "LOW",
+         "privilegesRequired": "LOW",
+         "scope": "CHANGED",
+         "userInteraction": "REQUIRED",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Stored cross-site scripting"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10894",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10894"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: ScreenOS 6.3.0r26 and all subsequent releases.\n\nReview and clear any previously stored cross-site scripting entries."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10894",
+      "defect": [
+         "1323345"
+      ],
+      "discovery": "EXTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Use access lists or firewall filters to limit access to the device only from trusted hosts and administrators.\n\nIn addition to the recommendations listed above, it is good security practice to limit the exploitable attack surface of critical infrastructure networking equipment. Use access lists or firewall filters to limit access to the device only from trusted, administrative networks or hosts."
+      },
+      {
+         "lang": "eng",
+         "value": "Disable the web administrative interface if it is not necessary."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0060.json
+++ b/2018/0xxx/CVE-2018-0060.json
@@ -1,18 +1,188 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0060",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0060",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Invalid IP/mask learned from DHCP server might cause device control daemon (dcd) process crash"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D40"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D20"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "EX2200/VC, EX3200, EX3300/VC, EX4200, EX4300, EX4550/VC, EX4600, EX6200, EX8200/VC (XRE), QFX3500, QFX3600, QFX5100",
+                                 "version_name": "14.1X53",
+                                 "version_value": "14.1X53-D40"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D20"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX10000 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D68"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5200/QFX5110",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D235"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "NFX150, NFX250",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D495"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "EX2300/EX3400",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D590"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R7-S2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "15.1R7-S2 16.1R4-S12, 16.1R6-S5, 16.1R7-S2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R2-S7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S9"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R1-S7, 17.2R2-S4"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R2-S4, 17.3R3"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "An improper input validation weakness in the device control daemon process (dcd) of Juniper Networks Junos OS allows an attacker to cause a Denial of Service to the dcd process and interfaces and connected clients when the Junos device is requesting an IP address for itself. \n\nJunos devices are not vulnerable to this issue when not configured to use DHCP.\n\nAffected releases are Juniper Networks Junos OS:\n12.1X46 versions prior to 12.1X46-D40 on SRX Series;\n12.3X48 versions prior to 12.3X48-D20 on SRX Series;\n14.1X53 versions prior to 14.1X53-D40 on EX2200/VC, EX3200, EX3300/VC, EX4200, EX4300, EX4550/VC, EX4600, EX6200, EX8200/VC (XRE), QFX3500, QFX3600, QFX5100;\n15.1X49 versions prior to 15.1X49-D20 on SRX Series;\n15.1X53 versions prior to 15.1X53-D68 on QFX10000 Series;\n15.1X53 versions prior to 15.1X53-D235 on QFX5200/QFX5110;\n15.1X53 versions prior to 15.1X53-D495 on NFX150, NFX250;\n15.1X53 versions prior to 15.1X53-D590  on EX2300/EX3400;\n15.1 versions prior to 15.1R7-S2 ;\n16.1 versions prior to 15.1R7-S2 16.1R4-S12, 16.1R6-S5, 16.1R7-S2;\n16.2 versions prior to 16.2R2-S7;\n17.1 versions prior to 17.1R2-S9;\n17.2 versions prior to 17.2R1-S7, 17.2R2-S4;\n17.3 versions prior to 17.3R2-S4, 17.3R3."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "NONE",
+         "baseScore": 5.3,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "LOW",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Improper input validation"
+               }
+            ]
+         },
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of Service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10895",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10895"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 12.1X46-D40, 12.3X48-D20, 14.1X53-D40, 15.1X49-D20, 15.1X53-D68, 15.1X53-D235, 15.1X53-D495, 15.1X53-D590, 15.1R7-S2, 15.1R7-S2 16.1R4-S12, 16.1R6-S5, 16.1R7-S2, 16.2R2-S7, 17.1R2-S9, 17.2R1-S7, 17.2R2-S4, 17.3R2-S4, 17.3R3, and all subsequent releases."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10895",
+      "defect": [
+         "1082817"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Configure the device to use static IP addresses for all interfaces.\nDisable DHCP services.\n"
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0061.json
+++ b/2018/0xxx/CVE-2018-0061.json
@@ -1,18 +1,200 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0061",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0061",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Denial of service in telnetd"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D81"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "12.3",
+                                 "version_value": "12.3R12-S11"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D80"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D150, 15.1X49-D160"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "EX2300/EX3400 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D59"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX10K Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D68"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5200/QFX5110 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D235"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "NFX Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D495"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R4-S12, 16.1R6-S6, 16.1R7"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R2-S7, 16.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S9, 17.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R2-S6, 17.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2X75",
+                                 "version_value": "17.2X75-D100"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R2-S4, 17.3R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.4",
+                                 "version_value": "17.4R1-S5, 17.4R2"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "18.2X75",
+                                 "version_value": "18.2X75-D5"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "This issue affects devices with telnet service enabled."
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A denial of service vulnerability in the telnetd service on Junos OS allows remote unauthenticated users to cause high CPU usage which may affect system performance.\nAffected releases are Juniper Networks Junos OS:\n12.1X46 versions prior to 12.1X46-D81 on SRX Series;\n12.3 versions prior to 12.3R12-S11;\n12.3X48 versions prior to 12.3X48-D80 on SRX Series;\n15.1 versions prior to 15.1R7;\n15.1X49 versions prior to 15.1X49-D150, 15.1X49-D160 on SRX Series;\n15.1X53 versions prior to 15.1X53-D59 on EX2300/EX3400 Series;\n15.1X53 versions prior to 15.1X53-D68 on QFX10K Series;\n15.1X53 versions prior to 15.1X53-D235 on QFX5200/QFX5110 Series;\n15.1X53 versions prior to 15.1X53-D495 on NFX Series;\n16.1 versions prior to 16.1R4-S12, 16.1R6-S6, 16.1R7;\n16.2 versions prior to 16.2R2-S7, 16.2R3;\n17.1 versions prior to 17.1R2-S9, 17.1R3;\n17.2 versions prior to 17.2R2-S6, 17.2R3;\n17.2X75 versions prior to 17.2X75-D100;\n17.3 versions prior to 17.3R2-S4, 17.3R3;\n17.4 versions prior to 17.4R1-S5, 17.4R2;\n18.2X75 versions prior to 18.2X75-D5."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "LOW",
+         "baseScore": 5.3,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "denial of service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10896",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10896"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 12.1X46-D81, 12.3R12-S11, 12.3R13, 12.3X48-D80, 15.1R7, 15.1X49-D150, 15.1X49-D160, 15.1X53-D235, 15.1X53-D495, 15.1X53-D59, 15.1X53-D68, 16.1R4-S12, 16.1R6-S6, 16.1R7, 16.2R2-S7, 16.2R3, 17.1R2-S9, 17.1R3, 17.2R2-S6, 17.2R3, 17.2X75-D100, 17.2X75-D110, 17.3R2-S4, 17.3R3, 17.4R1-S5, 17.4R2, 18.1R1, 18.1R2, 18.2R1, 18.2X75-D5, and all subsequent releases."
+      }
+   ],
+   "source": {
+      "advisory": "JSA10896",
+      "defect": [
+         "1331234"
+      ],
+      "discovery": "INTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Disabling the telnet service will completely mitigate this issue."
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0062.json
+++ b/2018/0xxx/CVE-2018-0062.json
@@ -1,18 +1,196 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0062",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0062",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Denial of Service in J-Web"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.1X46",
+                                 "version_value": "12.1X46-D77"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "12.3",
+                                 "version_value": "12.3R12-S10"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "12.3X48",
+                                 "version_value": "12.3X48-D60"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "15.1",
+                                 "version_value": "15.1R7"
+                              },
+                              {
+                                 "affected": "=",
+                                 "version_name": "15.1F6",
+                                 "version_value": "15.1F6"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "SRX Series",
+                                 "version_name": "15.1X49",
+                                 "version_value": "15.1X49-D120"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "EX2300/EX3400 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D59"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX10K Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D67"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "QFX5200/QFX5110 Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D234"
+                              },
+                              {
+                                 "affected": "<",
+                                 "platform": "NFX Series",
+                                 "version_name": "15.1X53",
+                                 "version_value": "15.1X53-D470, 15.1X53-D495"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.1",
+                                 "version_value": "16.1R6"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "16.2",
+                                 "version_value": "16.2R2-S6, 16.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.1",
+                                 "version_value": "17.1R2-S6, 17.1R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.2",
+                                 "version_value": "17.2R3"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.3",
+                                 "version_value": "17.3R2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "configuration": [
+      {
+         "lang": "eng",
+         "value": "The examples of the config stanza affected by this issue:\n  system services web-management http\n  system services web-management https"
+      }
+   ],
+   "credit": [
+      {
+         "lang": "eng",
+         "value": "Alex Chash from SecureCom Limited (https://www.securecom.co.nz)\n"
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A Denial of Service vulnerability in J-Web service may allow a remote unauthenticated user to cause Denial of Service which may prevent other users to authenticate or to perform J-Web operations.\nAffected releases are Juniper Networks Junos OS:\n12.1X46 versions prior to 12.1X46-D77 on SRX Series;\n12.3 versions prior to 12.3R12-S10;\n12.3X48 versions prior to 12.3X48-D60 on SRX Series;\n15.1 versions prior to 15.1R7;\n15.1F6;\n15.1X49 versions prior to 15.1X49-D120 on SRX Series;\n15.1X53 versions prior to 15.1X53-D59 on EX2300/EX3400 Series;\n15.1X53 versions prior to 15.1X53-D67 on QFX10K Series;\n15.1X53 versions prior to 15.1X53-D234 on QFX5200/QFX5110 Series;\n15.1X53 versions prior to 15.1X53-D470, 15.1X53-D495 on NFX Series;\n16.1 versions prior to 16.1R6;\n16.2 versions prior to 16.2R2-S6, 16.2R3;\n17.1 versions prior to 17.1R2-S6, 17.1R3;\n17.2 versions prior to 17.2R3;\n17.3 versions prior to 17.3R2.\n No other Juniper Networks products or platforms are affected by this issue."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "LOW",
+         "baseScore": 5.3,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of Service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10897",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10897"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to resolve this specific issue: 12.1X46-D77, 12.3R12-S10,12.3X48-D60, 15.1R7, 15.1X49-D120, 15.1X53-D234, 15.1X53-D470, 15.1X53-D495, 15.1X53-D59, 15.1X53-D67, 16.1R6, 16.2R2-S6, 16.2R3, 17.1R2-S6, 17.1R3, 17.2R3, 17.3R2, 17.4R1 and all subsequent releases.\n\n\n\n\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10897",
+      "defect": [
+         "1264695"
+      ],
+      "discovery": "EXTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Limit access to J-Web from only trusted hosts, networks and administrators.\n"
+      }
+   ]
 }

--- a/2018/0xxx/CVE-2018-0063.json
+++ b/2018/0xxx/CVE-2018-0063.json
@@ -1,18 +1,107 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0063",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "sirt@juniper.net",
+      "DATE_PUBLIC": "2018-10-10T16:00:00.000Z",
+      "ID": "CVE-2018-0063",
+      "STATE": "PUBLIC",
+      "TITLE": "Junos OS: Nexthop index allocation failed: private index space exhausted after incoming ARP requests to management interface"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Junos OS",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "17.3R3",
+                                 "version_value": "17.3R3-S1"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Juniper Networks"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "A vulnerability in the IP next-hop index database in Junos OS 17.3R3 may allow a flood of ARP requests, sent to the management interface, to exhaust the private Internal routing interfaces (IRIs) next-hop limit.  Once the IRI next-hop database is full, no further next hops can be learned and existing entries cannot be cleared, leading to a sustained denial of service (DoS) condition. \n\nAn indicator of compromise for this issue is the report of the following error message:\n\n  %KERN-4: Nexthop index allocation failed: private index space exhausted\n\nThis issue only affects the management interface, and does not impact regular transit traffic through the FPCs.\n\nThis issue also only affects Junos OS 17.3R3.  No prior versions of Junos OS are affected by this issue.\n\nAffected releases are Juniper Networks Junos OS: 17.3R3."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "ADJACENT_NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 6.5,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Denial of Service"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.juniper.net/JSA10899",
+            "refsource": "CONFIRM",
+            "url": "https://kb.juniper.net/JSA10899"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "The following software releases have been updated to recover from private index space exhaustion: 17.3R3-S1 and all subsequent releases.\n"
+      }
+   ],
+   "source": {
+      "advisory": "JSA10899",
+      "defect": [
+         "1360039"
+      ],
+      "discovery": "USER"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "There are no viable workarounds for this issue."
+      }
+   ]
 }


### PR DESCRIPTION
CVE IDs assigned in Juniper Network's Quarterly Security Advisory Bundle published Oct 10th 2018.