### PR TITLE
Three CVEs related to Eclipse Vert.x

### DIFF
--- a/2018/12xxx/CVE-2018-12541.json
+++ b/2018/12xxx/CVE-2018-12541.json
@@ -1,8 +1,36 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "emo@eclipse.org",
       "ID" : "CVE-2018-12541",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Eclipse Vert.x",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "3.0"
+                              },
+                              {
+                                 "version_affected" : "<=",
+                                 "version_value" : "3.5.3"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "The Eclipse Foundation"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +39,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "In version from 3.0.0 to 3.5.3 of Eclipse Vert.x, the WebSocket HTTP upgrade implementation buffers the full http request before doing the handshake, holding the entire request body in memory. There should be a reasonnable limit (8192 bytes) above which the WebSocket gets an HTTP response with the 413 status code and the connection gets closed."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-789: Uncontrolled Memory Allocation"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://bugs.eclipse.org/bugs/show_bug.cgi?id=539170"
+         },
+         {
+            "url" : "https://github.com/eclipse-vertx/vert.x/issues/2648"
          }
       ]
    }

--- a/2018/12xxx/CVE-2018-12542.json
+++ b/2018/12xxx/CVE-2018-12542.json
@@ -1,8 +1,36 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "emo@eclipse.org",
       "ID" : "CVE-2018-12542",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Eclipse Vert.x",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "3.0"
+                              },
+                              {
+                                 "version_affected" : "<=",
+                                 "version_value" : "3.5.3"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "The Eclipse Foundation"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +39,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "In version from 3.0.0 to 3.5.3 of Eclipse Vert.x, the StaticHandler uses external input to construct a pathname that should be within a restricted directory, but it does not properly neutralize '\\' (forward slashes) sequences that can resolve to a location that is outside of that directory when running on Windows Operating Systems."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-33: Path Traversal: '....' (Multiple Dot)"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://bugs.eclipse.org/bugs/show_bug.cgi?id=539171"
+         },
+         {
+            "url" : "https://github.com/vert-x3/vertx-web/issues/1025"
          }
       ]
    }

--- a/2018/12xxx/CVE-2018-12544.json
+++ b/2018/12xxx/CVE-2018-12544.json
@@ -1,8 +1,36 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "emo@eclipse.org",
       "ID" : "CVE-2018-12544",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Eclipse Vert.x",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "3.5.0"
+                              },
+                              {
+                                 "version_affected" : "<=",
+                                 "version_value" : "3.5.3"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "The Eclipse Foundation"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +39,29 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "In version from 3.5.Beta1 to 3.5.3 of Eclipse Vert.x, the OpenAPI XML type validator creates XML parsers without taking appropriate defense against XML attacks. This mechanism is exclusively when the developer uses the Eclipse Vert.x OpenAPI XML type validator to validate a provided schema."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-611: Improper Restriction of XML External Entity Reference ('XXE')"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://bugs.eclipse.org/bugs/show_bug.cgi?id=539568"
+         },
+         {
+            "url" : "https://github.com/vert-x3/vertx-web/issues/1021"
          }
       ]
    }


### PR DESCRIPTION
2018/12xxx/CVE-2018-12541.json
2018/12xxx/CVE-2018-12542.json
2018/12xxx/CVE-2018-12544.json