### PR TITLE
Adding Cisco CVE-2018-0381

### DIFF
--- a/2018/0xxx/CVE-2018-0381.json
+++ b/2018/0xxx/CVE-2018-0381.json
@@ -1,18 +1,95 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0381",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "CVE_data_meta": {
+        "ASSIGNER": "psirt@cisco.com",
+        "DATE_PUBLIC": "2018-10-17T16:00:00-0500",
+        "ID": "CVE-2018-0381",
+        "STATE": "PUBLIC",
+        "TITLE": "Cisco Aironet 1560, 1800, 2800, and 3800 Series Access Points Denial of Service Vulnerability"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Cisco Aironet Access Points ",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "8.2"
+                                        },
+                                        {
+                                            "version_value": "8.3"
+                                        },
+                                        {
+                                            "version_value": "8.5"
+                                        },
+                                        {
+                                            "version_value": "8.7"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Cisco"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "A vulnerability in the Cisco Aironet 1560, 1800, 2800, and 3800 Series Access Points (APs) software could allow an authenticated, adjacent attacker to cause an affected device to reload unexpectedly, resulting in a denial of service (DoS) condition. The vulnerability is due to a deadlock condition that may occur when an affected AP attempts to dequeue aggregated traffic that is destined to an attacker-controlled wireless client. An attacker who can successfully transition between multiple Service Set Identifiers (SSIDs) hosted on the same AP while replicating the required traffic patterns could trigger the deadlock condition. A watchdog timer that detects the condition will trigger a reload of the device, resulting in a DoS condition while the device restarts. "
+            }
+        ]
+    },
+    "exploit": [
+        {
+            "lang": "eng",
+            "value": "The Cisco Product Security Incident Response Team (PSIRT) is not aware of any public announcements or malicious use of the vulnerability that is described in this advisory. "
+        }
+    ],
+    "impact": {
+        "cvss": {
+            "baseScore": "5.8",
+            "vectorString": "CVSS:3.0/AV:A/AC:H/PR:L/UI:N/S:C/C:N/I:N/A:H ",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-400"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "20181017 Cisco Aironet 1560, 1800, 2800, and 3800 Series Access Points Denial of Service Vulnerability",
+                "refsource": "CISCO",
+                "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20181017-aironet-dos"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "cisco-sa-20181017-aironet-dos",
+        "defect": [
+            [
+                "CSCvh21953"
+            ]
+        ],
+        "discovery": "INTERNAL"
+    }
 }

--- a/2018/0xxx/CVE-2018-0381.json
+++ b/2018/0xxx/CVE-2018-0381.json
@@ -45,7 +45,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A vulnerability in the Cisco Aironet 1560, 1800, 2800, and 3800 Series Access Points (APs) software could allow an authenticated, adjacent attacker to cause an affected device to reload unexpectedly, resulting in a denial of service (DoS) condition. The vulnerability is due to a deadlock condition that may occur when an affected AP attempts to dequeue aggregated traffic that is destined to an attacker-controlled wireless client. An attacker who can successfully transition between multiple Service Set Identifiers (SSIDs) hosted on the same AP while replicating the required traffic patterns could trigger the deadlock condition. A watchdog timer that detects the condition will trigger a reload of the device, resulting in a DoS condition while the device restarts. "
+                "value": "A vulnerability in the Cisco Aironet Series Access Points (APs) software could allow an authenticated, adjacent attacker to cause an affected device to reload unexpectedly, resulting in a denial of service (DoS) condition. The vulnerability is due to a deadlock condition that may occur when an affected AP attempts to dequeue aggregated traffic that is destined to an attacker-controlled wireless client. An attacker who can successfully transition between multiple Service Set Identifiers (SSIDs) hosted on the same AP while replicating the required traffic patterns could trigger the deadlock condition. A watchdog timer that detects the condition will trigger a reload of the device, resulting in a DoS condition while the device restarts. "
             }
         ]
     },


### PR DESCRIPTION
Adding Cisco CVE-2018-0381 - A vulnerability in the Cisco Aironet Series Access Points (APs) software could allow an authenticated, adjacent attacker to cause an affected device to reload unexpectedly, resulting in a denial of service (DoS) condition. The vulnerability is due to a deadlock condition that may occur when an affected AP attempts to dequeue aggregated traffic that is destined to an attacker-controlled wireless client. An attacker who can successfully transition between multiple Service Set Identifiers (SSIDs) hosted on the same AP while replicating the required traffic patterns could trigger the deadlock condition. A watchdog timer that detects the condition will trigger a reload of the device, resulting in a DoS condition while the device restarts. 