### PR TITLE
Add OpenSSL CVE-2018-0734

### DIFF
--- a/2018/0xxx/CVE-2018-0734.json
+++ b/2018/0xxx/CVE-2018-0734.json
@@ -1,18 +1,98 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-0734",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "CVE_data_meta": {
+        "ASSIGNER": "openssl-security@openssl.org", 
+        "DATE_PUBLIC": "2018-10-30", 
+        "ID": "CVE-2018-0734", 
+        "STATE": "PUBLIC", 
+        "TITLE": "Timing attack against DSA"
+    }, 
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "OpenSSL", 
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "Fixed in OpenSSL 1.1.1a-dev (Affected 1.1.1)"
+                                        }, 
+                                        {
+                                            "version_value": "Fixed in OpenSSL 1.1.0j-dev (Affected 1.1.0-1.1.0i)"
+                                        }, 
+                                        {
+                                            "version_value": "Fixed in OpenSSL 1.0.2q-dev (Affected 1.0.2-1.0.2p)"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }, 
+                    "vendor_name": "OpenSSL"
+                }
+            ]
+        }
+    }, 
+    "credit": [
+        {
+            "lang": "eng", 
+            "value": "Samuel Weiser"
+        }
+    ], 
+    "data_format": "MITRE", 
+    "data_type": "CVE", 
+    "data_version": "4.0", 
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng", 
+                "value": "The OpenSSL DSA signature algorithm has been shown to be vulnerable to a timing side channel attack. An attacker could use variations in the signing algorithm to recover the private key. Fixed in OpenSSL 1.1.1a-dev (Affected 1.1.1). Fixed in OpenSSL 1.1.0j-dev (Affected 1.1.0-1.1.0i). Fixed in OpenSSL 1.0.2q-dev (Affected 1.0.2-1.0.2p)."
+            }
+        ]
+    }, 
+    "impact": [
+        {
+            "lang": "eng", 
+            "url": "https://www.openssl.org/policies/secpolicy.html#Low", 
+            "value": "Low"
+        }
+    ], 
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng", 
+                        "value": "Constant time issue"
+                    }
+                ]
+            }
+        ]
+    }, 
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.openssl.org/news/secadv/20181030.txt", 
+                "refsource": "CONFIRM", 
+                "url": "https://www.openssl.org/news/secadv/20181030.txt"
+            }, 
+            {
+                "name": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8abfe72e8c1de1b95f50aa0d9134803b4d00070f", 
+                "refsource": "CONFIRM", 
+                "url": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8abfe72e8c1de1b95f50aa0d9134803b4d00070f"
+            }, 
+            {
+                "name": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=ef11e19d1365eea2b1851e6f540a0bf365d303e7", 
+                "refsource": "CONFIRM", 
+                "url": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=ef11e19d1365eea2b1851e6f540a0bf365d303e7"
+            }, 
+            {
+                "name": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=43e6a58d4991a451daf4891ff05a48735df871ac", 
+                "refsource": "CONFIRM", 
+                "url": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=43e6a58d4991a451daf4891ff05a48735df871ac"
+            }
+        ]
+    }
 }


### PR DESCRIPTION
Note that the security advisory name has been incorrectly spelt on the OpenSSL website. See:
https://github.com/openssl/web/pull/91

The advisory URL as it stands in this PR is the correct one and the OpenSSL website will be shortly updated to match.