### PR TITLE
CVEs from Facebook CNA: Proxygen v2018.12.31.00

### DIFF
--- a/2018/6xxx/CVE-2018-6346.json
+++ b/2018/6xxx/CVE-2018-6346.json
@@ -1,18 +1,68 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-6346",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@fb.com",
+        "DATE_ASSIGNED": "2018-12-19",
+        "ID": "CVE-2018-6346",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Proxygen",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "v2018.12.31.00"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "v2018.12.31.00"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Facebook"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "A potential denial-of-service issue in the Proxygen handling of invalid HTTP2 priority settings (specifically a circular dependency). This affects Proxygen prior to v2018.12.31.00."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Denial of Service (CWE-400)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/facebook/proxygen/commit/52cf331743ebd74194d6343a6c2ec52bb917c982",
+                "refsource": "MISC",
+                "url": "https://github.com/facebook/proxygen/commit/52cf331743ebd74194d6343a6c2ec52bb917c982"
+            }
+        ]
+    }
 }

--- a/2018/6xxx/CVE-2018-6347.json
+++ b/2018/6xxx/CVE-2018-6347.json
@@ -1,18 +1,68 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-6347",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@fb.com",
+        "DATE_ASSIGNED": "2018-12-19",
+        "ID": "CVE-2018-6347",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Proxygen",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "v2018.12.31.00"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "v2018.12.31.00"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Facebook"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "An issue in the Proxygen handling of HTTP2 parsing of headers/trailers can lead to a denial-of-service attack. This affects Proxygen prior to v2018.12.31.00."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Denial of Service (CWE-400)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/facebook/proxygen/commit/223e0aa6bc7590e86af1e917185a2e0efe160711",
+                "refsource": "MISC",
+                "url": "https://github.com/facebook/proxygen/commit/223e0aa6bc7590e86af1e917185a2e0efe160711"
+            }
+        ]
+    }
 }


### PR DESCRIPTION
Cut a release today which included fixes for these two CVEs.