### PR TITLE
Older 2018 CVEs from Facebook CNA

### DIFF
--- a/2018/6xxx/CVE-2018-6331.json
+++ b/2018/6xxx/CVE-2018-6331.json
@@ -1,18 +1,68 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-6331",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@fb.com",
+        "DATE_ASSIGNED": "2018-03-26",
+        "ID": "CVE-2018-6331",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Buck",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "v2018.06.25.01"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "v2018.06.25.01"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Facebook"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "Buck parser-cache command loads/saves state using Java serialized object. If the state information is maliciously crafted, deserializing it could lead to code execution. This issue affects Buck versions prior to v2018.06.25.01."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Deserialization of Untrusted Data (CWE-502)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/facebook/buck/commit/8c5500981812564877bd122c0f8fab48d3528ddf",
+                "refsource": "MISC",
+                "url": "https://github.com/facebook/buck/commit/8c5500981812564877bd122c0f8fab48d3528ddf"
+            }
+        ]
+    }
 }

--- a/2018/6xxx/CVE-2018-6333.json
+++ b/2018/6xxx/CVE-2018-6333.json
@@ -1,18 +1,68 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-6333",
-      "STATE" : "RESERVED"
-   },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
-         {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
-         }
-      ]
-   }
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@fb.com",
+        "DATE_ASSIGNED": "2018-03-19",
+        "ID": "CVE-2018-6333",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Nuclide",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "v0.290.0"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "v0.290.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Facebook"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "The hhvm-attach deep link handler in Nuclide did not properly sanitize the provided hostname parameter when rendering. As a result, a malicious URL could be used to render HTML and other content inside of the editor's context, which could potentially be chained to lead to code execution. This issue affected Nuclude prior to v0.290.0."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Improper Neutralization of Input During Web Page Generation (CWE-79)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/facebook/nuclide/commit/65f6bbd683404be1bb569b8d1be84b5d4c74a324",
+                "refsource": "MISC",
+                "url": "https://github.com/facebook/nuclide/commit/65f6bbd683404be1bb569b8d1be84b5d4c74a324"
+            }
+        ]
+    }
 }


### PR DESCRIPTION
These two CVEs are from earlier in the year but their information was never publicly defined. Unfortunately neither project publicly documented the issues other than in the commit themselves. Let me know if that is going to a problem.