### PR TITLE
Latest updates from Facebook CNA

### DIFF
--- a/2018/6xxx/CVE-2018-6345.json
+++ b/2018/6xxx/CVE-2018-6345.json
@@ -1,8 +1,45 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "cve-assign@fb.com",
+      "DATE_ASSIGNED" : "2018-12-11",
       "ID" : "CVE-2018-6345",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "HHVM",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "!=>",
+                                 "version_value" : "3.30.2"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "3.30.0"
+                              },
+                              {
+                                 "version_affected" : "!=>",
+                                 "version_value" : "3.27.6"
+                              },
+                              {
+                                 "version_affected" : "<",
+                                 "version_value" : "3.27.6"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Facebook"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +48,33 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "The function number_format is vulnerable to a heap overflow issue when its second argument ($dec_points) is excessively large. The internal implementation of the function will cause a string to be created with an invalid length, which can then interact poorly with other functions. This affects all supported versions of HHVM (3.30.1 and 3.27.5 and below)."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Heap-based Buffer Overflow (CWE-122)"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "name" : "https://github.com/facebook/hhvm/commit/190ffdf6c8b1ec443be202c7d69e63a7e3da25e3",
+            "refsource" : "MISC",
+            "url" : "https://github.com/facebook/hhvm/commit/190ffdf6c8b1ec443be202c7d69e63a7e3da25e3"
+         },
+         {
+            "name" : "https://hhvm.com/blog/2019/01/14/hhvm-3.30.2.html",
+            "refsource" : "MISC",
+            "url" : "https://hhvm.com/blog/2019/01/14/hhvm-3.30.2.html"
          }
       ]
    }

--- a/2018/6xxx/CVE-2018-6346.json
+++ b/2018/6xxx/CVE-2018-6346.json
@@ -20,7 +20,7 @@
                                  "version_value" : "v2018.12.31.00"
                               },
                               {
-                                 "version_affected" : "<=",
+                                 "version_affected" : "<",
                                  "version_value" : "v2018.12.31.00"
                               }
                            ]

--- a/2019/3xxx/CVE-2019-3554.json
+++ b/2019/3xxx/CVE-2019-3554.json
@@ -1,8 +1,37 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "cve-assign@fb.com",
+      "DATE_ASSIGNED" : "2019-01-08",
       "ID" : "CVE-2019-3554",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Wangle",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "!=>",
+                                 "version_value" : "v2019.01.14.00"
+                              },
+                              {
+                                 "version_affected" : "<",
+                                 "version_value" : "v2019.01.14.00"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Facebook"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +40,28 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "Wangle's AcceptRoutingHandler incorrectly casts a socket when accepting a TLS 1.3 connection, leading to a potential denial of service attack against systems accepting such connections. This affects versions of Wangle prior to v2019.01.14.00"
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Denial of Service (CWE-400)"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "name" : "https://github.com/facebook/wangle/commit/3b17ba10a82c71e7808760e027ac6af687e06074",
+            "refsource" : "MISC",
+            "url" : "https://github.com/facebook/wangle/commit/3b17ba10a82c71e7808760e027ac6af687e06074"
          }
       ]
    }

--- a/2019/3xxx/CVE-2019-3557.json
+++ b/2019/3xxx/CVE-2019-3557.json
@@ -1,8 +1,45 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "cve-assign@fb.com",
+      "DATE_ASSIGNED" : "2019-01-09",
       "ID" : "CVE-2019-3557",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "HHVM",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "!=>",
+                                 "version_value" : "3.30.1"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "3.30.0"
+                              },
+                              {
+                                 "version_affected" : "!=>",
+                                 "version_value" : "3.27.5"
+                              },
+                              {
+                                 "version_affected" : "<",
+                                 "version_value" : "3.27.5"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Facebook"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +48,33 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "The implementations of streams for bz2 and php://output improperly implemented their readImpl functions, returning -1 consistently. This behavior caused some stream functions, such as stream_get_line, to trigger an out-of-bounds read when operating on such malformed streams. The implementations were updated to return valid values consistently. This affects all supported versions of HHVM (3.30 and 3.27.4 and below)."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Out-of-bounds Read (CWE-125)"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "name" : "https://github.com/facebook/hhvm/commit/6e4dd9ec3f14b48170fc45dc9d13a3261765f994",
+            "refsource" : "MISC",
+            "url" : "https://github.com/facebook/hhvm/commit/6e4dd9ec3f14b48170fc45dc9d13a3261765f994"
+         },
+         {
+            "name" : "https://hhvm.com/blog/2019/01/14/hhvm-3.30.2.html",
+            "refsource" : "MISC",
+            "url" : "https://hhvm.com/blog/2019/01/14/hhvm-3.30.2.html"
          }
       ]
    }


### PR DESCRIPTION
- Two CVEs from an HHVM release yesterday: https://hhvm.com/blog/2019/01/14/hhvm-3.30.2.html
- One CVE from Wangle's release yesterday.
- One typo corrected in CVE-2018-6346 (the affected versions had overlapping ranges)