### PR TITLE
Editing CVE-2018-18895

### DIFF
--- a/2018/18xxx/CVE-2018-18895.json
+++ b/2018/18xxx/CVE-2018-18895.json
@@ -15,7 +15,12 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "2.8"
+                                 "affected" : "<",
+                                 "version_value" : "2.8MR3"
+                              },
+                              {
+                                 "affected" : "<",
+                                 "version_value" : "3.0MR2 patch 1"
                               }
                            ]
                         }
@@ -34,7 +39,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "A version of Castor XML, as used in Cisco WebEx Meetings Server before 2.8MR3 and 3.x before 3.0MR2 patch 1 and other products, allows XXE attacks. This vulnerability was previously documented in CVE-2014-3004."
+            "value" : "A version of Castor XML, as used in Cisco WebEx Meetings Server before 2.8MR3 and 3.x before 3.0MR2 patch 1 and other products, allows XXE attacks. This vulnerability was previously documented in CVE-2014-3004. Cisco Webex Meetings Server prior to versions 2.8MR3 and 3.0MR2 patch 1."
          }
       ]
    },

--- a/2018/18xxx/CVE-2018-18895.json
+++ b/2018/18xxx/CVE-2018-18895.json
@@ -11,18 +11,18 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Cisco WebEx Meetings Server",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "2.8"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Cisco"
             }
          ]
       }
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "A version of Castor XML, as used in Cisco WebEx Meetings Server before 2.8MR3 and 3.x before 3.0MR2 patch 1 and other products, allows XXE attacks."
+            "value" : "A version of Castor XML, as used in Cisco WebEx Meetings Server before 2.8MR3 and 3.x before 3.0MR2 patch 1 and other products, allows XXE attacks. This vulnerability was previously documented in CVE-2014-3004."
          }
       ]
    },
@@ -44,7 +44,7 @@
             "description" : [
                {
                   "lang" : "eng",
-                  "value" : "n/a"
+                  "value" : "CWE-611"
                }
             ]
          }

--- a/2018/18xxx/CVE-2018-18895.json
+++ b/2018/18xxx/CVE-2018-18895.json
@@ -76,6 +76,11 @@
             "name" : "1042085",
             "refsource" : "SECTRACK",
             "url" : "http://www.securitytracker.com/id/1042085"
+         },
+         {
+            "name" : "20190208 Cisco Bug: CSCvm56811 - Evaluation of Cisco WebEx Meetings Server Castor XML Processing",
+            "refsource" : "CISCO",
+            "url" : "https://quickview.cloudapps.cisco.com/quickview/bug/CSCvm56811"
          }
       ]
    }


### PR DESCRIPTION
We (Cisco PSIRT) noticed the assignment of [CVE-2018-18895](https://github.com/CVEProject/cvelist/blob/d07fae782693caaecf0d08142d5e6a014e06b27a/2018/18xxx/CVE-2018-18895.json).

The vulnerability described in that CVE is the same as CVE-2014-3004 and it was properly documented as such in Cisco Bug ID CSSvm56811.

Cisco did not assign CVE-2018-18895 and request it be marked as invalid or somehow corrected to point to CVE-2014-3004.

I edited the CVE entry to include related information and also pointed to the older CVE. 

This is also documented in the following Issue: https://github.com/CVEProject/cvelist/issues/1570

Alternatively, this CVE should be invalidated. 

Thanks in advance! 
Omar