### PR TITLE
Consistency updates to Apache CNA issues

### DIFF
--- a/2010/2xxx/CVE-2010-2232.json
+++ b/2010/2xxx/CVE-2010-2232.json
@@ -11,18 +11,18 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Apache Derby",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "10.1.2.1, 10.2.2.0, 10.3.1.4, 10.4.1.3"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2012/3xxx/CVE-2012-3353.json
+++ b/2012/3xxx/CVE-2012-3353.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Sling",
+                        "product_name" : "Apache Sling",
                         "version" : {
                            "version_data" : [
                               {

--- a/2013/4xxx/CVE-2013-4317.json
+++ b/2013/4xxx/CVE-2013-4317.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CloudStack",
+                        "product_name" : "Apache CloudStack",
                         "version" : {
                            "version_data" : [
                               {

--- a/2014/0xxx/CVE-2014-0043.json
+++ b/2014/0xxx/CVE-2014-0043.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Wicket",
+                        "product_name" : "Apache Wicket",
                         "version" : {
                            "version_data" : [
                               {

--- a/2015/5xxx/CVE-2015-5241.json
+++ b/2015/5xxx/CVE-2015-5241.json
@@ -11,11 +11,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "jUDDI",
+                        "product_name" : "Apache jUDDI",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "3.1.2, 3.1.3, 3.1.4, and 3.1.5 utilize the portlets based user interface also known as 'Pluto', 'jUDDI Portal', 'UDDI Portal' or 'uddi-console'"
+                                 "version_value" : "3.1.2, 3.1.3, 3.1.4, and 3.1.5"
                               }
                            ]
                         }

--- a/2016/0xxx/CVE-2016-0762.json
+++ b/2016/0xxx/CVE-2016-0762.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/3xxx/CVE-2016-3083.json
+++ b/2016/3xxx/CVE-2016-3083.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hive",
+                        "product_name" : "Apache Hive",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/3xxx/CVE-2016-3086.json
+++ b/2016/3xxx/CVE-2016-3086.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hadoop",
+                        "product_name" : "Apache Hadoop",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/4xxx/CVE-2016-4462.json
+++ b/2016/4xxx/CVE-2016-4462.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OFBiz",
+                        "product_name" : "Apache OFBiz",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/5xxx/CVE-2016-5001.json
+++ b/2016/5xxx/CVE-2016-5001.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hadoop",
+                        "product_name" : "Apache Hadoop",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/5xxx/CVE-2016-5018.json
+++ b/2016/5xxx/CVE-2016-5018.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/5xxx/CVE-2016-5394.json
+++ b/2016/5xxx/CVE-2016-5394.json
@@ -12,18 +12,18 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Apache Sling",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "prior to 1.0.12"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2016/5xxx/CVE-2016-5397.json
+++ b/2016/5xxx/CVE-2016-5397.json
@@ -12,11 +12,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Thrift",
+                        "product_name" : "Apache Thrift",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "0.9.3 and older, Fixed in Apache Thrift 0.10.0"
+                                 "version_value" : "versions prior to 0.10.0"
                               }
                            ]
                         }

--- a/2016/6xxx/CVE-2016-6794.json
+++ b/2016/6xxx/CVE-2016-6794.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/6xxx/CVE-2016-6795.json
+++ b/2016/6xxx/CVE-2016-6795.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Struts",
+                        "product_name" : "Apache Struts",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/6xxx/CVE-2016-6796.json
+++ b/2016/6xxx/CVE-2016-6796.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/6xxx/CVE-2016-6797.json
+++ b/2016/6xxx/CVE-2016-6797.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/6xxx/CVE-2016-6798.json
+++ b/2016/6xxx/CVE-2016-6798.json
@@ -12,18 +12,18 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Apache Sling",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "prior to 1.0.12"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2016/6xxx/CVE-2016-6799.json
+++ b/2016/6xxx/CVE-2016-6799.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Cordova Android",
+                        "product_name" : "Apache Cordova Android",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/6xxx/CVE-2016-6800.json
+++ b/2016/6xxx/CVE-2016-6800.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OFBiz",
+                        "product_name" : "Apache OFBiz",
                         "version" : {
                            "version_data" : [
                               {
@@ -41,7 +41,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "The default configuration of the OFBiz framework offers a blog functionality. Different users are able to operate blogs which are related to specific parties. In the form field for the creation of new blog articles the user input of the summary field as well as the article field is not properly sanitized. It is possible to inject arbitrary JavaScript code in these form fields. This code gets executed from the browser of every user who is visiting this article. Mitigation: Upgrade to Apache OFBiz 16.11.01."
+            "value" : "The default configuration of the Apache OFBiz framework offers a blog functionality. Different users are able to operate blogs which are related to specific parties. In the form field for the creation of new blog articles the user input of the summary field as well as the article field is not properly sanitized. It is possible to inject arbitrary JavaScript code in these form fields. This code gets executed from the browser of every user who is visiting this article. Mitigation: Upgrade to Apache OFBiz 16.11.01."
          }
       ]
    },

--- a/2016/6xxx/CVE-2016-6803.json
+++ b/2016/6xxx/CVE-2016-6803.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenOffice",
+                        "product_name" : "Apache OpenOffice",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/6xxx/CVE-2016-6806.json
+++ b/2016/6xxx/CVE-2016-6806.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Wicket",
+                        "product_name" : "Apache Wicket",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/6xxx/CVE-2016-6810.json
+++ b/2016/6xxx/CVE-2016-6810.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "ActiveMQ",
+                        "product_name" : "Apache ActiveMQ",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/6xxx/CVE-2016-6813.json
+++ b/2016/6xxx/CVE-2016-6813.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CloudStack",
+                        "product_name" : "Apache CloudStack",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/6xxx/CVE-2016-6815.json
+++ b/2016/6xxx/CVE-2016-6815.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Ranger",
+                        "product_name" : "Apache Ranger",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/6xxx/CVE-2016-6817.json
+++ b/2016/6xxx/CVE-2016-6817.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/8xxx/CVE-2016-8734.json
+++ b/2016/8xxx/CVE-2016-8734.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Subversion",
+                        "product_name" : "Apache Subversion",
                         "version" : {
                            "version_data" : [
                               {
@@ -38,7 +38,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "Subversion's mod_dontdothat module and HTTP clients 1.4.0 through 1.8.16, and 1.9.0 through 1.9.4 are vulnerable to a denial-of-service attack caused by exponential XML entity expansion. The attack can cause the targeted process to consume an excessive amount of CPU resources or memory."
+            "value" : "Apache Subversion's mod_dontdothat module and HTTP clients 1.4.0 through 1.8.16, and 1.9.0 through 1.9.4 are vulnerable to a denial-of-service attack caused by exponential XML entity expansion. The attack can cause the targeted process to consume an excessive amount of CPU resources or memory."
          }
       ]
    },

--- a/2016/8xxx/CVE-2016-8735.json
+++ b/2016/8xxx/CVE-2016-8735.json
@@ -15,14 +15,26 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "Apache Tomcat"
+                                 "version_value" : "before 6.0.48"
+                              },
+                              {
+                                 "version_value" : "7.x before 7.0.73"
+                              },
+                              {
+                                 "version_value" : "8.x before 8.0.39"
+                              },
+                              {
+                                 "version_value" : "8.5.x before 8.5.7"
+                              },
+                              {
+                                 "version_value" : "9.x before 9.0.0.M12"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2016/8xxx/CVE-2016-8736.json
+++ b/2016/8xxx/CVE-2016-8736.json
@@ -11,18 +11,18 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "before 3.1.12"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "Apache Openmeetings before 3.1.2 is vulnerable to Remote Code Execution via RMI deserialization attack."
+            "value" : "Apache OpenMeetings before 3.1.2 is vulnerable to Remote Code Execution via RMI deserialization attack."
          }
       ]
    },

--- a/2016/8xxx/CVE-2016-8737.json
+++ b/2016/8xxx/CVE-2016-8737.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Brooklyn",
+                        "product_name" : "Apache Brooklyn",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/8xxx/CVE-2016-8738.json
+++ b/2016/8xxx/CVE-2016-8738.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Struts",
+                        "product_name" : "Apache Struts",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/8xxx/CVE-2016-8739.json
+++ b/2016/8xxx/CVE-2016-8739.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CXF",
+                        "product_name" : "Apache CXF",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/8xxx/CVE-2016-8740.json
+++ b/2016/8xxx/CVE-2016-8740.json
@@ -11,18 +11,18 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Apache HTTP Server",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "2.4.17 - 2.4.23"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2016/8xxx/CVE-2016-8741.json
+++ b/2016/8xxx/CVE-2016-8741.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Apache Qpid Broker for Java",
+                        "product_name" : "Apache Qpid Broker-J",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/8xxx/CVE-2016-8742.json
+++ b/2016/8xxx/CVE-2016-8742.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CouchDB",
+                        "product_name" : "Apache CouchDB",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/8xxx/CVE-2016-8744.json
+++ b/2016/8xxx/CVE-2016-8744.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Brooklyn",
+                        "product_name" : "Apache Brooklyn",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/8xxx/CVE-2016-8745.json
+++ b/2016/8xxx/CVE-2016-8745.json
@@ -12,11 +12,23 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "9.0.0.M1 to 9.0.0.M13, 8.5.0 to 8.5.8, 8.0.0.RC1 to 8.0.39, 7.0.0 to 7.0.73, 6.0.16 to 6.0.48"
+                                  "version_value" : "9.0.0.M1 to 9.0.0.M13"
+                              },
+                              {
+                                  "version_value" : "8.5.0 to 8.5.8"
+                              },
+                              {
+                                  "version_value" : "8.0.0.RC1 to 8.0.39"
+                              },
+                              {
+                                  "version_value" : "7.0.0 to 7.0.73"
+                              },
+                              {
+                                  "version_value" : "6.0.16 to 6.0.48"
                               }
                            ]
                         }

--- a/2016/8xxx/CVE-2016-8746.json
+++ b/2016/8xxx/CVE-2016-8746.json
@@ -11,11 +11,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Ranger",
+                        "product_name" : "Apache Ranger",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "0.6.0/0.6.1/0.6.2"
+                                 "version_value" : "0.6.0 - 0.6.2"
                               }
                            ]
                         }

--- a/2016/8xxx/CVE-2016-8747.json
+++ b/2016/8xxx/CVE-2016-8747.json
@@ -15,14 +15,17 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "Apache Tomcat"
+                                 "version_value" : "8.5.7 to 8.5.9"
+                              },
+                              {
+                                 "version_value" : "9.0.0.M11 to 9.0.0.M15"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2016/8xxx/CVE-2016-8748.json
+++ b/2016/8xxx/CVE-2016-8748.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "NiFi",
+                        "product_name" : "Apache NiFi",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/8xxx/CVE-2016-8750.json
+++ b/2016/8xxx/CVE-2016-8750.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Karaf",
+                        "product_name" : "Apache Karaf",
                         "version" : {
                            "version_data" : [
                               {

--- a/2016/8xxx/CVE-2016-8751.json
+++ b/2016/8xxx/CVE-2016-8751.json
@@ -11,11 +11,14 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Ranger",
+                        "product_name" : "Apache Ranger",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "0.5.x and 0.6.0/0.6.1/0.6.2"
+                                 "version_value" : "0.5.x"
+                              },
+                              {
+                                 "version_value" : "0.6.0 - 0.6.2"
                               }
                            ]
                         }
@@ -34,7 +37,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "Apache Ranger before 0.6.is vulnerable to a Stored Cross-Site Scripting in when entering custom policy conditions. Admin users can store some arbitrary javascript code to be executed when normal users login and access policies."
+            "value" : "Apache Ranger before 0.6.3 is vulnerable to a Stored Cross-Site Scripting in when entering custom policy conditions. Admin users can store some arbitrary javascript code to be executed when normal users login and access policies."
          }
       ]
    },

--- a/2016/8xxx/CVE-2016-8752.json
+++ b/2016/8xxx/CVE-2016-8752.json
@@ -12,17 +12,17 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Atlas",
+                        "product_name" : "Apache Atlas",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "0.6.0"
+                                 "version_value" : "0.6.0-incubating"
                               },
                               {
-                                 "version_value" : "0.7.0"
+                                 "version_value" : "0.7.0-incubating"
                               },
                               {
-                                 "version_value" : "0.7.1"
+                                 "version_value" : "0.7.1-incubating"
                               }
                            ]
                         }

--- a/2017/12xxx/CVE-2017-12610.json
+++ b/2017/12xxx/CVE-2017-12610.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Kafka",
+                        "product_name" : "Apache Kafka",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12611.json
+++ b/2017/12xxx/CVE-2017-12611.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Struts",
+                        "product_name" : "Apache Struts",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12613.json
+++ b/2017/12xxx/CVE-2017-12613.json
@@ -11,18 +11,18 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Apache Portable Runtime",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "1.6.2 and prior"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2017/12xxx/CVE-2017-12614.json
+++ b/2017/12xxx/CVE-2017-12614.json
@@ -12,11 +12,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Airflow",
+                        "product_name" : "Apache Airflow",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "< 1.9"
+                                 "version_value" : "< 1.9.0"
                               }
                            ]
                         }

--- a/2017/12xxx/CVE-2017-12615.json
+++ b/2017/12xxx/CVE-2017-12615.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12616.json
+++ b/2017/12xxx/CVE-2017-12616.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12617.json
+++ b/2017/12xxx/CVE-2017-12617.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12618.json
+++ b/2017/12xxx/CVE-2017-12618.json
@@ -11,18 +11,18 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Apache Portable Runtime",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "1.6.0 and prior"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2017/12xxx/CVE-2017-12620.json
+++ b/2017/12xxx/CVE-2017-12620.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenNLP",
+                        "product_name" : "Apache OpenNLP",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12621.json
+++ b/2017/12xxx/CVE-2017-12621.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Commons Jelly",
+                        "product_name" : "Apache Commons Jelly",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12622.json
+++ b/2017/12xxx/CVE-2017-12622.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Geode",
+                        "product_name" : "Apache Geode",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12623.json
+++ b/2017/12xxx/CVE-2017-12623.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "NiFi",
+                        "product_name" : "Apache NiFi",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12624.json
+++ b/2017/12xxx/CVE-2017-12624.json
@@ -12,11 +12,14 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CXF",
+                        "product_name" : "Apache CXF",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "All versions of Apache CXF prior to 3.2.1 and 3.1.14."
+                                 "version_value" : "prior to 3.1.14"
+                              },
+                              {
+                                 "version_value" : "3.2.x prior to 3.2.1"
                               }
                            ]
                         }

--- a/2017/12xxx/CVE-2017-12625.json
+++ b/2017/12xxx/CVE-2017-12625.json
@@ -12,11 +12,17 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hive",
+                        "product_name" : "Apache Hive",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "2.1.0 to 2.3.0"
+                                 "version_value" : "2.1.x before 2.1.2"
+                              },
+                              {
+                                  "version_value" : "2.2.x before 2.2.1"
+                              },
+                              {
+                                 "version_value" : "2.3.0"
                               }
                            ]
                         }

--- a/2017/12xxx/CVE-2017-12626.json
+++ b/2017/12xxx/CVE-2017-12626.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "POI",
+                        "product_name" : "Apache POI",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12627.json
+++ b/2017/12xxx/CVE-2017-12627.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Xerces-C",
+                        "product_name" : "Apache Xerces C++",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12628.json
+++ b/2017/12xxx/CVE-2017-12628.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "James Server",
+                        "product_name" : "Apache James",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12629.json
+++ b/2017/12xxx/CVE-2017-12629.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Solr",
+                        "product_name" : "Apache Solr",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12630.json
+++ b/2017/12xxx/CVE-2017-12630.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Drill",
+                        "product_name" : "Apache Drill",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12631.json
+++ b/2017/12xxx/CVE-2017-12631.json
@@ -12,11 +12,14 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CXF Fediz",
+                        "product_name" : "Apache CXF Fediz",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "prior to 1.4.3 and 1.3.3"
+                                 "version_value" : "1.4.x prior to 1.4.3"
+                              },
+                              {
+                                 "version_value" : "prior to 1.3.3"
                               }
                            ]
                         }

--- a/2017/12xxx/CVE-2017-12632.json
+++ b/2017/12xxx/CVE-2017-12632.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "NiFi",
+                        "product_name" : "Apache NiFi",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12633.json
+++ b/2017/12xxx/CVE-2017-12633.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Camel",
+                        "product_name" : "Apache Camel",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12634.json
+++ b/2017/12xxx/CVE-2017-12634.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Camel",
+                        "product_name" : "Apache Camel",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12635.json
+++ b/2017/12xxx/CVE-2017-12635.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CouchDB",
+                        "product_name" : "Apache CouchDB",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/12xxx/CVE-2017-12636.json
+++ b/2017/12xxx/CVE-2017-12636.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CouchDB",
+                        "product_name" : "Apache CouchDB",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15691.json
+++ b/2017/15xxx/CVE-2017-15691.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "UIMA",
+                        "product_name" : "Apache UIMA",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15692.json
+++ b/2017/15xxx/CVE-2017-15692.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Geode",
+                        "product_name" : "Apache Geode",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15693.json
+++ b/2017/15xxx/CVE-2017-15693.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Geode",
+                        "product_name" : "Apache Geode",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15695.json
+++ b/2017/15xxx/CVE-2017-15695.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Geode",
+                        "product_name" : "Apache Geode",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15697.json
+++ b/2017/15xxx/CVE-2017-15697.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "NiFi",
+                        "product_name" : "Apache NiFi",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15698.json
+++ b/2017/15xxx/CVE-2017-15698.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat Native Connector",
+                        "product_name" : "Apache Tomcat Native",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15700.json
+++ b/2017/15xxx/CVE-2017-15700.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Sling",
+                        "product_name" : "Apache Sling",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15701.json
+++ b/2017/15xxx/CVE-2017-15701.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Qpid Broker-J",
+                        "product_name" : "Apache Qpid Broker-J",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15702.json
+++ b/2017/15xxx/CVE-2017-15702.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Qpid Broker-J",
+                        "product_name" : "Apache Qpid Broker-J",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15703.json
+++ b/2017/15xxx/CVE-2017-15703.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "NiFi",
+                        "product_name" : "Apache NiFi",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15705.json
+++ b/2017/15xxx/CVE-2017-15705.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "SpamAssassin",
+                        "product_name" : "Apache SpamAssassin",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15706.json
+++ b/2017/15xxx/CVE-2017-15706.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15707.json
+++ b/2017/15xxx/CVE-2017-15707.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Struts",
+                        "product_name" : "Apache Struts",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15708.json
+++ b/2017/15xxx/CVE-2017-15708.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Synapse",
+                        "product_name" : "Apache Synapse",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15712.json
+++ b/2017/15xxx/CVE-2017-15712.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Oozie",
+                        "product_name" : "Apache Oozie",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15713.json
+++ b/2017/15xxx/CVE-2017-15713.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hadoop",
+                        "product_name" : "Apache Hadoop",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15714.json
+++ b/2017/15xxx/CVE-2017-15714.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OFBiz",
+                        "product_name" : "Apache OFBiz",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/15xxx/CVE-2017-15717.json
+++ b/2017/15xxx/CVE-2017-15717.json
@@ -12,17 +12,17 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Sling XSS Protection API",
+                        "product_name" : "Apache Sling",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "1.0.4 to 1.0.18"
+                                 "version_value" : "XSS Protection API 1.0.4 to 1.0.18"
                               },
                               {
-                                 "version_value" : "Compat 1.1.0"
+                                 "version_value" : "XSS Protection API Compat 1.1.0"
                               },
                               {
-                                 "version_value" : "2.0.0"
+                                 "version_value" : "XSS Protection API 2.0.0"
                               }
                            ]
                         }

--- a/2017/15xxx/CVE-2017-15718.json
+++ b/2017/15xxx/CVE-2017-15718.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hadoop",
+                        "product_name" : "Apache Hadoop",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/17xxx/CVE-2017-17837.json
+++ b/2017/17xxx/CVE-2017-17837.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "DeltaSpike",
+                        "product_name" : "Apache DeltaSpike",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3150.json
+++ b/2017/3xxx/CVE-2017-3150.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Atlas",
+                        "product_name" : "Apache Atlas",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3151.json
+++ b/2017/3xxx/CVE-2017-3151.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Atlas",
+                        "product_name" : "Apache Atlas",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3152.json
+++ b/2017/3xxx/CVE-2017-3152.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Atlas",
+                        "product_name" : "Apache Atlas",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3153.json
+++ b/2017/3xxx/CVE-2017-3153.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Atlas",
+                        "product_name" : "Apache Atlas",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3154.json
+++ b/2017/3xxx/CVE-2017-3154.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Atlas",
+                        "product_name" : "Apache Atlas",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3155.json
+++ b/2017/3xxx/CVE-2017-3155.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Atlas",
+                        "product_name" : "Apache Atlas",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3156.json
+++ b/2017/3xxx/CVE-2017-3156.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CXF",
+                        "product_name" : "Apache CXF",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3161.json
+++ b/2017/3xxx/CVE-2017-3161.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hadoop",
+                        "product_name" : "Apache Hadoop",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3162.json
+++ b/2017/3xxx/CVE-2017-3162.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hadoop",
+                        "product_name" : "Apache Hadoop",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3163.json
+++ b/2017/3xxx/CVE-2017-3163.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Solr",
+                        "product_name" : "Apache Solr",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3165.json
+++ b/2017/3xxx/CVE-2017-3165.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Brooklyn",
+                        "product_name" : "Apache Brooklyn",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/3xxx/CVE-2017-3166.json
+++ b/2017/3xxx/CVE-2017-3166.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hadoop",
+                        "product_name" : "Apache Hadoop",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/5xxx/CVE-2017-5635.json
+++ b/2017/5xxx/CVE-2017-5635.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "NiFi",
+                        "product_name" : "Apache NiFi",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/5xxx/CVE-2017-5636.json
+++ b/2017/5xxx/CVE-2017-5636.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "NiFi",
+                        "product_name" : "Apache NiFi",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/5xxx/CVE-2017-5637.json
+++ b/2017/5xxx/CVE-2017-5637.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "ZooKeeper",
+                        "product_name" : "Apache ZooKeeper",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/5xxx/CVE-2017-5638.json
+++ b/2017/5xxx/CVE-2017-5638.json
@@ -11,18 +11,21 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Apache Struts",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "2.3.x before 2.3.32"
+                              },
+                              {
+                                 "version_value" : "2.5.x before 2.5.10.1"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2017/5xxx/CVE-2017-5640.json
+++ b/2017/5xxx/CVE-2017-5640.json
@@ -12,11 +12,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Impala (incubating)",
+                        "product_name" : "Apache Impala",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "2.7.0 to 2.8.0"
+                                 "version_value" : "2.7.0 to 2.8.0 incubating"
                               }
                            ]
                         }

--- a/2017/5xxx/CVE-2017-5641.json
+++ b/2017/5xxx/CVE-2017-5641.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Flex BlazeDS",
+                        "product_name" : "Apache Flex Blaze DS",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/5xxx/CVE-2017-5646.json
+++ b/2017/5xxx/CVE-2017-5646.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Knox",
+                        "product_name" : "Apache Knox",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/5xxx/CVE-2017-5652.json
+++ b/2017/5xxx/CVE-2017-5652.json
@@ -12,11 +12,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Impala (incubating)",
+                        "product_name" : "Apache Impala",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "2.7.0 to 2.8.0"
+                                 "version_value" : "2.7.0 to 2.8.0 incubating"
                               }
                            ]
                         }

--- a/2017/5xxx/CVE-2017-5653.json
+++ b/2017/5xxx/CVE-2017-5653.json
@@ -11,18 +11,21 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CXF",
+                        "product_name" : "Apache CXF",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "All versions prior to 3.1.11 and 3.0.13."
+                                 "version_value" : "prior to 3.0.13"
+                              },
+                              {
+                                 "version_value" : "3.1.x prior to 3.1.11"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "Apache"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2017/5xxx/CVE-2017-5656.json
+++ b/2017/5xxx/CVE-2017-5656.json
@@ -15,14 +15,17 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "All versions prior to 3.1.11 and 3.0.13."
+                                 "version_value" : "3.1.x before 3.1.11"
+                              },
+                              {
+                                 "version_value" : "versions before 3.0.13"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "Apache"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2017/5xxx/CVE-2017-5658.json
+++ b/2017/5xxx/CVE-2017-5658.json
@@ -12,11 +12,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Pony Mail",
+                        "product_name" : "Apache Pony Mail",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "0.7 to 0.9"
+                                 "version_value" : "0.7 to 0.9 (incubating)"
                               }
                            ]
                         }

--- a/2017/5xxx/CVE-2017-5660.json
+++ b/2017/5xxx/CVE-2017-5660.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Traffic Server",
+                        "product_name" : "Apache Traffic Server",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/5xxx/CVE-2017-5661.json
+++ b/2017/5xxx/CVE-2017-5661.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Apache XML Graphics FOP",
+                        "product_name" : "Apache FOP",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/5xxx/CVE-2017-5663.json
+++ b/2017/5xxx/CVE-2017-5663.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Fineract",
+                        "product_name" : "Apache Fineract",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/5xxx/CVE-2017-5664.json
+++ b/2017/5xxx/CVE-2017-5664.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7659.json
+++ b/2017/7xxx/CVE-2017-7659.json
@@ -11,18 +11,18 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Apache HTTP Server",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "2.4.24, 2.4.25"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "A maliciously constructed HTTP/2 request could cause mod_http2 2.4.24, 2.4.25 to dereference a NULL pointer and crash the server process."
+            "value" : "A maliciously constructed HTTP/2 request could cause mod_http2 in Apache HTTP Server 2.4.24, 2.4.25 to dereference a NULL pointer and crash the server process."
          }
       ]
    },

--- a/2017/7xxx/CVE-2017-7660.json
+++ b/2017/7xxx/CVE-2017-7660.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Solr",
+                        "product_name" : "Apache Solr",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7663.json
+++ b/2017/7xxx/CVE-2017-7663.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenMeetings",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7664.json
+++ b/2017/7xxx/CVE-2017-7664.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenMeetings",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7665.json
+++ b/2017/7xxx/CVE-2017-7665.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "NiFi",
+                        "product_name" : "Apache NiFi",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7666.json
+++ b/2017/7xxx/CVE-2017-7666.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenMeetings",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7667.json
+++ b/2017/7xxx/CVE-2017-7667.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "NiFi",
+                        "product_name" : "Apache NiFi",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7669.json
+++ b/2017/7xxx/CVE-2017-7669.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hadoop",
+                        "product_name" : "Apache Hadoop",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7670.json
+++ b/2017/7xxx/CVE-2017-7670.json
@@ -12,14 +12,14 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Traffic Control Traffic Router",
+                        "product_name" : "Apache Traffic Control",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "1.8.0"
+                                 "version_value" : "1.8.0 incubating"
                               },
                               {
-                                 "version_value" : "2.0.0 RC0"
+                                 "version_value" : "2.0.0 RC0 incubating"
                               }
                            ]
                         }

--- a/2017/7xxx/CVE-2017-7671.json
+++ b/2017/7xxx/CVE-2017-7671.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Traffic Server",
+                        "product_name" : "Apache Traffic Server",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7672.json
+++ b/2017/7xxx/CVE-2017-7672.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Struts",
+                        "product_name" : "Apache Struts",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7673.json
+++ b/2017/7xxx/CVE-2017-7673.json
@@ -11,18 +11,18 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "1.0.0"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2017/7xxx/CVE-2017-7674.json
+++ b/2017/7xxx/CVE-2017-7674.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7675.json
+++ b/2017/7xxx/CVE-2017-7675.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7676.json
+++ b/2017/7xxx/CVE-2017-7676.json
@@ -11,11 +11,17 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Ranger",
+                        "product_name" : "Apache Ranger",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "0.5.x/0.6.x/0.7.0"
+                                 "version_value" : "0.5.x"
+                              },
+                              {
+                                 "version_value" : "0.6.x"
+                              },
+                              {
+                                 "version_value" : "0.7.0"
                               }
                            ]
                         }

--- a/2017/7xxx/CVE-2017-7677.json
+++ b/2017/7xxx/CVE-2017-7677.json
@@ -11,11 +11,17 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Ranger",
+                        "product_name" : "Apache Ranger",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "0.5.x/0.6.x/0.7.0"
+                                 "version_value" : "0.5.x"
+                              },
+                              {
+                                 "version_value" : "0.6.x"
+                              },
+                              {
+                                 "version_value" : "0.7.0"
                               }
                            ]
                         }

--- a/2017/7xxx/CVE-2017-7678.json
+++ b/2017/7xxx/CVE-2017-7678.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Spark",
+                        "product_name" : "Apache Spark",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7680.json
+++ b/2017/7xxx/CVE-2017-7680.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenMeetings",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7681.json
+++ b/2017/7xxx/CVE-2017-7681.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenMeetings",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7682.json
+++ b/2017/7xxx/CVE-2017-7682.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenMeetings",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7683.json
+++ b/2017/7xxx/CVE-2017-7683.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenMeetings",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7684.json
+++ b/2017/7xxx/CVE-2017-7684.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenMeetings",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7685.json
+++ b/2017/7xxx/CVE-2017-7685.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenMeetings",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7686.json
+++ b/2017/7xxx/CVE-2017-7686.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Ignite",
+                        "product_name" : "Apache Ignite",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/7xxx/CVE-2017-7687.json
+++ b/2017/7xxx/CVE-2017-7687.json
@@ -12,17 +12,20 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Mesos",
+                        "product_name" : "Apache Mesos",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "1.1.0 to 1.3.0"
+                                 "version_value" : "versions prior to 1.1.3"
                               },
                               {
-                                 "version_value" : "1.0.x"
+                                 "version_value" : "1.2.x before 1.2.2"
                               },
                               {
-                                 "version_value" : "0.x"
+                                 "version_value" : "1.3.x before 1.3.1"
+                              },
+                              {
+                                 "version_value" : "1.4.0-dev"
                               }
                            ]
                         }

--- a/2017/7xxx/CVE-2017-7688.json
+++ b/2017/7xxx/CVE-2017-7688.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenMeetings",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/9xxx/CVE-2017-9787.json
+++ b/2017/9xxx/CVE-2017-9787.json
@@ -12,11 +12,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Struts",
+                        "product_name" : "Apache Struts",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "2.3.x series"
+                                 "version_value" : "2.3.x prior to 2.3.33"
                               },
                               {
                                  "version_value" : "2.5 to 2.5.10.1"

--- a/2017/9xxx/CVE-2017-9788.json
+++ b/2017/9xxx/CVE-2017-9788.json
@@ -12,11 +12,14 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "HTTP Server",
+                        "product_name" : "Apache HTTP Server",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "All through 2.2.33 and 2.4.26"
+                                 "version_value" : "2.2.0 to 2.2.33"
+                              },
+                              {
+                                 "version_value" : "2.4.1 to 2.4.26"
                               }
                            ]
                         }

--- a/2017/9xxx/CVE-2017-9789.json
+++ b/2017/9xxx/CVE-2017-9789.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "HTTP Server",
+                        "product_name" : "Apache HTTP Server",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/9xxx/CVE-2017-9790.json
+++ b/2017/9xxx/CVE-2017-9790.json
@@ -12,17 +12,20 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Mesos",
+                        "product_name" : "APache Mesos",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "1.1.0 to 1.3.0"
+                                 "version_value" : "versions prior to 1.1.3"
                               },
                               {
-                                 "version_value" : "1.0.x"
+                                 "version_value" : "1.2.x before 1.2.2"
                               },
                               {
-                                 "version_value" : "0.x"
+                                 "version_value" : "1.3.x before 1.3.1"
+                              },
+                              {
+                                 "version_value" : "1.4.0-dev"
                               }
                            ]
                         }

--- a/2017/9xxx/CVE-2017-9792.json
+++ b/2017/9xxx/CVE-2017-9792.json
@@ -12,14 +12,14 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Impala (incubating)",
+                        "product_name" : "Apache Impala",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "2.8.0"
+                                 "version_value" : "2.8.0 incubating"
                               },
                               {
-                                 "version_value" : "2.9.0"
+                                 "version_value" : "2.9.0 incubating"
                               }
                            ]
                         }

--- a/2017/9xxx/CVE-2017-9793.json
+++ b/2017/9xxx/CVE-2017-9793.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Struts",
+                        "product_name" : "Apache Struts",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/9xxx/CVE-2017-9794.json
+++ b/2017/9xxx/CVE-2017-9794.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Geode",
+                        "product_name" : "Apache Geode",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/9xxx/CVE-2017-9795.json
+++ b/2017/9xxx/CVE-2017-9795.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Geode",
+                        "product_name" : "Apache Geode",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/9xxx/CVE-2017-9796.json
+++ b/2017/9xxx/CVE-2017-9796.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Geode",
+                        "product_name" : "Apache Geode",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/9xxx/CVE-2017-9797.json
+++ b/2017/9xxx/CVE-2017-9797.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Geode",
+                        "product_name" : "Apache Geode",
                         "version" : {
                            "version_data" : [
                               {

--- a/2017/9xxx/CVE-2017-9802.json
+++ b/2017/9xxx/CVE-2017-9802.json
@@ -12,11 +12,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Sling Servlets Post",
+                        "product_name" : "Apache Sling",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "2.3.20 or older"
+                                 "version_value" : "Servlets Post 2.3.20 or older"
                               }
                            ]
                         }

--- a/2017/9xxx/CVE-2017-9803.json
+++ b/2017/9xxx/CVE-2017-9803.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Solr",
+                        "product_name" : "Apache Solr",
                         "version" : {
                            "version_data" : [
                               {
@@ -35,7 +35,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "Solr's Kerberos plugin can be configured to use delegation tokens, which allows an application to reuse the authentication of an end-user or another application. There are two issues with this functionality (when using SecurityAwareZkACLProvider type of ACL provider e.g. SaslZkACLProvider). Firstly, access to the security configuration can be leaked to users other than the solr super user. Secondly, malicious users can exploit this leaked configuration for privilege escalation to further expose/modify private data and/or disrupt operations in the Solr cluster. The vulnerability is fixed from Solr 6.6.1 onwards."
+            "value" : "Apache Solr's Kerberos plugin can be configured to use delegation tokens, which allows an application to reuse the authentication of an end-user or another application. There are two issues with this functionality (when using SecurityAwareZkACLProvider type of ACL provider e.g. SaslZkACLProvider). Firstly, access to the security configuration can be leaked to users other than the solr super user. Secondly, malicious users can exploit this leaked configuration for privilege escalation to further expose/modify private data and/or disrupt operations in the Solr cluster. The vulnerability is fixed from Apache Solr 6.6.1 onwards."
          }
       ]
    },

--- a/2017/9xxx/CVE-2017-9804.json
+++ b/2017/9xxx/CVE-2017-9804.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Struts",
+                        "product_name" : "Apache Struts",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11758.json
+++ b/2018/11xxx/CVE-2018-11758.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Cayenne",
+                        "product_name" : "Apache Cayenne",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11759.json
+++ b/2018/11xxx/CVE-2018-11759.json
@@ -11,7 +11,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Apache Tomcat JK (mod_jk) Connector",
+                        "product_name" : "Apache Tomcat Connectors",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11761.json
+++ b/2018/11xxx/CVE-2018-11761.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tika",
+                        "product_name" : "Apache Tika",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11762.json
+++ b/2018/11xxx/CVE-2018-11762.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tika",
+                        "product_name" : "Apache Tika",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11763.json
+++ b/2018/11xxx/CVE-2018-11763.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "HTTP Server",
+                        "product_name" : "Apache HTTP Server",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11770.json
+++ b/2018/11xxx/CVE-2018-11770.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Spark",
+                        "product_name" : "Apache Spark",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11771.json
+++ b/2018/11xxx/CVE-2018-11771.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Commons Compress",
+                        "product_name" : "Apache Commons Compress",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11775.json
+++ b/2018/11xxx/CVE-2018-11775.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "ActiveMQ",
+                        "product_name" : "Apache ActiveMQ",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11776.json
+++ b/2018/11xxx/CVE-2018-11776.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Struts",
+                        "product_name" : "Apache Struts",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11778.json
+++ b/2018/11xxx/CVE-2018-11778.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Ranger",
+                        "product_name" : "Apache Ranger",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11780.json
+++ b/2018/11xxx/CVE-2018-11780.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "SpamAssassin",
+                        "product_name" : "Apache SpamAssassin",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11781.json
+++ b/2018/11xxx/CVE-2018-11781.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "SpamAssassin",
+                        "product_name" : "Apache SpamAssassin",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11784.json
+++ b/2018/11xxx/CVE-2018-11784.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11786.json
+++ b/2018/11xxx/CVE-2018-11786.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Karaf",
+                        "product_name" : "Apache Karaf",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11787.json
+++ b/2018/11xxx/CVE-2018-11787.json
@@ -12,11 +12,17 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Karaf",
+                        "product_name" : "Apache Karaf",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "prior to 3.0.9, 4.0.9, 4.1.1"
+                                 "version_value" : "prior to 3.0.9"
+                              },
+                              {
+                                 "version_value" : "4.0.x prior to 4.0.9"
+                              },
+                              {
+                                 "version_value" : "4.1.x prior to 4.1.1"
                               }
                            ]
                         }

--- a/2018/11xxx/CVE-2018-11797.json
+++ b/2018/11xxx/CVE-2018-11797.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "PDFBox",
+                        "product_name" : "Apache PDFBox",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/11xxx/CVE-2018-11804.json
+++ b/2018/11xxx/CVE-2018-11804.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Spark",
+                        "product_name" : "Apache Spark",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/17xxx/CVE-2018-17191.json
+++ b/2018/17xxx/CVE-2018-17191.json
@@ -11,11 +11,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Apache NetBeans (incubating)",
+                        "product_name" : "Apache NetBeans",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "Apache NetBeans (incubating) 9.0"
+                                 "version_value" : "9.0 incubating"
                               }
                            ]
                         }

--- a/2018/1xxx/CVE-2018-1281.json
+++ b/2018/1xxx/CVE-2018-1281.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "MXNet",
+                        "product_name" : "Apache MXNet",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1282.json
+++ b/2018/1xxx/CVE-2018-1282.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hive",
+                        "product_name" : "Apache Hive",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1284.json
+++ b/2018/1xxx/CVE-2018-1284.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hive",
+                        "product_name" : "Apache Hive",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1286.json
+++ b/2018/1xxx/CVE-2018-1286.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "OpenMeetings",
+                        "product_name" : "Apache OpenMeetings",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1287.json
+++ b/2018/1xxx/CVE-2018-1287.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "JMeter",
+                        "product_name" : "Apache JMeter",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1288.json
+++ b/2018/1xxx/CVE-2018-1288.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Kafka",
+                        "product_name" : "Apache Kafka",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1289.json
+++ b/2018/1xxx/CVE-2018-1289.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Fineract",
+                        "product_name" : "Apache Fineract",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1290.json
+++ b/2018/1xxx/CVE-2018-1290.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Fineract",
+                        "product_name" : "Apache Fineract",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1291.json
+++ b/2018/1xxx/CVE-2018-1291.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Fineract",
+                        "product_name" : "Apache Fineract",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1292.json
+++ b/2018/1xxx/CVE-2018-1292.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Fineract",
+                        "product_name" : "Apache Fineract",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1294.json
+++ b/2018/1xxx/CVE-2018-1294.json
@@ -16,7 +16,7 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "All Versions of Commons-Email, from 1.0, to 1.4, inclusive. The current version 1.5 is not affected."
+                                 "version_value" : "versions prior to 1.5"
                               }
                            ]
                         }
@@ -35,7 +35,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "If a user of Commons-Email (typically an application programmer) passes unvalidated input as the so-called \"Bounce Address\", and that input contains line-breaks, then the email details (recipients, contents, etc.) might be manipulated. Mitigation: Users should upgrade to Commons-Email 1.5. You can mitigate this vulnerability for older versions of Commons Email by stripping line-breaks from data, that will be passed to Email.setBounceAddress(String)."
+            "value" : "If a user of Apache Commons Email (typically an application programmer) passes unvalidated input as the so-called \"Bounce Address\", and that input contains line-breaks, then the email details (recipients, contents, etc.) might be manipulated. Mitigation: Users should upgrade to Commons-Email 1.5. You can mitigate this vulnerability for older versions of Commons Email by stripping line-breaks from data, that will be passed to Email.setBounceAddress(String)."
          }
       ]
    },

--- a/2018/1xxx/CVE-2018-1295.json
+++ b/2018/1xxx/CVE-2018-1295.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Ignite",
+                        "product_name" : "Apache Ignite",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1297.json
+++ b/2018/1xxx/CVE-2018-1297.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "JMeter",
+                        "product_name" : "Apache JMeter",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1298.json
+++ b/2018/1xxx/CVE-2018-1298.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Qpid Broker-J",
+                        "product_name" : "Apache Qpid Broker-J",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1299.json
+++ b/2018/1xxx/CVE-2018-1299.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Allura",
+                        "product_name" : "Apache Allura",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1306.json
+++ b/2018/1xxx/CVE-2018-1306.json
@@ -12,11 +12,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Apache Portals Pluto",
+                        "product_name" : "Apache Pluto",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "Apache Portals Pluto version 3.0.0"
+                                 "version_value" : "3.0.0"
                               }
                            ]
                         }
@@ -35,7 +35,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "The PortletV3AnnotatedDemo Multipart Portlet war file code provided in Pluto version 3.0.0 could allow a remote attacker to obtain sensitive information, caused by the failure to restrict path information provided during a file upload. An attacker could exploit this vulnerability to obtain configuration data and other sensitive information."
+            "value" : "The PortletV3AnnotatedDemo Multipart Portlet war file code provided in Apache Pluto version 3.0.0 could allow a remote attacker to obtain sensitive information, caused by the failure to restrict path information provided during a file upload. An attacker could exploit this vulnerability to obtain configuration data and other sensitive information."
          }
       ]
    },

--- a/2018/1xxx/CVE-2018-1307.json
+++ b/2018/1xxx/CVE-2018-1307.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "jUDDI",
+                        "product_name" : "Apache jUDDI",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1308.json
+++ b/2018/1xxx/CVE-2018-1308.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Solr",
+                        "product_name" : "Apache Solr",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1309.json
+++ b/2018/1xxx/CVE-2018-1309.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "NiFi",
+                        "product_name" : "Apache NiFi",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1310.json
+++ b/2018/1xxx/CVE-2018-1310.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "NiFi",
+                        "product_name" : "Apache NiFi",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1313.json
+++ b/2018/1xxx/CVE-2018-1313.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Derby",
+                        "product_name" : "Apache Derby",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1315.json
+++ b/2018/1xxx/CVE-2018-1315.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Hive",
+                        "product_name" : "Apache Hive",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1316.json
+++ b/2018/1xxx/CVE-2018-1316.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "ODE",
+                        "product_name" : "Apache ODE",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1319.json
+++ b/2018/1xxx/CVE-2018-1319.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Allura",
+                        "product_name" : "Apache Allura",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1323.json
+++ b/2018/1xxx/CVE-2018-1323.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Apache Tomcat JK ISAPI Connector",
+                        "product_name" : "Apache Tomcat Connectors",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1324.json
+++ b/2018/1xxx/CVE-2018-1324.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Commons Compress",
+                        "product_name" : "Apache Commons Compress",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1331.json
+++ b/2018/1xxx/CVE-2018-1331.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Storm",
+                        "product_name" : "Apache Storm",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1334.json
+++ b/2018/1xxx/CVE-2018-1334.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Spark",
+                        "product_name" : "Apache Spark",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1335.json
+++ b/2018/1xxx/CVE-2018-1335.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tika",
+                        "product_name" : "Apache Tika",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1336.json
+++ b/2018/1xxx/CVE-2018-1336.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1337.json
+++ b/2018/1xxx/CVE-2018-1337.json
@@ -12,11 +12,11 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "LDAP API",
+                        "product_name" : "Apache Directory",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "1.0.2"
+                                 "version_value" : "LDAP API prior to 1.0.2"
                               }
                            ]
                         }
@@ -35,7 +35,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "In Apache LDAP API before 1.0.2, a bug in the way the SSL Filter was setup made it possible for another thread to use the connection before the TLS layer has been established, if the connection has already been used and put back in a pool of connections, leading to leaking any information contained in this request (including the credentials when sending a BIND request)."
+            "value" : "In Apache Directory LDAP API before 1.0.2, a bug in the way the SSL Filter was setup made it possible for another thread to use the connection before the TLS layer has been established, if the connection has already been used and put back in a pool of connections, leading to leaking any information contained in this request (including the credentials when sending a BIND request)."
          }
       ]
    },

--- a/2018/1xxx/CVE-2018-1338.json
+++ b/2018/1xxx/CVE-2018-1338.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tika",
+                        "product_name" : "Apache Tika",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/1xxx/CVE-2018-1339.json
+++ b/2018/1xxx/CVE-2018-1339.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tika",
+                        "product_name" : "Apache Tika",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8006.json
+++ b/2018/8xxx/CVE-2018-8006.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "ActiveMQ",
+                        "product_name" : "Apache ActiveMQ",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8007.json
+++ b/2018/8xxx/CVE-2018-8007.json
@@ -12,11 +12,14 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CouchDB",
+                        "product_name" : "Apache CouchDB",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "versions up to and including 1.7.1, and 2.1.1"
+                                 "version_value" : "< 1.7.2"
+                              },
+                              {
+                                 "version_value" : "2.0.0 to 2.1.1"
                               }
                            ]
                         }

--- a/2018/8xxx/CVE-2018-8013.json
+++ b/2018/8xxx/CVE-2018-8013.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Batik",
+                        "product_name" : "Apache Batik",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8014.json
+++ b/2018/8xxx/CVE-2018-8014.json
@@ -11,18 +11,27 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                 "version_value" : "9.0.0.M1 to 9.0.8"
+                              },
+                              {
+                                 "version_value" : "8.5.0 to 8.5.31"
+                              },
+                              {
+                                 "version_value" : "8.0.0.RC1 to 8.0.52"
+                              },
+                              {
+                                 "version_value" : "7.0.41 to 7.0.88"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Apache Software Foundation"
             }
          ]
       }

--- a/2018/8xxx/CVE-2018-8015.json
+++ b/2018/8xxx/CVE-2018-8015.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "ORC",
+                        "product_name" : "Apache ORC",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8017.json
+++ b/2018/8xxx/CVE-2018-8017.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tika",
+                        "product_name" : "Apache Tika",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8018.json
+++ b/2018/8xxx/CVE-2018-8018.json
@@ -12,11 +12,14 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Ignite",
+                        "product_name" : "Apache Ignite",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "2.5 and earlier"
+                                 "version_value" : "2.5.x before 2.5.3"
+                              },
+                              {
+                                 "version_value" : "2.4.x before 2.4.8"
                               }
                            ]
                         }

--- a/2018/8xxx/CVE-2018-8019.json
+++ b/2018/8xxx/CVE-2018-8019.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat Native Connector",
+                        "product_name" : "Apache Tomcat Native",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8020.json
+++ b/2018/8xxx/CVE-2018-8020.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat Native Connector",
+                        "product_name" : "Apache Tomcat Native",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8021.json
+++ b/2018/8xxx/CVE-2018-8021.json
@@ -15,14 +15,14 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "Superset prior to 0.23"
+                                 "version_value" : "prior to 0.23"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "Apache Software Foundation"
+               "vendor_name" : ""
             }
          ]
       }

--- a/2018/8xxx/CVE-2018-8023.json
+++ b/2018/8xxx/CVE-2018-8023.json
@@ -12,11 +12,17 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Mesos",
+                        "product_name" : "Apache Mesos",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "1.4.0 to 1.6.0"
+                                 "version_value" : "versions prior to 1.4.2"
+                              },
+                              {
+                                 "version_value" : "1.5.0, 1.5.1"
+                              },
+                              {
+                                 "version_value" : "1.6.0"
                               }
                            ]
                         }

--- a/2018/8xxx/CVE-2018-8024.json
+++ b/2018/8xxx/CVE-2018-8024.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Spark",
+                        "product_name" : "Apache Spark",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8026.json
+++ b/2018/8xxx/CVE-2018-8026.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Solr",
+                        "product_name" : "Apache Solr",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8027.json
+++ b/2018/8xxx/CVE-2018-8027.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Camel",
+                        "product_name" : "Apache Camel",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8030.json
+++ b/2018/8xxx/CVE-2018-8030.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Qpid Broker-J",
+                        "product_name" : "Apache Qpid Broker-J",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8031.json
+++ b/2018/8xxx/CVE-2018-8031.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "TomEE",
+                        "product_name" : "Apache TomEE",
                         "version" : {
                            "version_data" : [
                               {
@@ -35,7 +35,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "The TomEE console (tomee-webapp) has a XSS vulnerability which could allow javascript to be executed if the user is given a malicious URL. This web application is typically used to add TomEE features to a Tomcat installation. The TomEE bundles do not ship with this application included. This issue can be mitigated by removing the application after TomEE is setup (if using the application to install TomEE), using one of the provided pre-configured bundles, or by upgrading to TomEE 7.0.5. This issue is resolve in this commit: b8bbf50c23ce97dd64f3a5d77f78f84e47579863."
+            "value" : "The Apache TomEE console (tomee-webapp) has a XSS vulnerability which could allow javascript to be executed if the user is given a malicious URL. This web application is typically used to add TomEE features to a Tomcat installation. The TomEE bundles do not ship with this application included. This issue can be mitigated by removing the application after TomEE is setup (if using the application to install TomEE), using one of the provided pre-configured bundles, or by upgrading to TomEE 7.0.5. This issue is resolve in this commit: b8bbf50c23ce97dd64f3a5d77f78f84e47579863."
          }
       ]
    },

--- a/2018/8xxx/CVE-2018-8032.json
+++ b/2018/8xxx/CVE-2018-8032.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Axis",
+                        "product_name" : "Apache Axis",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8034.json
+++ b/2018/8xxx/CVE-2018-8034.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8036.json
+++ b/2018/8xxx/CVE-2018-8036.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "PDFBox",
+                        "product_name" : "Apache PDFBox",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8037.json
+++ b/2018/8xxx/CVE-2018-8037.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Tomcat",
+                        "product_name" : "Apache Tomcat",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8038.json
+++ b/2018/8xxx/CVE-2018-8038.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CXF Fediz",
+                        "product_name" : "Apache CXF Fediz",
                         "version" : {
                            "version_data" : [
                               {

--- a/2018/8xxx/CVE-2018-8039.json
+++ b/2018/8xxx/CVE-2018-8039.json
@@ -12,11 +12,14 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "CXF",
+                        "product_name" : "Apache CXF",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "prior to 3.2.5 and 3.1.16"
+                                 "version_value" : "prior to 3.1.16"
+                              },
+                              {
+                                 "version_value" : "3.2.x prior to 3.2.5"
                               }
                            ]
                         }

--- a/2018/8xxx/CVE-2018-8042.json
+++ b/2018/8xxx/CVE-2018-8042.json
@@ -12,7 +12,7 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "Ambari",
+                        "product_name" : "Apache Ambari",
                         "version" : {
                            "version_data" : [
                               {


### PR DESCRIPTION
Note: This is a non-time-sensitive update given then number of entries changed.

We went through all entries assigned from security@apache.org (Apache CNA) and ensure that the product names are correct and consistent (which in most cases means adding "Apache", but some required more work). Make sure the vendor name is correct.  Make sure affected versions matches the text somewhat, although we don't try to make every product write these in the same way, they're not supposed to be totally machine readable.  Then make some fixes to the text as required where there are mistakes or inconsistencies or the Apache name isn't mentioned.  There are 5 left untouched for now, one is known (where we assigned an issues to an incubator version which came out prior to being part of Apache), and four which need more work.