### PR TITLE
CVE-2018-12547 and CVE-2018-12549.

### DIFF
--- a/2018/12xxx/CVE-2018-12547.json
+++ b/2018/12xxx/CVE-2018-12547.json
@@ -1,8 +1,32 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "emo@eclipse.org",
       "ID" : "CVE-2018-12547",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Eclipse OpenJ9",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "<",
+                                 "version_value" : "0.12.0"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "The Eclipse Foundation"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +35,28 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "In Eclipse OpenJ9, prior to the 0.12.0 release, the jio_snprintf() and jio_vsnprintf() native methods ignored the length parameter.  This affects existing APIs that called the functions to exceed the allocated buffer. This functions were not directly callable by non-native user code."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-20: Improper Input Validation"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "name" : "https://bugs.eclipse.org/bugs/show_bug.cgi?id=543659",
+            "refsource" : "CONFIRM",
+            "url" : "https://bugs.eclipse.org/bugs/show_bug.cgi?id=543659"
          }
       ]
    }

--- a/2018/12xxx/CVE-2018-12549.json
+++ b/2018/12xxx/CVE-2018-12549.json
@@ -1,8 +1,32 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "emo@eclipse.org",
       "ID" : "CVE-2018-12549",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Eclipse OpenJ9",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "=",
+                                 "version_value" : "0.11.0"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "The Eclipse Foundation"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +35,28 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "In Eclipse OpenJ9 version 0.11.0, the OpenJ9 JIT compiler may incorrectly omit a null check on the receiver object of an Unsafe call when accelerating it."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-111: Direct Use of Unsafe JNI"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "name" : "https://bugs.eclipse.org/bugs/show_bug.cgi?id=544019",
+            "refsource" : "CONFIRM",
+            "url" : "https://bugs.eclipse.org/bugs/show_bug.cgi?id=544019"
          }
       ]
    }


### PR DESCRIPTION
For the Eclipse OpenJ9 Project.