### PR TITLE
Editing CVE-2014-3004

### DIFF
--- a/2014/3xxx/CVE-2014-3004.json
+++ b/2014/3xxx/CVE-2014-3004.json
@@ -11,18 +11,19 @@
                "product" : {
                   "product_data" : [
                      {
-                        "product_name" : "n/a",
+                        "product_name" : "Xerces SAX Parser",
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "n/a"
+                                  "affected" : "<",
+                                  "version_value" : "1.3.3"
                               }
                            ]
                         }
                      }
                   ]
                },
-               "vendor_name" : "n/a"
+               "vendor_name" : "Xerces"
             }
          ]
       }
@@ -76,6 +77,11 @@
             "name" : "59427",
             "refsource" : "SECUNIA",
             "url" : "http://secunia.com/advisories/59427"
+         },
+         {
+            "name" : "CSCvm56811",
+            "refsource" : "CISCO",
+            "url" : "https://quickview.cloudapps.cisco.com/quickview/bug/CSCvm56811"
          }
       ]
    }


### PR DESCRIPTION
Added additional information to the product data (since it had no information). Added information about the impact of this open source vulnerability in Cisco product via CSCvm56811.