### PR TITLE
CVE-2018-9867

### DIFF
--- a/2018/9xxx/CVE-2018-9867.json
+++ b/2018/9xxx/CVE-2018-9867.json
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "In SonicWall SonicOS, administrators without full permissions can download imported certificates. Occurs when administrators who are not in the SonicWall Administrators user group attempt to download imported certificates."
+            "value" : "In SonicWall SonicOS, administrators without full permissions can download imported certificates. Occurs when administrators who are not in the SonicWall Administrators user group attempt to download imported certificates. This vulnerability affected SonicOS Gen 5 version 5.9.1.10 and earlier."
          }
       ]
    },

--- a/2018/9xxx/CVE-2018-9867.json
+++ b/2018/9xxx/CVE-2018-9867.json
@@ -34,7 +34,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "Administrators without full permissions can download imported certificates. Occurs when administrators who are not in the SonicWall Administrators user group attempt to download imported certificates."
+            "value" : "In SonicWall SonicOS, administrators without full permissions can download imported certificates. Occurs when administrators who are not in the SonicWall Administrators user group attempt to download imported certificates."
          }
       ]
    },

--- a/2018/9xxx/CVE-2018-9867.json
+++ b/2018/9xxx/CVE-2018-9867.json
@@ -1,8 +1,31 @@
 {
    "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
+      "ASSIGNER" : "psirt@sonicwall.com",
       "ID" : "CVE-2018-9867",
-      "STATE" : "RESERVED"
+      "STATE" : "PUBLIC"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
+            {
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "SonicOS",
+                        "version" : {
+                           "version_data" : [                            
+                              {
+                                 "version_value" : "5.9.1.10 and earlier"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "SonicWall"
+            }
+         ]
+      }
    },
    "data_format" : "MITRE",
    "data_type" : "CVE",
@@ -11,7 +34,28 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "value" : "Administrators without full permissions can download imported certificates. Occurs when administrators who are not in the SonicWall Administrators user group attempt to download imported certificates."
+         }
+      ]
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "CWE-285: Improper Authorization"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "name" : "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2018-0017",
+            "refsource" : "CONFIRM",
+            "url" : "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2018-0017"
          }
       ]
    }


### PR DESCRIPTION
SonicOS administrators without full permissions can download imported certificates.