### PR TITLE
Publishing CVE-2019-3582

### DIFF
--- a/2019/3xxx/CVE-2019-3582.json
+++ b/2019/3xxx/CVE-2019-3582.json
@@ -1,18 +1,99 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2019-3582",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "psirt@mcafee.com",
+      "ID": "CVE-2019-3582",
+      "STATE": "PUBLIC",
+      "TITLE": "McAfee Endpoint Security updates fix a privilege escalation vulnerability"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "McAfee Endpoint Security (ENS)",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<",
+                                 "version_name": "10.5.3",
+                                 "version_value": "10.5.3 Hotfix 1240838"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "10.5.4",
+                                 "version_value": "10.5.4 Hotfix 1240838"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "10.5.5",
+                                 "version_value": "10.5.5 Nov 2018 update"
+                              },
+                              {
+                                 "affected": "<",
+                                 "version_name": "10.6.1",
+                                 "version_value": "10.6.1 Nov 2018 update"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "McAfee, LLC"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Privilege Escalation vulnerability in Microsoft Windows client in McAfee Endpoint Security (ENS) 10.6.1 and earlier allows local users to gain elevated privileges via a specific set of circumstances."
          }
       ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "LOCAL",
+         "availabilityImpact": "HIGH",
+         "baseScore": 8.6,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "NONE",
+         "scope": "CHANGED",
+         "userInteraction": "REQUIRED",
+         "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Privilege Escalation vulnerability"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kc.mcafee.com/corporate/index?page=content&id=SB10254",
+            "refsource": "CONFIRM",
+            "url": "https://kc.mcafee.com/corporate/index?page=content&id=SB10254"
+         }
+      ]
+   },
+   "source": {
+      "discovery": "EXTERNAL"
    }
 }


### PR DESCRIPTION
Initial publication - the SB went live 1/2 hour ago.