### PR TITLE
CVE-2018-9867 update and CVE-2019-7474, 5 and 6 related to SonicWall SonicOS

### DIFF
--- a/2018/9xxx/CVE-2018-9867.json
+++ b/2018/9xxx/CVE-2018-9867.json
@@ -11,15 +11,58 @@
                     "product": {
                         "product_data": [
                             {
-                                "product_name": "SonicOS",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "5.9.1.10 and earlier"
-                                        }
-                                    ]
+                                "product_name" : "SonicOS",
+                                "version" : {
+                                   "version_data" : [                              
+                                      {
+                                         "version_value" : "5.9.1.10 and earlier"
+                                      },                              
+                                      {
+                                         "version_value" : "6.2.7.3"
+                                      },                              
+                                      {
+                                         "version_value" : "6.5.1.3"
+                                      },
+                                      {
+                                         "version_value" : "6.5.2.2"
+                                      },                              
+                                      {
+                                         "version_value" : "6.5.3.1"
+                                      },
+                                      {
+                                         "version_value" : "6.2.7.8"
+                                      },
+                                      {
+                                         "version_value" : "6.4.0.0"
+                                      },                              
+                                      {
+                                         "version_value" : "6.5.1.8"
+                                      },
+                                      {
+                                         "version_value" : "6.0.5.3-86o"
+                                      }
+                                   ]
                                 }
-                            }
+                             },                      
+                             {
+                                "product_name" : "SonicOSv",
+                                "version" : {
+                                   "version_data" : [                              
+                                      {
+                                         "version_value" : "6.5.0.2-8v_RC363 (VMWARE)"
+                                      },                              
+                                      {
+                                         "version_value" : "6.5.0.2.8v_RC367 (AZURE)"
+                                      },                              
+                                      {
+                                         "version_value" : "6.5.0.2.8v_RC368 (AWS)"
+                                      },
+                                      {
+                                         "version_value" : "6.5.0.2.8v_RC366 (HYPER_V)"
+                                      }
+                                   ]
+                                }
+                             }
                         ]
                     },
                     "vendor_name": "SonicWall"

--- a/2018/9xxx/CVE-2018-9867.json
+++ b/2018/9xxx/CVE-2018-9867.json
@@ -77,7 +77,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In SonicWall SonicOS, administrators without full permissions can download imported certificates. Occurs when administrators who are not in the SonicWall Administrators user group attempt to download imported certificates. This vulnerability affected SonicOS Gen 5 version 5.9.1.10 and earlier."
+                "value": "In SonicWall SonicOS, administrators without full permissions can download imported certificates. Occurs when administrators who are not in the SonicWall Administrators user group attempt to download imported certificates. This vulnerability affected SonicOS Gen 5 version 5.9.1.10 and earlier, Gen 6 version 6.2.7.3, 6.5.1.3, 6.5.2.2, 6.5.3.1, 6.2.7.8, 6.4.0.0, 6.5.1.8, 6.0.5.3-86o and SonicOSv 6.5.0.2-8v_RC363 (VMWARE), 6.5.0.2.8v_RC367 (AZURE), SonicOSv 6.5.0.2.8v_RC368 (AWS), SonicOSv 6.5.0.2.8v_RC366 (HYPER_V)."
             }
         ]
     },

--- a/2019/7xxx/CVE-2019-7474.json
+++ b/2019/7xxx/CVE-2019-7474.json
@@ -1,18 +1,106 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-7474",
-        "STATE": "RESERVED"
+    "CVE_data_meta" : {
+       "ASSIGNER" : "psirt@sonicwall.com",
+       "ID" : "CVE-2019-7474",
+       "STATE" : "PUBLIC"
     },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+    "affects" : {
+       "vendor" : {
+          "vendor_data" : [
+             {
+                "product" : {
+                   "product_data" : [
+                      {
+                         "product_name" : "SonicOS",
+                         "version" : {
+                            "version_data" : [                              
+                               {
+                                  "version_value" : "5.9.1.10 and earlier"
+                               },                              
+                               {
+                                  "version_value" : "6.2.7.3"
+                               },                              
+                               {
+                                  "version_value" : "6.5.1.3"
+                               },
+                               {
+                                  "version_value" : "6.5.2.2"
+                               },                              
+                               {
+                                  "version_value" : "6.5.3.1"
+                               },
+                               {
+                                  "version_value" : "6.2.7.8"
+                               },
+                               {
+                                  "version_value" : "6.4.0.0"
+                               },                              
+                               {
+                                  "version_value" : "6.5.1.8"
+                               },
+                               {
+                                  "version_value" : "6.0.5.3-86o"
+                               }
+                            ]
+                         }
+                      },
+                      {
+                         "product_name" : "SonicOSv",
+                         "version" : {
+                            "version_data" : [                              
+                               {
+                                  "version_value" : "6.5.0.2-8v_RC363 (VMWARE)"
+                               },                              
+                               {
+                                  "version_value" : "6.5.0.2.8v_RC367 (AZURE)"
+                               },                              
+                               {
+                                  "version_value" : "6.5.0.2.8v_RC368 (AWS)"
+                               },
+                               {
+                                  "version_value" : "6.5.0.2.8v_RC366 (HYPER_V)"
+                               }
+                            ]
+                         }
+                      }
+                   ]
+                },
+                "vendor_name" : "SonicWall"
+             }
+          ]
+       }
+    },
+    "data_format" : "MITRE",
+    "data_type" : "CVE",
+    "data_version" : "4.0",
+    "description" : {
+       "description_data" : [
+          {
+             "lang" : "eng",
+             "value" : "A vulnerability in SonicWall SonicOS and SonicOSv, allow authenticated read-only admin to leave the firewall in an unstable state by downloading certificate with specific extension. This vulnerability affected SonicOS Gen 5 version 5.9.1.10 and earlier, Gen 6 version 6.2.7.3, 6.5.1.3, 6.5.2.2, 6.5.3.1, 6.2.7.8, 6.4.0.0, 6.5.1.8, 6.0.5.3-86o and SonicOSv 6.5.0.2-8v_RC363 (VMWARE), 6.5.0.2.8v_RC367 (AZURE), SonicOSv 6.5.0.2.8v_RC368 (AWS), SonicOSv 6.5.0.2.8v_RC366 (HYPER_V)."
+          }
+       ]
+    },
+    "problemtype" : {
+       "problemtype_data" : [
+          {
+             "description" : [
+                {
+                   "lang" : "eng",
+                   "value" : "CWE-248: Uncaught Exception"
+                }
+             ]
+          }
+       ]
+    },
+    "references" : {
+       "reference_data" : [
+          {
+             "name" : "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2019-0001",
+             "refsource" : "CONFIRM",
+             "url" : "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2019-0001"
+          }
+       ]
     }
-}
+ }
+ 

--- a/2019/7xxx/CVE-2019-7475.json
+++ b/2019/7xxx/CVE-2019-7475.json
@@ -1,18 +1,106 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-7475",
-        "STATE": "RESERVED"
+    "CVE_data_meta" : {
+       "ASSIGNER" : "psirt@sonicwall.com",
+       "ID" : "CVE-2019-7475",
+       "STATE" : "PUBLIC"
     },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+    "affects" : {
+       "vendor" : {
+          "vendor_data" : [
+             {
+                "product" : {
+                   "product_data" : [
+                      {
+                         "product_name" : "SonicOS",
+                         "version" : {
+                            "version_data" : [                              
+                               {
+                                  "version_value" : "5.9.1.10 and earlier"
+                               },                              
+                               {
+                                  "version_value" : "6.2.7.3"
+                               },                              
+                               {
+                                  "version_value" : "6.5.1.3"
+                               },
+                               {
+                                  "version_value" : "6.5.2.2"
+                               },                              
+                               {
+                                  "version_value" : "6.5.3.1"
+                               },
+                               {
+                                  "version_value" : "6.2.7.8"
+                               },
+                               {
+                                  "version_value" : "6.4.0.0"
+                               },                              
+                               {
+                                  "version_value" : "6.5.1.8"
+                               },
+                               {
+                                  "version_value" : "6.0.5.3-86o"
+                               }
+                            ]
+                         }
+                      },
+                      {
+                         "product_name" : "SonicOSv",
+                         "version" : {
+                            "version_data" : [                              
+                               {
+                                  "version_value" : "6.5.0.2-8v_RC363 (VMWARE)"
+                               },                              
+                               {
+                                  "version_value" : "6.5.0.2.8v_RC367 (AZURE)"
+                               },                              
+                               {
+                                  "version_value" : "6.5.0.2.8v_RC368 (AWS)"
+                               },
+                               {
+                                  "version_value" : "6.5.0.2.8v_RC366 (HYPER_V)"
+                               }
+                            ]
+                         }
+                      }
+                   ]
+                },
+                "vendor_name" : "SonicWall"
+             }
+          ]
+       }
+    },
+    "data_format" : "MITRE",
+    "data_type" : "CVE",
+    "data_version" : "4.0",
+    "description" : {
+       "description_data" : [
+          {
+             "lang" : "eng",
+             "value" : "A vulnerability in SonicWall SonicOS and SonicOSv with management enabled system on specific configuration allow unprivileged user to access advanced routing services. This vulnerability affected SonicOS Gen 5 version 5.9.1.10 and earlier, Gen 6 version 6.2.7.3, 6.5.1.3, 6.5.2.2, 6.5.3.1, 6.2.7.8, 6.4.0.0, 6.5.1.8, 6.0.5.3-86o and SonicOSv 6.5.0.2-8v_RC363 (VMWARE), 6.5.0.2.8v_RC367 (AZURE), SonicOSv 6.5.0.2.8v_RC368 (AWS), SonicOSv 6.5.0.2.8v_RC366 (HYPER_V)."
+          }
+       ]
+    },
+    "problemtype" : {
+       "problemtype_data" : [
+          {
+             "description" : [
+                {
+                   "lang" : "eng",
+                   "value" : "CWE-284: Improper Access Control"
+                }
+             ]
+          }
+       ]
+    },
+    "references" : {
+       "reference_data" : [
+          {
+             "name" : "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2019-0002",
+             "refsource" : "CONFIRM",
+             "url" : "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2019-0002"
+          }
+       ]
     }
-}
+ }
+ 

--- a/2019/7xxx/CVE-2019-7477.json
+++ b/2019/7xxx/CVE-2019-7477.json
@@ -1,18 +1,106 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-7477",
-        "STATE": "RESERVED"
+    "CVE_data_meta" : {
+       "ASSIGNER" : "psirt@sonicwall.com",
+       "ID" : "CVE-2019-7477",
+       "STATE" : "PUBLIC"
     },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+    "affects" : {
+       "vendor" : {
+          "vendor_data" : [
+             {
+                "product" : {
+                   "product_data" : [
+                      {
+                         "product_name" : "SonicOS",
+                         "version" : {
+                            "version_data" : [                              
+                               {
+                                  "version_value" : "5.9.1.10 and earlier"
+                               },                              
+                               {
+                                  "version_value" : "6.2.7.3"
+                               },                              
+                               {
+                                  "version_value" : "6.5.1.3"
+                               },
+                               {
+                                  "version_value" : "6.5.2.2"
+                               },                              
+                               {
+                                  "version_value" : "6.5.3.1"
+                               },
+                               {
+                                  "version_value" : "6.2.7.8"
+                               },
+                               {
+                                  "version_value" : "6.4.0.0"
+                               },                              
+                               {
+                                  "version_value" : "6.5.1.8"
+                               },
+                               {
+                                  "version_value" : "6.0.5.3-86o"
+                               }
+                            ]
+                         }
+                      },
+                      {
+                         "product_name" : "SonicOSv",
+                         "version" : {
+                            "version_data" : [                              
+                               {
+                                  "version_value" : "6.5.0.2-8v_RC363 (VMWARE)"
+                               },                              
+                               {
+                                  "version_value" : "6.5.0.2.8v_RC367 (AZURE)"
+                               },                              
+                               {
+                                  "version_value" : "6.5.0.2.8v_RC368 (AWS)"
+                               },
+                               {
+                                  "version_value" : "6.5.0.2.8v_RC366 (HYPER_V)"
+                               }
+                            ]
+                         }
+                      }
+                   ]
+                },
+                "vendor_name" : "SonicWall"
+             }
+          ]
+       }
+    },
+    "data_format" : "MITRE",
+    "data_type" : "CVE",
+    "data_version" : "4.0",
+    "description" : {
+       "description_data" : [
+          {
+             "lang" : "eng",
+             "value" : "A vulnerability in SonicWall SonicOS and SonicOSv TLS CBC Cipher allow remote attackers to obtain sensitive plaintext data when CBC cipher suites are enabled. This vulnerability affected SonicOS Gen 5 version 5.9.1.10 and earlier, Gen 6 version 6.2.7.3, 6.5.1.3, 6.5.2.2, 6.5.3.1, 6.2.7.8, 6.4.0.0, 6.5.1.8, 6.0.5.3-86o and SonicOSv 6.5.0.2-8v_RC363 (VMWARE), 6.5.0.2.8v_RC367 (AZURE), SonicOSv 6.5.0.2.8v_RC368 (AWS), SonicOSv 6.5.0.2.8v_RC366 (HYPER_V)."
+          }
+       ]
+    },
+    "problemtype" : {
+       "problemtype_data" : [
+          {
+             "description" : [
+                {
+                   "lang" : "eng",
+                   "value" : "CWE-327: Use of a Broken or Risky Cryptographic Algorithm"
+                }
+             ]
+          }
+       ]
+    },
+    "references" : {
+       "reference_data" : [
+          {
+             "name" : "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2019-0003",
+             "refsource" : "CONFIRM",
+             "url" : "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2019-0003"
+          }
+       ]
     }
-}
+ }
+ 


### PR DESCRIPTION
Updating CVE-2018-9867 by adding additional affected products. Adding CVE-2019-7474, 5 and 6 related to SonicWall SonicOS and SonicOSv vulnerabilities. 