### PR TITLE
Update CVE-2017-7649.json

### DIFF
--- a/2017/7xxx/CVE-2017-7649.json
+++ b/2017/7xxx/CVE-2017-7649.json
@@ -12,11 +12,12 @@
                     "product": {
                         "product_data": [
                             {
-                                "product_name": "Kura",
+                                "product_name": "Eclipse Kura Installer",
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "Versions prior to 2.1.0"
+                                            "version_affected": "<",
+                                            "version_value": "2.1.0"
                                         }
                                     ]
                                 }


### PR DESCRIPTION
The current CVE gives the impression that the issue impacts the entire Eclipse Kura product. This patch refines the CVE to indicate that the only element affected by this issue is the Kura Installer. While we were there, we decided to tweak the affected version information to be more inline with the pattern established by our more recent contributions.