### PR TITLE
Update CVE-2019-3566 to reflect WhatsApp Business for Android affected versions

### DIFF
--- a/2019/3xxx/CVE-2019-3566.json
+++ b/2019/3xxx/CVE-2019-3566.json
@@ -29,6 +29,21 @@
                                         }
                                     ]
                                 }
+                            },
+                            {
+                                "product_name": "WhatsApp Business for Android",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "2.19.38"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "2.19.22"
+                                        }
+                                    ]
+                                }
                             }
                         ]
                     },
@@ -44,7 +59,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A bug in WhatsApp for Android's messaging logic would potentially allow a malicious individual who has taken over over a WhatsApp user's account to recover previously sent messages. This behavior requires independent knowledge of metadata for previous messages, which are not available publicly. This issue affects WhatsApp for Android 2.19.52 and 2.19.54 - 2.19.103."
+                "value": "A bug in WhatsApp for Android's messaging logic would potentially allow a malicious individual who has taken over over a WhatsApp user's account to recover previously sent messages. This behavior requires independent knowledge of metadata for previous messages, which are not available publicly. This issue affects WhatsApp for Android 2.19.52 and 2.19.54 - 2.19.103, as well as WhatsApp Business for Android starting in v2.19.22 until v2.19.38."
             }
         ]
     },


### PR DESCRIPTION
This should have been noted in the original CVE but was incorrectly omitted.