### PR TITLE
Fix typo in CVE-2019-1003000

### DIFF
--- a/2019/1003xxx/CVE-2019-1003000.json
+++ b/2019/1003xxx/CVE-2019-1003000.json
@@ -17,7 +17,7 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "2.49 and earlier"
+                                            "version_value": "1.49 and earlier"
                                         }
                                     ]
                                 }
@@ -36,7 +36,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A sandbox bypass vulnerability exists in Script Security Plugin 2.49 and earlier in src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovySandbox.java that allows attackers with the ability to provide sandboxed scripts to execute arbitrary code on the Jenkins master JVM."
+                "value": "A sandbox bypass vulnerability exists in Script Security Plugin 1.49 and earlier in src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovySandbox.java that allows attackers with the ability to provide sandboxed scripts to execute arbitrary code on the Jenkins master JVM."
             }
         ]
     },


### PR DESCRIPTION
See https://jenkins.io/security/advisory/2019-01-08/#affected-versions

This resolves service request 660041 at Mitre, which I apparently am unable to respond to via email.