### PR TITLE
Update CVE-2018-6674

### DIFF
--- a/2018/6xxx/CVE-2018-6674.json
+++ b/2018/6xxx/CVE-2018-6674.json
@@ -1,10 +1,9 @@
 {
     "CVE_data_meta": {
         "ASSIGNER": "psirt@mcafee.com",
-        "DATE_PUBLIC": "2018-05-09T17:00:00.000Z",
         "ID": "CVE-2018-6674",
         "STATE": "PUBLIC",
-        "TITLE": "SB10237 -  VirusScan Enterprise (VSE) - Privilege Escalation vulnerability"
+        "TITLE": "Privilege escalation vulnerability in McAfee VSE when McTray run with elevated privileges"
     },
     "affects": {
         "vendor": {
@@ -17,17 +16,17 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "affected": "<",
-                                            "platform": "x86",
+                                            "platform": "Windows",
+                                            "version_affected": "<",
                                             "version_name": "8.8",
-                                            "version_value": "8.8 Patch 11"
+                                            "version_value": "8.8 Patch 13"
                                         }
                                     ]
                                 }
                             }
                         ]
                     },
-                    "vendor_name": "McAfee"
+                    "vendor_name": "McAfee, LLC"
                 }
             ]
         }
@@ -39,9 +38,12 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Privilege Escalation vulnerability in Microsoft Windows client in McAfee VirusScan Enterprise (VSE) 8.8 allows local users to view configuration information in plain text format via the GUI or GUI terminal commands."
+                "value": "Privilege Escalation vulnerability in Microsoft Windows client (McTray.exe) in McAfee VirusScan Enterprise (VSE) 8.8 prior to Patch 13 allows local users to spawn unrelated processes with elevated privileges via the system administrator granting McTray.exe elevated privileges (by default it runs with the current user's privileges)."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
     },
     "impact": {
         "cvss": {
@@ -65,7 +67,23 @@
                 "description": [
                     {
                         "lang": "eng",
-                        "value": "Privilege Escalation vulnerability"
+                        "value": "Permissions, Privileges, and Access Control (CWE-264)"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Privilege Escalation (CWE-274)"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Data Leakage via Privilege Escalation (CWE-269)"
                     }
                 ]
             }
@@ -73,16 +91,6 @@
     },
     "references": {
         "reference_data": [
-            {
-                "name": "104180",
-                "refsource": "BID",
-                "url": "http://www.securityfocus.com/bid/104180"
-            },
-            {
-                "name": "1040893",
-                "refsource": "SECTRACK",
-                "url": "http://www.securitytracker.com/id/1040893"
-            },
             {
                 "name": "https://kc.mcafee.com/corporate/index?page=content&id=SB10237",
                 "refsource": "CONFIRM",


### PR DESCRIPTION
Updating this CVE rather than issuing a new one for this variant as they are chained, so I believe count as the same issue.  Taken us longer than expected to close out the vector.
The description has changed a lot, as we've dug into the issue the realised it needed updating.
When updating the JSON I see this in the current public version and not in the new version I've submitted.  No idea what this is or what I should do with it.
 "reference_data": [
            {
                "name": "104180",
                "refsource": "BID",
                "url": "http://www.securityfocus.com/bid/104180"
            },
            {
                "name": "1040893",
                "refsource": "SECTRACK",
                "url": "http://www.securitytracker.com/id/1040893"
            },