### PR TITLE
Upstream did not merge fix in 2.9 so it is still affected

### DIFF
--- a/2019/10xxx/CVE-2019-10137.json
+++ b/2019/10xxx/CVE-2019-10137.json
@@ -18,7 +18,7 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "spacewalk through 2.8"
+                                            "version_value": "spacewalk through 2.9"
                                         }
                                     ]
                                 }
@@ -54,7 +54,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A path traversal flaw was found in spacewalk-proxy, all versions through 2.8, in the way the proxy processes cached client tokens. A remote, unauthenticated attacker could use this flaw to test the existence of arbitrary files, if they have access to the proxy's filesystem, or can execute arbitrary code in the context of the httpd process."
+                "value": "A path traversal flaw was found in spacewalk-proxy, all versions through 2.9, in the way the proxy processes cached client tokens. A remote, unauthenticated attacker could use this flaw to test the existence of arbitrary files, if they have access to the proxy's filesystem, or can execute arbitrary code in the context of the httpd process."
             }
         ]
     },


### PR DESCRIPTION
Sorry it took whole day, but can we please merge this update as the version 2.8 implying version 2.9 is safe is misleading users.
Thank you.
Marian