### PR TITLE
Upstream did not merge fix in 2.9 so it is stil laffected.

### DIFF
--- a/2019/10xxx/CVE-2019-10136.json
+++ b/2019/10xxx/CVE-2019-10136.json
@@ -18,7 +18,7 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "spacewalk all through 2.8"
+                                            "version_value": "spacewalk all through 2.9"
                                         }
                                     ]
                                 }
@@ -54,7 +54,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "It was found that Spacewalk, all versions through 2.8, did not safely compute client token checksums. An attacker with a valid, but expired, authenticated set of headers could move some digits around, artificially extending the session validity without modifying the checksum."
+                "value": "It was found that Spacewalk, all versions through 2.9, did not safely compute client token checksums. An attacker with a valid, but expired, authenticated set of headers could move some digits around, artificially extending the session validity without modifying the checksum."
             }
         ]
     },


### PR DESCRIPTION
Sorry it took whole day, but can we please merge this update as the version 2.8 implying version 2.9 is safe is misleading users.
Thank you.
Marian