### PR TITLE
Struts version number changes

### DIFF
--- a/2011/5xxx/CVE-2011-5057.json
+++ b/2011/5xxx/CVE-2011-5057.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Apache Struts 2.3.1.1 and earlier provides interfaces that do not properly restrict access to collections such as the session and request collections, which might allow remote attackers to modify run-time data values via a crafted parameter to an application that implements an affected interface, as demonstrated by the SessionAware, RequestAware, ApplicationAware, ServletRequestAware, ServletResponseAware, and ParameterAware interfaces.  NOTE: the vendor disputes the significance of this report because of an \"easy work-around in existing apps by configuring the interceptor.\""
+                "value": "Apache Struts 2.3.1.2 and earlier, 2.3.19-2.3.23, provides interfaces that do not properly restrict access to collections such as the session and request collections, which might allow remote attackers to modify run-time data values via a crafted parameter to an application that implements an affected interface, as demonstrated by the SessionAware, RequestAware, ApplicationAware, ServletRequestAware, ServletResponseAware, and ParameterAware interfaces.  NOTE: the vendor disputes the significance of this report because of an \"easy work-around in existing apps by configuring the interceptor.\""
             }
         ]
     },

--- a/2013/1xxx/CVE-2013-1965.json
+++ b/2013/1xxx/CVE-2013-1965.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Apache Struts Showcase App 2.0.0 through 2.3.13, as used in Struts 2 before 2.3.14.1, allows remote attackers to execute arbitrary OGNL code via a crafted parameter name that is not properly handled when invoking a redirect."
+                "value": "Apache Struts Showcase App 2.0.0 through 2.3.13, as used in Struts 2 before 2.3.14.3, allows remote attackers to execute arbitrary OGNL code via a crafted parameter name that is not properly handled when invoking a redirect."
             }
         ]
     },

--- a/2013/1xxx/CVE-2013-1966.json
+++ b/2013/1xxx/CVE-2013-1966.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Apache Struts 2 before 2.3.14.1 allows remote attackers to execute arbitrary OGNL code via a crafted request that is not properly handled when using the includeParams attribute in the (1) URL or (2) A tag."
+                "value": "Apache Struts 2 before 2.3.14.2 allows remote attackers to execute arbitrary OGNL code via a crafted request that is not properly handled when using the includeParams attribute in the (1) URL or (2) A tag."
             }
         ]
     },

--- a/2014/0xxx/CVE-2014-0094.json
+++ b/2014/0xxx/CVE-2014-0094.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "The ParametersInterceptor in Apache Struts before 2.3.16.1 allows remote attackers to \"manipulate\" the ClassLoader via the class parameter, which is passed to the getClass method."
+                "value": "The ParametersInterceptor in Apache Struts before 2.3.16.2 allows remote attackers to \"manipulate\" the ClassLoader via the class parameter, which is passed to the getClass method."
             }
         ]
     },

--- a/2014/0xxx/CVE-2014-0112.json
+++ b/2014/0xxx/CVE-2014-0112.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "ParametersInterceptor in Apache Struts before 2.3.16.2 does not properly restrict access to the getClass method, which allows remote attackers to \"manipulate\" the ClassLoader and execute arbitrary code via a crafted request.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-0094."
+                "value": "ParametersInterceptor in Apache Struts before 2.3.20 does not properly restrict access to the getClass method, which allows remote attackers to \"manipulate\" the ClassLoader and execute arbitrary code via a crafted request.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-0094."
             }
         ]
     },

--- a/2014/0xxx/CVE-2014-0113.json
+++ b/2014/0xxx/CVE-2014-0113.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "CookieInterceptor in Apache Struts before 2.3.16.2, when a wildcard cookiesName value is used, does not properly restrict access to the getClass method, which allows remote attackers to \"manipulate\" the ClassLoader and execute arbitrary code via a crafted request.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-0094."
+                "value": "CookieInterceptor in Apache Struts before 2.3.20, when a wildcard cookiesName value is used, does not properly restrict access to the getClass method, which allows remote attackers to \"manipulate\" the ClassLoader and execute arbitrary code via a crafted request.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-0094."
             }
         ]
     },

--- a/2014/0xxx/CVE-2014-0116.json
+++ b/2014/0xxx/CVE-2014-0116.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "CookieInterceptor in Apache Struts 2.x before 2.3.16.3, when a wildcard cookiesName value is used, does not properly restrict access to the getClass method, which allows remote attackers to \"manipulate\" the ClassLoader and modify session state via a crafted request.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-0113."
+                "value": "CookieInterceptor in Apache Struts 2.x before 2.3.20, when a wildcard cookiesName value is used, does not properly restrict access to the getClass method, which allows remote attackers to \"manipulate\" the ClassLoader and modify session state via a crafted request.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-0113."
             }
         ]
     },

--- a/2016/3xxx/CVE-2016-3081.json
+++ b/2016/3xxx/CVE-2016-3081.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Apache Struts 2.x before 2.3.20.2, 2.3.24.x before 2.3.24.2, and 2.3.28.x before 2.3.28.1, when Dynamic Method Invocation is enabled, allow remote attackers to execute arbitrary code via method: prefix, related to chained expressions."
+                "value": "Apache Struts 2.3.19 to 2.3.20.2, 2.3.21 to 2.3.24.1, and 2.3.25 to 2.3.28, when Dynamic Method Invocation is enabled, allow remote attackers to execute arbitrary code via method: prefix, related to chained expressions."
             }
         ]
     },

--- a/2016/3xxx/CVE-2016-3087.json
+++ b/2016/3xxx/CVE-2016-3087.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Apache Struts 2.3.20.x before 2.3.20.3, 2.3.24.x before 2.3.24.3, and 2.3.28.x before 2.3.28.1, when Dynamic Method Invocation is enabled, allow remote attackers to execute arbitrary code via vectors related to an ! (exclamation mark) operator to the REST Plugin."
+                "value": "Apache Struts 2.3.19 to 2.3.20.2, 2.3.21 to 2.3.24.1, and 2.3.25 to 2.3.28, when Dynamic Method Invocation is enabled, allow remote attackers to execute arbitrary code via vectors related to an ! (exclamation mark) operator to the REST Plugin."
             }
         ]
     },

--- a/2016/4xxx/CVE-2016-4438.json
+++ b/2016/4xxx/CVE-2016-4438.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "The REST plugin in Apache Struts 2 2.3.20 through 2.3.28.1 allows remote attackers to execute arbitrary code via a crafted expression."
+                "value": "The REST plugin in Apache Struts 2 2.3.19 through 2.3.28.1 allows remote attackers to execute arbitrary code via a crafted expression."
             }
         ]
     },

--- a/2016/6xxx/CVE-2016-6795.json
+++ b/2016/6xxx/CVE-2016-6795.json
@@ -16,7 +16,10 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "2.3.20 - 2.3.30"
+                                            "version_value": "2.3.x before 2.3.31"
+                                        },
+                                        {
+                                            "version_value": "2.5.x before 2.5.5"
                                         }
                                     ]
                                 }
@@ -35,7 +38,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In the Convention plugin in Apache Struts 2.3.20 through 2.3.30, it is possible to prepare a special URL which will be used for path traversal and execution of arbitrary code on server side."
+                "value": "In the Convention plugin in Apache Struts 2.3.x before 2.3.31, and 2.5.x before 2.5.5, it is possible to prepare a special URL which will be used for path traversal and execution of arbitrary code on server side."
             }
         ]
     },

--- a/2017/12xxx/CVE-2017-12611.json
+++ b/2017/12xxx/CVE-2017-12611.json
@@ -16,10 +16,10 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "2.0.1 - 2.3.33"
+                                            "version_value": "2.0.0 - 2.3.33"
                                         },
                                         {
-                                            "version_value": "2.5 - 2.5.10"
+                                            "version_value": "2.5 - 2.5.10.1"
                                         }
                                     ]
                                 }
@@ -38,7 +38,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In Apache Struts 2.0.1 through 2.3.33 and 2.5 through 2.5.10, using an unintentional expression in a Freemarker tag instead of string literals can lead to a RCE attack."
+                "value": "In Apache Struts 2.0.0 through 2.3.33 and 2.5 through 2.5.10.1, using an unintentional expression in a Freemarker tag instead of string literals can lead to a RCE attack."
             }
         ]
     },

--- a/2017/9xxx/CVE-2017-9791.json
+++ b/2017/9xxx/CVE-2017-9791.json
@@ -16,6 +16,9 @@
                                 "version": {
                                     "version_data": [
                                         {
+                                            "version_value": "2.1.x series"
+                                        },
+                                        {
                                             "version_value": "2.3.x series"
                                         }
                                     ]
@@ -35,7 +38,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "The Struts 1 plugin in Apache Struts 2.3.x might allow remote code execution via a malicious field value passed in a raw message to the ActionMessage."
+                "value": "The Struts 1 plugin in Apache Struts 2.1.x and 2.3.x might allow remote code execution via a malicious field value passed in a raw message to the ActionMessage."
             }
         ]
     },

--- a/2017/9xxx/CVE-2017-9793.json
+++ b/2017/9xxx/CVE-2017-9793.json
@@ -20,6 +20,9 @@
                                         },
                                         {
                                             "version_value": "2.5 - 2.5.12"
+                                        },
+                                        {
+                                            "version_value": "2.1.x series"
                                         }
                                     ]
                                 }
@@ -38,7 +41,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "The REST Plugin in Apache Struts 2.3.7 through 2.3.33 and 2.5 through 2.5.12 is using an outdated XStream library which is vulnerable and allow perform a DoS attack using malicious request with specially crafted XML payload."
+                "value": "The REST Plugin in Apache Struts 2.1.x, 2.3.7 through 2.3.33 and 2.5 through 2.5.12 is using an outdated XStream library which is vulnerable and allow perform a DoS attack using malicious request with specially crafted XML payload."
             }
         ]
     },

--- a/2017/9xxx/CVE-2017-9805.json
+++ b/2017/9xxx/CVE-2017-9805.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "The REST Plugin in Apache Struts 2.1.2 through 2.3.x before 2.3.34 and 2.5.x before 2.5.13 uses an XStreamHandler with an instance of XStream for deserialization without any type filtering, which can lead to Remote Code Execution when deserializing XML payloads."
+                "value": "The REST Plugin in Apache Struts 2.1.1 through 2.3.x before 2.3.34 and 2.5.x before 2.5.13 uses an XStreamHandler with an instance of XStream for deserialization without any type filtering, which can lead to Remote Code Execution when deserializing XML payloads."
             }
         ]
     },


### PR DESCRIPTION
A researcher reported a number of cases where Struts affected versions didn't match their research.  These have been updated in the various Struts advisories already.

This patch fixes the CVE entries to match the research and struts updated. advisories.