### PR TITLE
JSON content for CVE-2019-5632, -5633, -5634, -5635

### DIFF
--- a/2019/5xxx/CVE-2019-5632.json
+++ b/2019/5xxx/CVE-2019-5632.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2019-08-01T13:05:00.000Z",
         "ID": "CVE-2019-5632",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Hickory Smart Lock Insecure Storage on Android"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Hickory Smart",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "01.01.43"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Belwith Products, LLC"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered and reported by Deral Heiland of Rapid7. It has been disclosed in accordance with Rapid7's vulnerability disclosure policy (https://www.rapid7.com/disclosure/)."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An insecure storage of sensitive information vulnerability is present in Hickory Smart for Android mobile devices from Belwith Products, LLC. The application's database was found to contain information that could be used to control the lock devices remotely. This issue affects Hickory Smart for Android, version 01.01.43 and prior versions."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-922: Insecure Storage of Sensitive Information"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://blog.rapid7.com/2019/08/01/r7-2019-18-multiple-hickory-smart-lock-vulnerabilities/",
+                "refsource": "MISC",
+                "url": "https://blog.rapid7.com/2019/08/01/r7-2019-18-multiple-hickory-smart-lock-vulnerabilities/"
+            },
+            {
+                "name": "https://play.google.com/store/apps/details?id=com.belwith.hickorysmart&hl=en_US",
+                "refsource": "MISC",
+                "url": "https://play.google.com/store/apps/details?id=com.belwith.hickorysmart&hl=en_US"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "R7-2019-18.1",
+        "discovery": "INTERNAL"
     }
 }

--- a/2019/5xxx/CVE-2019-5633.json
+++ b/2019/5xxx/CVE-2019-5633.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2019-08-01T13:05:00.000Z",
         "ID": "CVE-2019-5633",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Hickory Smart Lock Insecure Storage on iOS"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Hickory Smart",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "01.01.07"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Belwith Products, LLC"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered and reported by Deral Heiland of Rapid7. It has been disclosed in accordance with Rapid7's vulnerability disclosure policy (https://www.rapid7.com/disclosure/)."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An insecure storage of sensitive information vulnerability is present in Hickory Smart for iOS mobile devices from Belwith Products, LLC. The application's database was found to contain information that could be used to control the lock devices remotely. This issue affects Hickory Smart for iOS, version 01.01.07 and prior versions."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-922: Insecure Storage of Sensitive Information"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://blog.rapid7.com/2019/08/01/r7-2019-18-multiple-hickory-smart-lock-vulnerabilities/",
+                "refsource": "MISC",
+                "url": "https://blog.rapid7.com/2019/08/01/r7-2019-18-multiple-hickory-smart-lock-vulnerabilities/"
+            },
+            {
+                "name": "https://apps.apple.com/us/app/hickory-smart/id1189748191",
+                "refsource": "MISC",
+                "url": "https://apps.apple.com/us/app/hickory-smart/id1189748191"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "R7-2019-18.2",
+        "discovery": "INTERNAL"
     }
 }

--- a/2019/5xxx/CVE-2019-5634.json
+++ b/2019/5xxx/CVE-2019-5634.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2019-08-01T13:05:00.000Z",
         "ID": "CVE-2019-5634",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Hickory Smart Lock Insecure Logging on Android"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Hickory Smart",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "01.01.43"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Belwith Products, LLC"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered and reported by Deral Heiland of Rapid7. It has been disclosed in accordance with Rapid7's vulnerability disclosure policy (https://www.rapid7.com/disclosure/)."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An inclusion of sensitive information in log files vulnerability is present in Hickory Smart for Android mobile devices from Belwith Products, LLC. Communications to the internet API services and direct connections to the lock via Bluetooth Low Energy (BLE) from the mobile application are  logged in a debug log on the Android device at HickorySmartLog/Logs/SRDeviceLog.txt. This information was found stored in the Android device's default USB or SDcard storage paths and is accessible without rooting the device. This issue affects Hickory Smart for Android, version 01.01.43 and prior versions."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-532: Inclusion of Sensitive Information in Log Files"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://blog.rapid7.com/2019/08/01/r7-2019-18-multiple-hickory-smart-lock-vulnerabilities/",
+                "refsource": "MISC",
+                "url": "https://blog.rapid7.com/2019/08/01/r7-2019-18-multiple-hickory-smart-lock-vulnerabilities/"
+            },
+            {
+                "name": "https://play.google.com/store/apps/details?id=com.belwith.hickorysmart&hl=en_US",
+                "refsource": "MISC",
+                "url": "https://play.google.com/store/apps/details?id=com.belwith.hickorysmart&hl=en_US"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "R7-2019-18.3",
+        "discovery": "INTERNAL"
     }
 }

--- a/2019/5xxx/CVE-2019-5635.json
+++ b/2019/5xxx/CVE-2019-5635.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2019-08-01T13:05:00.000Z",
         "ID": "CVE-2019-5635",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Hickory Smart Lock Cleartext Password"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Hickory Smart Ethernet Bridge",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "H077646"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Belwith Products, LLC"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered and reported by Deral Heiland of Rapid7. It has been disclosed in accordance with Rapid7's vulnerability disclosure policy (https://www.rapid7.com/disclosure/)."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A cleartext transmission of sensitive information vulnerability is present in Hickory Smart Ethernet Bridge from Belwith Products, LLC. Captured data reveals that the Hickory Smart Ethernet Bridge device communicates over the network to an MQTT broker without using encryption. This exposed the default username and password used to authenticate to the MQTT broker. This issue affects Hickory Smart Ethernet Bridge, model number H077646. The firmware does not appear to contain versioning information."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-319: Cleartext Transmission of Sensitive Information"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://blog.rapid7.com/2019/08/01/r7-2019-18-multiple-hickory-smart-lock-vulnerabilities/",
+                "refsource": "MISC",
+                "url": "https://blog.rapid7.com/2019/08/01/r7-2019-18-multiple-hickory-smart-lock-vulnerabilities/"
+            },
+            {
+                "name": "https://hickoryhardware.com/products/hickory-smart-ethernet-bridge?variant=20882150228086",
+                "refsource": "MISC",
+                "url": "https://hickoryhardware.com/products/hickory-smart-ethernet-bridge?variant=20882150228086"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "R7-2019-18.6",
+        "discovery": "INTERNAL"
     }
 }


### PR DESCRIPTION
A few notes to avoid confusion :-)

- The vendor did NOT confirm this issue, thus there's no CONFIRM link (may fail validation?). 
  - Both Rapid7 and CERT/CC tried to get Hickory/Belwith to respond, but did not hear back. 
- We don’t have firmware version info for the ethernet bridge (CVE-2019-5635), only the model number, so used that. As noted in the description for that CVE, we didn't find any evidence of versioning in the firmware.
- Product links go to Hickory Hardware, but Belwith Products, LLC is listed as the vendor as they are the parent company for Hickory.