### PR TITLE
Add Ubuntu apport issues discovered by Kevin Backhouse

### DIFF
--- a/2019/11xxx/CVE-2019-11476.json
+++ b/2019/11xxx/CVE-2019-11476.json
@@ -1,18 +1,116 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2019-07-09T00:00:00.000Z",
         "ID": "CVE-2019-11476",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Integer overflow in whoopsie results in out-of-bounds heap write"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Whoopsie",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "0.2.52 ",
+                                            "version_value": "0.2.52.5ubuntu0.1"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": " 0.2.62",
+                                            "version_value": "0.2.62ubuntu0.1"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": " 0.2.64",
+                                            "version_value": "0.2.64ubuntu0.1"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "0.2",
+                                            "version_value": "0.2.66"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Ubuntu"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Kevin Backhouse of Semmle Security Research Team"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An integer overflow in whoopsie before versions 0.2.52.5ubuntu0.1, 0.2.62ubuntu0.1, 0.2.64ubuntu0.1, 0.2.66, results in an out-of-bounds write to a heap allocated buffer when processing large crash dumps. This results in a crash or possible code-execution in the context of the whoopsie process."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-190 Integer Overflow or Wraparound"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://usn.ubuntu.com/4052-1/"
+            },
+            {
+                "refsource": "UBUNTU",
+                "url": "https://bugs.launchpad.net/ubuntu/%2Bsource/whoopsie/%2Bbug/1830863"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "https://usn.ubuntu.com/usn/usn-4052-1",
+        "defect": [
+            "https://bugs.launchpad.net/ubuntu/+source/whoopsie/+bug/1830863"
+        ],
+        "discovery": "EXTERNAL"
     }
 }

--- a/2019/7xxx/CVE-2019-7307.json
+++ b/2019/7xxx/CVE-2019-7307.json
@@ -1,9 +1,62 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2019-07-09T00:00:00.000Z",
         "ID": "CVE-2019-7307",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Apport contains a TOCTTOU vulnerability when reading the users ~/.apport-ignore.xml"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "apport",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "2.14.1",
+                                            "version_value": "2.14.1-0ubuntu3.29+esm1"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "2.20.1",
+                                            "version_value": "2.20.1-0ubuntu2.19"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "2.20.9",
+                                            "version_value": "2.20.9-0ubuntu7.7"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "2.20.10",
+                                            "version_value": "2.20.10-0ubuntu27.1"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "2.20.11",
+                                            "version_value": "2.20.11-0ubuntu5"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Ubuntu"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Kevin Backhouse of Semmle Security Research Team"
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +64,58 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Apport before versions 2.14.1-0ubuntu3.29+esm1, 2.20.1-0ubuntu2.19, 2.20.9-0ubuntu7.7, 2.20.10-0ubuntu27.1, 2.20.11-0ubuntu5 contained a TOCTTOU vulnerability when reading the users ~/.apport-ignore.xml file, which allows a local attacker to replace this file with a symlink to any other file on the system and so cause Apport to include the contents of this other file in the resulting crash report. The crash report could then be read by that user either by causing it to be uploaded and reported to Launchpad, or by leveraging some other vulnerability to read the resulting crash report, and so allow the user to read arbitrary files on the system."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-367 Time-of-check Time-of-use (TOCTOU) Race Condition"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-7307.html"
+            },
+            {
+                "refsource": "UBUNTU",
+                "url": "https://bugs.launchpad.net/ubuntu/%2Bsource/apport/%2Bbug/1830858"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "https://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-7307.html",
+        "defect": [
+            "https://bugs.launchpad.net/ubuntu/%2Bsource/apport/%2Bbug/1830858"
+        ],
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
Hello, here's the two publicly used but not yet pushed CVEs that were flagged when requesting new CVE numbers for the Ubuntu CNA:

CVE Request 748394 for CNA Block Request

Thanks