### PR TITLE
Corrections for CVE-2019-10392

### DIFF
--- a/2019/10xxx/CVE-2019-10392.json
+++ b/2019/10xxx/CVE-2019-10392.json
@@ -16,7 +16,7 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "2.8.4 and earlier"
+                                            "version_value": "2.8.4 and earlier, 3.0.0-rc"
                                         }
                                     ]
                                 }
@@ -44,7 +44,7 @@
                 "description": [
                     {
                         "lang": "eng",
-                        "value": "CWE-79"
+                        "value": "CWE-78"
                     }
                 ]
             }


### PR DESCRIPTION
* 3.0.0-rc was accidentally published for a week in February, was installed by 10k users, and is also affected
* CWE-78, not -79