### PR TITLE
Make Jenkins security advisories the CONFIRM refsources again

### DIFF
--- a/2019/1003xxx/CVE-2019-1003040.json
+++ b/2019/1003xxx/CVE-2019-1003040.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-1353",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-1353"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003041.json
+++ b/2019/1003xxx/CVE-2019-1003041.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-1353",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-1353"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003042.json
+++ b/2019/1003xxx/CVE-2019-1003042.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-1361",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-1361"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003043.json
+++ b/2019/1003xxx/CVE-2019-1003043.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-976",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-976"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003044.json
+++ b/2019/1003xxx/CVE-2019-1003044.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-976",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-976"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003045.json
+++ b/2019/1003xxx/CVE-2019-1003045.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-846",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-846"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003046.json
+++ b/2019/1003xxx/CVE-2019-1003046.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-992",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-992"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003047.json
+++ b/2019/1003xxx/CVE-2019-1003047.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-992",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-992"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003048.json
+++ b/2019/1003xxx/CVE-2019-1003048.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-1089",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-03-25/#SECURITY-1089"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003049.json
+++ b/2019/1003xxx/CVE-2019-1003049.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-10/#SECURITY-1289",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-10/#SECURITY-1289"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003050.json
+++ b/2019/1003xxx/CVE-2019-1003050.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-10/#SECURITY-1327",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-10/#SECURITY-1327"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003051.json
+++ b/2019/1003xxx/CVE-2019-1003051.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-829",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-829"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003052.json
+++ b/2019/1003xxx/CVE-2019-1003052.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-831",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-831"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003053.json
+++ b/2019/1003xxx/CVE-2019-1003053.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-839",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-839"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003054.json
+++ b/2019/1003xxx/CVE-2019-1003054.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-837",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-837"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003055.json
+++ b/2019/1003xxx/CVE-2019-1003055.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-954",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-954"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003056.json
+++ b/2019/1003xxx/CVE-2019-1003056.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-956",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-956"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003057.json
+++ b/2019/1003xxx/CVE-2019-1003057.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-965",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-965"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003058.json
+++ b/2019/1003xxx/CVE-2019-1003058.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-974",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-974"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003059.json
+++ b/2019/1003xxx/CVE-2019-1003059.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-974",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-974"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003060.json
+++ b/2019/1003xxx/CVE-2019-1003060.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1041",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1041"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003061.json
+++ b/2019/1003xxx/CVE-2019-1003061.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1042",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1042"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003062.json
+++ b/2019/1003xxx/CVE-2019-1003062.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-830",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-830"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003063.json
+++ b/2019/1003xxx/CVE-2019-1003063.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-832",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-832"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003064.json
+++ b/2019/1003xxx/CVE-2019-1003064.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-835",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-835"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003065.json
+++ b/2019/1003xxx/CVE-2019-1003065.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-838",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-838"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003066.json
+++ b/2019/1003xxx/CVE-2019-1003066.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-841",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-841"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003067.json
+++ b/2019/1003xxx/CVE-2019-1003067.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-842",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-842"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003068.json
+++ b/2019/1003xxx/CVE-2019-1003068.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-945",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-945"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003069.json
+++ b/2019/1003xxx/CVE-2019-1003069.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-949",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-949"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003070.json
+++ b/2019/1003xxx/CVE-2019-1003070.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-952",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-952"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003071.json
+++ b/2019/1003xxx/CVE-2019-1003071.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-957",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-957"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003072.json
+++ b/2019/1003xxx/CVE-2019-1003072.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-961",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-961"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003073.json
+++ b/2019/1003xxx/CVE-2019-1003073.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-962",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-962"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003074.json
+++ b/2019/1003xxx/CVE-2019-1003074.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-964",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-964"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003075.json
+++ b/2019/1003xxx/CVE-2019-1003075.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-966",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-966"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003076.json
+++ b/2019/1003xxx/CVE-2019-1003076.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-977",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-977"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003077.json
+++ b/2019/1003xxx/CVE-2019-1003077.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-977",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-977"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003078.json
+++ b/2019/1003xxx/CVE-2019-1003078.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-979",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-979"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003079.json
+++ b/2019/1003xxx/CVE-2019-1003079.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-979",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-979"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003080.json
+++ b/2019/1003xxx/CVE-2019-1003080.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-981",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-981"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003081.json
+++ b/2019/1003xxx/CVE-2019-1003081.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-981",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-981"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003082.json
+++ b/2019/1003xxx/CVE-2019-1003082.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-991",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-991"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003083.json
+++ b/2019/1003xxx/CVE-2019-1003083.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-991",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-991"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003084.json
+++ b/2019/1003xxx/CVE-2019-1003084.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-993",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-993"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003085.json
+++ b/2019/1003xxx/CVE-2019-1003085.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-993",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-993"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003086.json
+++ b/2019/1003xxx/CVE-2019-1003086.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1037",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1037"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003087.json
+++ b/2019/1003xxx/CVE-2019-1003087.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1037",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1037"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003088.json
+++ b/2019/1003xxx/CVE-2019-1003088.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1043",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1043"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003089.json
+++ b/2019/1003xxx/CVE-2019-1003089.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1044",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1044"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003090.json
+++ b/2019/1003xxx/CVE-2019-1003090.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1054",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1054"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003091.json
+++ b/2019/1003xxx/CVE-2019-1003091.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1054",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1054"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003092.json
+++ b/2019/1003xxx/CVE-2019-1003092.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1058",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1058"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003093.json
+++ b/2019/1003xxx/CVE-2019-1003093.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1058",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1058"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003094.json
+++ b/2019/1003xxx/CVE-2019-1003094.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1059",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1059"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003095.json
+++ b/2019/1003xxx/CVE-2019-1003095.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1061",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1061"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003096.json
+++ b/2019/1003xxx/CVE-2019-1003096.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1062",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1062"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003097.json
+++ b/2019/1003xxx/CVE-2019-1003097.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1069",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1069"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003098.json
+++ b/2019/1003xxx/CVE-2019-1003098.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1084",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1084"
             },
             {

--- a/2019/1003xxx/CVE-2019-1003099.json
+++ b/2019/1003xxx/CVE-2019-1003099.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1084",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1084"
             },
             {

--- a/2019/10xxx/CVE-2019-10277.json
+++ b/2019/10xxx/CVE-2019-10277.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1085",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1085"
             },
             {

--- a/2019/10xxx/CVE-2019-10278.json
+++ b/2019/10xxx/CVE-2019-10278.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1091",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1091"
             },
             {

--- a/2019/10xxx/CVE-2019-10279.json
+++ b/2019/10xxx/CVE-2019-10279.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1091",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1091"
             },
             {

--- a/2019/10xxx/CVE-2019-10280.json
+++ b/2019/10xxx/CVE-2019-10280.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1093",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1093"
             },
             {

--- a/2019/10xxx/CVE-2019-10281.json
+++ b/2019/10xxx/CVE-2019-10281.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-828",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-828"
             },
             {

--- a/2019/10xxx/CVE-2019-10282.json
+++ b/2019/10xxx/CVE-2019-10282.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-843",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-843"
             },
             {

--- a/2019/10xxx/CVE-2019-10283.json
+++ b/2019/10xxx/CVE-2019-10283.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-946",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-946"
             },
             {

--- a/2019/10xxx/CVE-2019-10284.json
+++ b/2019/10xxx/CVE-2019-10284.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-947",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-947"
             },
             {

--- a/2019/10xxx/CVE-2019-10285.json
+++ b/2019/10xxx/CVE-2019-10285.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-955",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-955"
             },
             {

--- a/2019/10xxx/CVE-2019-10286.json
+++ b/2019/10xxx/CVE-2019-10286.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-959",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-959"
             },
             {

--- a/2019/10xxx/CVE-2019-10287.json
+++ b/2019/10xxx/CVE-2019-10287.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-963",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-963"
             },
             {

--- a/2019/10xxx/CVE-2019-10288.json
+++ b/2019/10xxx/CVE-2019-10288.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1031",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1031"
             },
             {

--- a/2019/10xxx/CVE-2019-10289.json
+++ b/2019/10xxx/CVE-2019-10289.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1032",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1032"
             },
             {

--- a/2019/10xxx/CVE-2019-10290.json
+++ b/2019/10xxx/CVE-2019-10290.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1032",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1032"
             },
             {

--- a/2019/10xxx/CVE-2019-10291.json
+++ b/2019/10xxx/CVE-2019-10291.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1040",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1040"
             },
             {

--- a/2019/10xxx/CVE-2019-10292.json
+++ b/2019/10xxx/CVE-2019-10292.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1055",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1055"
             },
             {

--- a/2019/10xxx/CVE-2019-10293.json
+++ b/2019/10xxx/CVE-2019-10293.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1055",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1055"
             },
             {

--- a/2019/10xxx/CVE-2019-10294.json
+++ b/2019/10xxx/CVE-2019-10294.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1056",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1056"
             },
             {

--- a/2019/10xxx/CVE-2019-10295.json
+++ b/2019/10xxx/CVE-2019-10295.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1063",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1063"
             },
             {

--- a/2019/10xxx/CVE-2019-10296.json
+++ b/2019/10xxx/CVE-2019-10296.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1066",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1066"
             },
             {

--- a/2019/10xxx/CVE-2019-10297.json
+++ b/2019/10xxx/CVE-2019-10297.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1090",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1090"
             },
             {

--- a/2019/10xxx/CVE-2019-10298.json
+++ b/2019/10xxx/CVE-2019-10298.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1092",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1092"
             },
             {

--- a/2019/10xxx/CVE-2019-10299.json
+++ b/2019/10xxx/CVE-2019-10299.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-960",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-960"
             },
             {

--- a/2019/10xxx/CVE-2019-10300.json
+++ b/2019/10xxx/CVE-2019-10300.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-1357",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-1357"
             },
             {

--- a/2019/10xxx/CVE-2019-10301.json
+++ b/2019/10xxx/CVE-2019-10301.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-1357",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-1357"
             },
             {

--- a/2019/10xxx/CVE-2019-10302.json
+++ b/2019/10xxx/CVE-2019-10302.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-836",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-836"
             },
             {

--- a/2019/10xxx/CVE-2019-10303.json
+++ b/2019/10xxx/CVE-2019-10303.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-844",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-844"
             },
             {

--- a/2019/10xxx/CVE-2019-10304.json
+++ b/2019/10xxx/CVE-2019-10304.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-983",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-983"
             },
             {

--- a/2019/10xxx/CVE-2019-10305.json
+++ b/2019/10xxx/CVE-2019-10305.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-983",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-983"
             },
             {

--- a/2019/10xxx/CVE-2019-10306.json
+++ b/2019/10xxx/CVE-2019-10306.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-1341",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-1341"
             },
             {

--- a/2019/10xxx/CVE-2019-10307.json
+++ b/2019/10xxx/CVE-2019-10307.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1100",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1100"
             },
             {

--- a/2019/10xxx/CVE-2019-10308.json
+++ b/2019/10xxx/CVE-2019-10308.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1100",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1100"
             },
             {

--- a/2019/10xxx/CVE-2019-10309.json
+++ b/2019/10xxx/CVE-2019-10309.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1252",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1252"
             },
             {

--- a/2019/10xxx/CVE-2019-10310.json
+++ b/2019/10xxx/CVE-2019-10310.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1355",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1355"
             },
             {

--- a/2019/10xxx/CVE-2019-10311.json
+++ b/2019/10xxx/CVE-2019-10311.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1355",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1355"
             },
             {

--- a/2019/10xxx/CVE-2019-10312.json
+++ b/2019/10xxx/CVE-2019-10312.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1355",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1355"
             },
             {

--- a/2019/10xxx/CVE-2019-10313.json
+++ b/2019/10xxx/CVE-2019-10313.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1143",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1143"
             },
             {

--- a/2019/10xxx/CVE-2019-10314.json
+++ b/2019/10xxx/CVE-2019-10314.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-936",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-936"
             },
             {

--- a/2019/10xxx/CVE-2019-10315.json
+++ b/2019/10xxx/CVE-2019-10315.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-443",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-443"
             },
             {

--- a/2019/10xxx/CVE-2019-10316.json
+++ b/2019/10xxx/CVE-2019-10316.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1380",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1380"
             },
             {

--- a/2019/10xxx/CVE-2019-10317.json
+++ b/2019/10xxx/CVE-2019-10317.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-930",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-930"
             },
             {

--- a/2019/10xxx/CVE-2019-10318.json
+++ b/2019/10xxx/CVE-2019-10318.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1390",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1390"
             },
             {

--- a/2019/10xxx/CVE-2019-10319.json
+++ b/2019/10xxx/CVE-2019-10319.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-21/#SECURITY-1316",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-21/#SECURITY-1316"
             },
             {

--- a/2019/10xxx/CVE-2019-10320.json
+++ b/2019/10xxx/CVE-2019-10320.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-21/#SECURITY-1322",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-21/#SECURITY-1322"
             },
             {

--- a/2019/10xxx/CVE-2019-10321.json
+++ b/2019/10xxx/CVE-2019-10321.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1015%20(1)",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1015%20(1)"
             },
             {

--- a/2019/10xxx/CVE-2019-10322.json
+++ b/2019/10xxx/CVE-2019-10322.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1015%20(1)",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1015%20(1)"
             },
             {

--- a/2019/10xxx/CVE-2019-10323.json
+++ b/2019/10xxx/CVE-2019-10323.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1015%20(2)",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1015%20(2)"
             },
             {

--- a/2019/10xxx/CVE-2019-10324.json
+++ b/2019/10xxx/CVE-2019-10324.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1347",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1347"
             },
             {

--- a/2019/10xxx/CVE-2019-10325.json
+++ b/2019/10xxx/CVE-2019-10325.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1373",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1373"
             },
             {

--- a/2019/10xxx/CVE-2019-10326.json
+++ b/2019/10xxx/CVE-2019-10326.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1391",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1391"
             },
             {

--- a/2019/10xxx/CVE-2019-10327.json
+++ b/2019/10xxx/CVE-2019-10327.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1409",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1409"
             },
             {

--- a/2019/10xxx/CVE-2019-10328.json
+++ b/2019/10xxx/CVE-2019-10328.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-921",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-921"
             },
             {

--- a/2019/10xxx/CVE-2019-10329.json
+++ b/2019/10xxx/CVE-2019-10329.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1403",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1403"
             },
             {

--- a/2019/10xxx/CVE-2019-10330.json
+++ b/2019/10xxx/CVE-2019-10330.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1046",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1046"
             },
             {

--- a/2019/10xxx/CVE-2019-10331.json
+++ b/2019/10xxx/CVE-2019-10331.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1410%20(1)",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1410%20(1)"
             },
             {

--- a/2019/10xxx/CVE-2019-10332.json
+++ b/2019/10xxx/CVE-2019-10332.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1410%20(1)",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1410%20(1)"
             },
             {

--- a/2019/10xxx/CVE-2019-10333.json
+++ b/2019/10xxx/CVE-2019-10333.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1410%20(2)",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1410%20(2)"
             },
             {

--- a/2019/10xxx/CVE-2019-10334.json
+++ b/2019/10xxx/CVE-2019-10334.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1411",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1411"
             },
             {

--- a/2019/10xxx/CVE-2019-10335.json
+++ b/2019/10xxx/CVE-2019-10335.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1412",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1412"
             },
             {

--- a/2019/10xxx/CVE-2019-10336.json
+++ b/2019/10xxx/CVE-2019-10336.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1420",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1420"
             },
             {

--- a/2019/10xxx/CVE-2019-10337.json
+++ b/2019/10xxx/CVE-2019-10337.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1399",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1399"
             },
             {

--- a/2019/10xxx/CVE-2019-10338.json
+++ b/2019/10xxx/CVE-2019-10338.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1379",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1379"
             },
             {

--- a/2019/10xxx/CVE-2019-10339.json
+++ b/2019/10xxx/CVE-2019-10339.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1379",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1379"
             },
             {

--- a/2019/10xxx/CVE-2019-10340.json
+++ b/2019/10xxx/CVE-2019-10340.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1010",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1010"
             },
             {

--- a/2019/10xxx/CVE-2019-10341.json
+++ b/2019/10xxx/CVE-2019-10341.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1010",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1010"
             },
             {

--- a/2019/10xxx/CVE-2019-10342.json
+++ b/2019/10xxx/CVE-2019-10342.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1400",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1400"
             },
             {

--- a/2019/10xxx/CVE-2019-10343.json
+++ b/2019/10xxx/CVE-2019-10343.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1279",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1279"
             },
             {

--- a/2019/10xxx/CVE-2019-10344.json
+++ b/2019/10xxx/CVE-2019-10344.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1290",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1290"
             },
             {

--- a/2019/10xxx/CVE-2019-10345.json
+++ b/2019/10xxx/CVE-2019-10345.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1303",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1303"
             },
             {

--- a/2019/10xxx/CVE-2019-10346.json
+++ b/2019/10xxx/CVE-2019-10346.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1419",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1419"
             },
             {

--- a/2019/10xxx/CVE-2019-10347.json
+++ b/2019/10xxx/CVE-2019-10347.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-775",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-775"
             },
             {

--- a/2019/10xxx/CVE-2019-10348.json
+++ b/2019/10xxx/CVE-2019-10348.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1438",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1438"
             },
             {

--- a/2019/10xxx/CVE-2019-10349.json
+++ b/2019/10xxx/CVE-2019-10349.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1177",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1177"
             },
             {

--- a/2019/10xxx/CVE-2019-10350.json
+++ b/2019/10xxx/CVE-2019-10350.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1441",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1441"
             },
             {

--- a/2019/10xxx/CVE-2019-10351.json
+++ b/2019/10xxx/CVE-2019-10351.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1437",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1437"
             },
             {

--- a/2019/10xxx/CVE-2019-10352.json
+++ b/2019/10xxx/CVE-2019-10352.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-17/#SECURITY-1424",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-17/#SECURITY-1424"
             },
             {

--- a/2019/10xxx/CVE-2019-10353.json
+++ b/2019/10xxx/CVE-2019-10353.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-17/#SECURITY-626",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-17/#SECURITY-626"
             },
             {

--- a/2019/10xxx/CVE-2019-10354.json
+++ b/2019/10xxx/CVE-2019-10354.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-17/#SECURITY-534",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-17/#SECURITY-534"
             },
             {

--- a/2019/10xxx/CVE-2019-10355.json
+++ b/2019/10xxx/CVE-2019-10355.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1465%20(1)",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1465%20(1)"
             },
             {

--- a/2019/10xxx/CVE-2019-10356.json
+++ b/2019/10xxx/CVE-2019-10356.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1465%20(2)",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1465%20(2)"
             },
             {

--- a/2019/10xxx/CVE-2019-10357.json
+++ b/2019/10xxx/CVE-2019-10357.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY1422",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY1422"
             },
             {

--- a/2019/10xxx/CVE-2019-10358.json
+++ b/2019/10xxx/CVE-2019-10358.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-713",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-713"
             },
             {

--- a/2019/10xxx/CVE-2019-10359.json
+++ b/2019/10xxx/CVE-2019-10359.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1098",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1098"
             },
             {

--- a/2019/10xxx/CVE-2019-10360.json
+++ b/2019/10xxx/CVE-2019-10360.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1184",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1184"
             },
             {

--- a/2019/10xxx/CVE-2019-10361.json
+++ b/2019/10xxx/CVE-2019-10361.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1435",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1435"
             },
             {

--- a/2019/10xxx/CVE-2019-10362.json
+++ b/2019/10xxx/CVE-2019-10362.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1446",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1446"
             },
             {

--- a/2019/10xxx/CVE-2019-10363.json
+++ b/2019/10xxx/CVE-2019-10363.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1458",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1458"
             },
             {

--- a/2019/10xxx/CVE-2019-10364.json
+++ b/2019/10xxx/CVE-2019-10364.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-673",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-673"
             },
             {

--- a/2019/10xxx/CVE-2019-10365.json
+++ b/2019/10xxx/CVE-2019-10365.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1345",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1345"
             },
             {

--- a/2019/10xxx/CVE-2019-10366.json
+++ b/2019/10xxx/CVE-2019-10366.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1429",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1429"
             },
             {

--- a/2019/10xxx/CVE-2019-10367.json
+++ b/2019/10xxx/CVE-2019-10367.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1497",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1497"
             },
             {

--- a/2019/10xxx/CVE-2019-10368.json
+++ b/2019/10xxx/CVE-2019-10368.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1482",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1482"
             },
             {

--- a/2019/10xxx/CVE-2019-10369.json
+++ b/2019/10xxx/CVE-2019-10369.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1482",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1482"
             },
             {

--- a/2019/10xxx/CVE-2019-10370.json
+++ b/2019/10xxx/CVE-2019-10370.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-157",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-157"
             },
             {

--- a/2019/10xxx/CVE-2019-10371.json
+++ b/2019/10xxx/CVE-2019-10371.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-795",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-795"
             },
             {

--- a/2019/10xxx/CVE-2019-10372.json
+++ b/2019/10xxx/CVE-2019-10372.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-796",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-796"
             },
             {

--- a/2019/10xxx/CVE-2019-10373.json
+++ b/2019/10xxx/CVE-2019-10373.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-879",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-879"
             },
             {

--- a/2019/10xxx/CVE-2019-10374.json
+++ b/2019/10xxx/CVE-2019-10374.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-142",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-142"
             },
             {

--- a/2019/10xxx/CVE-2019-10375.json
+++ b/2019/10xxx/CVE-2019-10375.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-569",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-569"
             },
             {

--- a/2019/10xxx/CVE-2019-10376.json
+++ b/2019/10xxx/CVE-2019-10376.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-751",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-751"
             },
             {

--- a/2019/10xxx/CVE-2019-10377.json
+++ b/2019/10xxx/CVE-2019-10377.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1099",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1099"
             },
             {

--- a/2019/10xxx/CVE-2019-10378.json
+++ b/2019/10xxx/CVE-2019-10378.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1428",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1428"
             },
             {

--- a/2019/10xxx/CVE-2019-10379.json
+++ b/2019/10xxx/CVE-2019-10379.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-591",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-591"
             },
             {

--- a/2019/10xxx/CVE-2019-10380.json
+++ b/2019/10xxx/CVE-2019-10380.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-922",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-922"
             },
             {

--- a/2019/10xxx/CVE-2019-10381.json
+++ b/2019/10xxx/CVE-2019-10381.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-931",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-931"
             },
             {

--- a/2019/10xxx/CVE-2019-10382.json
+++ b/2019/10xxx/CVE-2019-10382.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1376",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1376"
             },
             {

--- a/2019/10xxx/CVE-2019-10383.json
+++ b/2019/10xxx/CVE-2019-10383.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-28/#SECURITY-1453",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-28/#SECURITY-1453"
             },
             {

--- a/2019/10xxx/CVE-2019-10384.json
+++ b/2019/10xxx/CVE-2019-10384.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-28/#SECURITY-1491",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-28/#SECURITY-1491"
             },
             {

--- a/2019/10xxx/CVE-2019-10385.json
+++ b/2019/10xxx/CVE-2019-10385.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1430",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1430"
             },
             {

--- a/2019/10xxx/CVE-2019-10386.json
+++ b/2019/10xxx/CVE-2019-10386.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1008",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1008"
             },
             {

--- a/2019/10xxx/CVE-2019-10387.json
+++ b/2019/10xxx/CVE-2019-10387.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1008",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1008"
             },
             {

--- a/2019/10xxx/CVE-2019-10388.json
+++ b/2019/10xxx/CVE-2019-10388.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1053",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1053"
             },
             {

--- a/2019/10xxx/CVE-2019-10389.json
+++ b/2019/10xxx/CVE-2019-10389.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1053",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1053"
             },
             {

--- a/2019/10xxx/CVE-2019-10390.json
+++ b/2019/10xxx/CVE-2019-10390.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-28/#SECURITY-1294",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-28/#SECURITY-1294"
             },
             {

--- a/2019/10xxx/CVE-2019-10391.json
+++ b/2019/10xxx/CVE-2019-10391.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-08-28/#SECURITY-1512",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-08-28/#SECURITY-1512"
             },
             {

--- a/2019/10xxx/CVE-2019-10392.json
+++ b/2019/10xxx/CVE-2019-10392.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1534",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1534"
             },
             {

--- a/2019/10xxx/CVE-2019-10393.json
+++ b/2019/10xxx/CVE-2019-10393.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1538",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1538"
             },
             {

--- a/2019/10xxx/CVE-2019-10394.json
+++ b/2019/10xxx/CVE-2019-10394.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1538",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1538"
             },
             {

--- a/2019/10xxx/CVE-2019-10395.json
+++ b/2019/10xxx/CVE-2019-10395.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1476",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1476"
             },
             {

--- a/2019/10xxx/CVE-2019-10396.json
+++ b/2019/10xxx/CVE-2019-10396.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1489",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1489"
             },
             {

--- a/2019/10xxx/CVE-2019-10397.json
+++ b/2019/10xxx/CVE-2019-10397.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-09-12/#SECURTY-1509",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-09-12/#SECURTY-1509"
             },
             {

--- a/2019/10xxx/CVE-2019-10398.json
+++ b/2019/10xxx/CVE-2019-10398.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1545",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1545"
             },
             {

--- a/2019/10xxx/CVE-2019-10399.json
+++ b/2019/10xxx/CVE-2019-10399.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1538",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1538"
             },
             {

--- a/2019/10xxx/CVE-2019-10400.json
+++ b/2019/10xxx/CVE-2019-10400.json
@@ -54,7 +54,7 @@
         "reference_data": [
             {
                 "url": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1538",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "name": "https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1538"
             },
             {


### PR DESCRIPTION
I was unaware of https://github.com/CVEProject/cvelist/pull/2542#issuecomment-531885056 so all our advisories are just MISC after import.