### PR TITLE
Add CVE-2019015760

### DIFF
--- a/2019/16xxx/CVE-2019-16760.json
+++ b/2019/16xxx/CVE-2019-16760.json
@@ -1,0 +1,105 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
+        "ID": "CVE-2019-16760",
+        "STATE": "PUBLIC",
+        "TITLE": "Cargo prior to Rust 1.26.0 may download the wrong dependency"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "cargo",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "1.0.0",
+                                            "version_value": "1.26.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "rust"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "Cargo prior to Rust 1.26.0 may download the wrong dependency if your package.toml file uses the `package` configuration key. Usage of the `package` key to rename dependencies in `Cargo.toml` is ignored in Rust 1.25.0 and prior. When Rust 1.25.0 and prior is used Cargo may download the wrong dependency, which could be squatted on crates.io to be a malicious package. This not only affects manifests that you write locally yourself, but also manifests published to crates.io. If you published a crate, for example, that depends on `serde1` to crates.io then users who depend on you may also be vulnerable if they use Rust 1.25.0 and prior.\n\nRust 1.0.0 through Rust 1.25.0 is affected by this advisory because Cargo will ignore the `package` key in manifests. Rust 1.26.0 through Rust 1.30.0 are not affected and typically will emit an error because the `package` key is unstable. Rust 1.31.0 and after are not affected because Cargo understands the `package` key.\n\nUsers of the affected versions are strongly encouraged to update their compiler to the latest available one. Preventing this issue from happening requires updating your compiler to be either Rust 1.26.0 or newer. \n\nThere will be no patch issued for Rust versions prior to 1.26.0. Users of Rust 1.19.0 to Rust 1.25.0 can instead apply linked patches to mitigate the issue."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 4.6,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-16 Configuration"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/rust-lang/rust/security/advisories/GHSA-phjm-8x66-qw4r",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/rust-lang/rust/security/advisories/GHSA-phjm-8x66-qw4r"
+            },
+            {
+                "name": "https://groups.google.com/forum/#!topic/rustlang-security-announcements/rVQ5e3TDnpQ",
+                "refsource": "MISC",
+                "url": "https://groups.google.com/forum/#!topic/rustlang-security-announcements/rVQ5e3TDnpQ"
+            },
+            {
+                "name": "https://github.com/rust-lang/cargo/pull/4953",
+                "refsource": "MISC",
+                "url": "https://github.com/rust-lang/cargo/pull/4953"
+            },
+            {
+                "name": "https://gist.github.com/pietroalbini/0d293b24a44babbeb6187e06eebd4992",
+                "refsource": "MISC",
+                "url": "https://gist.github.com/pietroalbini/0d293b24a44babbeb6187e06eebd4992"
+            },
+            {
+                "name": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml",
+                "refsource": "MISC",
+                "url": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-phjm-8x66-qw4r",
+        "discovery": "UNKNOWN"
+    }
+}


### PR DESCRIPTION
This is the first published CVE from GitHub CNA.

We are prototyping our submission flow currently, so this PR is a temporary process while we are still getting setup.

Please respond to this PR, or reach to `security-advisories@github.com` with any questions.

