### PR TITLE
Add CVEs for 2019-10-01 security advisory

### DIFF
--- a/2019/10xxx/CVE-2019-10431.json
+++ b/2019/10xxx/CVE-2019-10431.json
@@ -1,17 +1,60 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2019-10431",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Script Security Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.64 and earlier"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A sandbox bypass vulnerability in Jenkins Script Security Plugin 1.64 and earlier related to the handling of default parameter expressions in constructors allowed attackers to execute arbitrary code in sandboxed scripts."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-265"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1579",
+                "url": "https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1579",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2019/10xxx/CVE-2019-10432.json
+++ b/2019/10xxx/CVE-2019-10432.json
@@ -1,17 +1,60 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2019-10432",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins HTML Publisher Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.20 and earlier"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins HTML Publisher Plugin 1.20 and earlier did not escape the project and build display names in the HTML report frame, resulting in a cross-site scripting vulnerability exploitable by users able to change those."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1590",
+                "url": "https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1590",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2019/10xxx/CVE-2019-10433.json
+++ b/2019/10xxx/CVE-2019-10433.json
@@ -1,17 +1,60 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2019-10433",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Dingding[\u9489\u9489] Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.9 and earlier"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins Dingding[\u9489\u9489] Plugin stores credentials unencrypted in job config.xml files on the Jenkins master where they can be viewed by users with Extended Read permission, or access to the master file system."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-256"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1423",
+                "url": "https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1423",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2019/10xxx/CVE-2019-10434.json
+++ b/2019/10xxx/CVE-2019-10434.json
@@ -1,17 +1,60 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2019-10434",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins LDAP Email Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "0.8 and earlier"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins LDAP Email Plugin transmits configured credentials in plain text as part of the global Jenkins configuration form, potentially resulting in their exposure."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-319"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1515",
+                "url": "https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1515",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2019/10xxx/CVE-2019-10435.json
+++ b/2019/10xxx/CVE-2019-10435.json
@@ -1,17 +1,60 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2019-10435",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins SourceGear Vault Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.1.1 and earlier"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins SourceGear Vault Plugin transmits configured credentials in plain text as part of job configuration forms, potentially resulting in their exposure."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-319"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1524",
+                "url": "https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1524",
+                "refsource": "CONFIRM"
             }
         ]
     }


### PR DESCRIPTION
https://jenkins.io/security/advisory/2019-10-01/

**Note**: One of the plugins' names is *Jenkins Dingding[钉钉]* Plugin and it looks like the following in JSON:

    Jenkins Dingding[\u9489\u9489] Plugin

I haven't found whether this is a problem for you, but if it is, we can remove it.