### PR TITLE
update references and description for CVE-2019-16760

### DIFF
--- a/2019/16xxx/CVE-2019-16760.json
+++ b/2019/16xxx/CVE-2019-16760.json
@@ -37,7 +37,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Cargo prior to Rust 1.26.0 may download the wrong dependency if your package.toml file uses the `package` configuration key. Usage of the `package` key to rename dependencies in `Cargo.toml` is ignored in Rust 1.25.0 and prior. When Rust 1.25.0 and prior is used Cargo may download the wrong dependency, which could be squatted on crates.io to be a malicious package. This not only affects manifests that you write locally yourself, but also manifests published to crates.io. If you published a crate, for example, that depends on `serde1` to crates.io then users who depend on you may also be vulnerable if they use Rust 1.25.0 and prior. Rust 1.0.0 through Rust 1.25.0 is affected by this advisory because Cargo will ignore the `package` key in manifests. Rust 1.26.0 through Rust 1.30.0 are not affected and typically will emit an error because the `package` key is unstable. Rust 1.31.0 and after are not affected because Cargo understands the `package` key. Users of the affected versions are strongly encouraged to update their compiler to the latest available one. Preventing this issue from happening requires updating your compiler to be either Rust 1.26.0 or newer. There will be no patch issued for Rust versions prior to 1.26.0. Users of Rust 1.19.0 to Rust 1.25.0 can instead apply linked patches to mitigate the issue."
+                "value": "Cargo prior to Rust 1.26.0 may download the wrong dependency if your package.toml file uses the `package` configuration key. Usage of the `package` key to rename dependencies in `Cargo.toml` is ignored in Rust 1.25.0 and prior. When Rust 1.25.0 and prior is used Cargo may download the wrong dependency, which could be squatted on crates.io to be a malicious package. This not only affects manifests that you write locally yourself, but also manifests published to crates.io. Rust 1.0.0 through Rust 1.25.0 is affected by this advisory because Cargo will ignore the `package` key in manifests. Rust 1.26.0 through Rust 1.30.0 are not affected and typically will emit an error because the `package` key is unstable. Rust 1.31.0 and after are not affected because Cargo understands the `package` key. Users of the affected versions are strongly encouraged to update their compiler to the latest available one. Preventing this issue from happening requires updating your compiler to be either Rust 1.26.0 or newer. There will be no point release for Rust versions prior to 1.26.0. Users of Rust 1.19.0 to Rust 1.25.0 can instead apply linked patches to mitigate the issue."
             }
         ]
     },
@@ -82,19 +82,9 @@
                 "url": "https://groups.google.com/forum/#!topic/rustlang-security-announcements/rVQ5e3TDnpQ"
             },
             {
-                "name": "https://github.com/rust-lang/cargo/pull/4953",
-                "refsource": "MISC",
-                "url": "https://github.com/rust-lang/cargo/pull/4953"
-            },
-            {
                 "name": "https://gist.github.com/pietroalbini/0d293b24a44babbeb6187e06eebd4992",
                 "refsource": "MISC",
                 "url": "https://gist.github.com/pietroalbini/0d293b24a44babbeb6187e06eebd4992"
-            },
-            {
-                "name": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml",
-                "refsource": "MISC",
-                "url": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml"
             }
         ]
     },


### PR DESCRIPTION
This is an update for CVE-2019-16760

- It removes two irrelevant references
- Updates the description for accuracy and to be a bit more minimal.

This is the first GitHub submitted CVE to be updated, we are continuing are evaluation so please advise us at security-advisories@github.com if anything we can do to streamline the process.
