### PR TITLE
[ISC] update vuln info for 9 CVEs from 2018 & 2019, processing backlog

### DIFF
--- a/2018/5xxx/CVE-2018-5732.json
+++ b/2018/5xxx/CVE-2018-5732.json
@@ -1,18 +1,96 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2018-5732",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
+   "CVE_data_meta": {
+      "ASSIGNER": "security-officer@isc.org",
+      "DATE_PUBLIC": "2018-02-28T00:00:00.000Z",
+      "ID": "CVE-2018-5732",
+      "STATE": "PUBLIC",
+      "TITLE": "A specially constructed response from a malicious server can cause a buffer overflow in dhclient"
+   },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "ISC DHCP",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_name": "ISC DHCP",
+                                 "version_value": "4.1.0 -> 4.1-ESV-R15, 4.2.0 -> 4.2.8, 4.3.0 -> 4.3.6, 4.4.0"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "ISC"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "credit": [
+      {
+         "lang": "eng",
+         "value": "ISC would like to thank Felix Wilhelm, Google Security Team, for reporting this vulnerability."
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
+         {
+            "lang": "eng",
+            "value": "Failure to properly bounds-check a buffer used for processing DHCP options allows a malicious server (or an entity masquerading as a server) to cause a buffer overflow (and resulting crash) in dhclient by sending a response containing a specially constructed options section.\n\nAffects ISC DHCP versions 4.1.0 -> 4.1-ESV-R15, 4.2.0 -> 4.2.8, 4.3.0 -> 4.3.6, 4.4.0"
+         }
+      ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 7.5,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Affected versions of dhclient should crash due to an out-of-bounds memory access if they receive and process a triggering response packet. However, buffer overflow outcomes can vary by operating system, and outcomes such as remote code execution may be possible in some circumstances. Where they are present, operating system mitigation strategies such as address space layout randomization (ASLR) should make it difficult to leverage this vulnerability to achieve remote code execution, but we cannot rule it out as impossible. The safest course is to patch dhclient so that the buffer overflow cannot occur."
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.isc.org/docs/aa-01565",
+            "refsource": "CONFIRM",
+            "url": "https://kb.isc.org/docs/aa-01565"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "Upgrade to the patched release most closely related to your current version of DHCP. ISC DHCP releases are available from https://www.isc.org/downloads.\n\n >=   DHCP 4.1-ESV-R15-P1\n >=   DHCP 4.3.6-P1\n >=   DHCP 4.4.1"
+      }
+   ],
+   "source": {
+      "discovery": "EXTERNAL"
+   }
 }

--- a/2018/5xxx/CVE-2018-5743.json
+++ b/2018/5xxx/CVE-2018-5743.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "security-officer@isc.org",
+        "DATE_PUBLIC": "2019-04-24T23:00:00.000Z",
         "ID": "CVE-2018-5743",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Limiting simultaneous TCP clients was ineffective"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "BIND 9",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_name": "BIND 9",
+                                            "version_value": "BIND 9.9.0 -> 9.10.8-P1, 9.11.0 -> 9.11.6, 9.12.0 -> 9.12.4, 9.14.0. BIND 9 Supported Preview Edition versions 9.9.3-S1 -> 9.11.5-S3, and 9.11.5-S5. Versions 9.13.0 -> 9.13.7 of the 9.13 development branch are also affected. Versions prior to BIND 9.9.0 have not been evaluated for vulnerability to CVE-2018-5743."
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ISC"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "ISC would like to thank AT&T for helping us to discover this issue."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "By design, BIND is intended to limit the number of TCP clients that can be connected at any given time. The number of allowed connections is a tunable parameter which, if unset, defaults to a conservative value for most servers. Unfortunately, the code which was intended to limit the number of simultaneous connections contained an error which could be exploited to grow the number of simultaneous connections beyond this limit.\n\nVersions affected:  BIND 9.9.0 -> 9.10.8-P1, 9.11.0 -> 9.11.6, 9.12.0 -> 9.12.4, 9.14.0. BIND 9 Supported Preview Edition versions 9.9.3-S1 -> 9.11.5-S3, and 9.11.5-S5. Versions 9.13.0 -> 9.13.7 of the 9.13 development branch are also affected. Versions prior to BIND 9.9.0 have not been evaluated for vulnerability to CVE-2018-5743."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "By exploiting the failure to limit simultaneous TCP connections, an attacker can deliberately exhaust the pool of file descriptors available to named, potentially affecting network connections and the management of files such as log files or zone journal files.  In cases where the named process is not limited by OS-enforced per-process limits, this could additionally potentially lead to exhaustion of all available free file descriptors on that system."
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://kb.isc.org/docs/cve-2018-5743",
+                "refsource": "CONFIRM",
+                "url": "https://kb.isc.org/docs/cve-2018-5743"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Upgrade to a version of BIND containing a fix for the ineffective limits.\n\n+    BIND 9.11.6-P1\n+    BIND 9.12.4-P1\n+    BIND 9.14.1\n\nBIND Supported Preview Edition is a special feature preview branch of BIND provided to eligible ISC support customers.\n\n +   BIND 9.11.5-S6\n +   BIND 9.11.6-S1"
+        }
+    ],
+    "source": {
+        "discovery": "USER"
     }
 }

--- a/2018/5xxx/CVE-2018-5744.json
+++ b/2018/5xxx/CVE-2018-5744.json
@@ -1,18 +1,96 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2018-5744",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
+   "CVE_data_meta": {
+      "ASSIGNER": "security-officer@isc.org",
+      "DATE_PUBLIC": "2019-02-21T00:00:00.000Z",
+      "ID": "CVE-2018-5744",
+      "STATE": "PUBLIC",
+      "TITLE": "A specially crafted packet can cause named to leak memory"
+   },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "BIND 9",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_name": "BIND 9",
+                                 "version_value": "BIND 9.10.7 -> 9.10.8-P1, 9.11.3 -> 9.11.5-P1, 9.12.0 -> 9.12.3-P1, and versions 9.10.7-S1 -> 9.11.5-S3 of BIND 9 Supported Preview Edition. Versions 9.13.0 -> 9.13.6 of the 9.13 development branch are also affected."
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "ISC"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "credit": [
+      {
+         "lang": "eng",
+         "value": "ISC would like to thank Toshifumi Sakaguchi for reporting this issue to us."
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
+         {
+            "lang": "eng",
+            "value": "A failure to free memory can occur when processing messages having a specific combination of EDNS options.\n\nVersions affected are: BIND 9.10.7 -> 9.10.8-P1, 9.11.3 -> 9.11.5-P1, 9.12.0 -> 9.12.3-P1, and versions 9.10.7-S1 -> 9.11.5-S3 of BIND 9 Supported Preview Edition. Versions 9.13.0 -> 9.13.6 of the 9.13 development branch are also affected."
+         }
+      ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 7.5,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "By exploiting this condition, an attacker can potentially cause named's memory use to grow without bounds until all memory available to the process is exhausted. Typically a server process is limited as to the amount of memory it can use but if the named process is not limited by the operating system all free memory on the server could be exhausted."
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.isc.org/docs/cve-2018-5744",
+            "refsource": "CONFIRM",
+            "url": "https://kb.isc.org/docs/cve-2018-5744"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "Upgrade to a version of BIND containing a fix for the memory leak.\n\n >=   BIND 9.11.5-P4\n >=   BIND 9.12.3-P4\n"
+      }
+   ],
+   "source": {
+      "discovery": "EXTERNAL"
+   }
 }

--- a/2018/5xxx/CVE-2018-5745.json
+++ b/2018/5xxx/CVE-2018-5745.json
@@ -1,18 +1,90 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2018-5745",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
+   "CVE_data_meta": {
+      "ASSIGNER": "security-officer@isc.org",
+      "DATE_PUBLIC": "2019-02-21T00:00:00.000Z",
+      "ID": "CVE-2018-5745",
+      "STATE": "PUBLIC",
+      "TITLE": "An assertion failure can occur if a trust anchor rolls over to an unsupported key algorithm when using managed-keys"
+   },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "BIND 9",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_name": "BIND 9",
+                                 "version_value": "BIND 9.9.0 -> 9.10.8-P1, 9.11.0 -> 9.11.5-P1, 9.12.0 -> 9.12.3-P1, and versions 9.9.3-S1 -> 9.11.5-S3 of BIND 9 Supported Preview Edition. Versions 9.13.0 -> 9.13.6 of the 9.13 development branch are also affected. Versions prior to BIND 9.9.0 have not been evaluated for vulnerability to CVE-2018-5745."
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "ISC"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
+         {
+            "lang": "eng",
+            "value": "\"managed-keys\" is a feature which allows a BIND resolver to automatically maintain the keys used by trust anchors which operators configure for use in DNSSEC validation. Due to an error in the managed-keys feature it is possible for a BIND server which uses managed-keys to exit due to an assertion failure if, during key rollover, a trust anchor's keys are replaced with keys which use an unsupported algorithm.\n\nVersions affected:  BIND 9.9.0 -> 9.10.8-P1, 9.11.0 -> 9.11.5-P1, 9.12.0 -> 9.12.3-P1, and versions 9.9.3-S1 -> 9.11.5-S3 of BIND 9 Supported Preview Edition. Versions 9.13.0 -> 9.13.6 of the 9.13 development branch are also affected. Versions prior to BIND 9.9.0 have not been evaluated for vulnerability to CVE-2018-5745."
+         }
+      ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 4.9,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "NONE",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "HIGH",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "This particular vulnerability would be very difficult for an arbitrary attacker to use because it requires an operator to have BIND configured to use a trust anchor managed by the attacker. However, if successfully exercised, the defect will cause named to deliberately exit after encountering an assertion failure.\n\nIt is more likely, perhaps, that this bug could be encountered accidentally, as not all versions of BIND support the same set of cryptographic algorithms. Specifically, recent branches of BIND have begun deliberately removing support for cryptographic algorithms that are now deprecated (for example because they are no longer considered sufficiently secure.) This vulnerability could be encountered if a resolver running a version of BIND which has removed support for deprecated algorithms is configured to use a trust anchor which elects to change algorithm types to one of those deprecated algorithms.\n\n    Support for GOST was removed from BIND in 9.13.1.\n    Support for DSA was removed from BIND in 9.13.4\n    Support for RSAMD5 will be removed from future BIND releases in the 9.13 branch and higher.\n"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.isc.org/docs/cve-2018-5745",
+            "refsource": "CONFIRM",
+            "url": "https://kb.isc.org/docs/cve-2018-5745"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "Upgrade to a version of BIND containing a fix preventing the assertion failure.\n\n>=    BIND 9.11.5-P4\n>=    BIND 9.12.3-P4\n\nBIND Supported Preview Edition is a special feature preview branch of BIND provided to eligible ISC support customers.\n\n>=    BIND 9.11.5-S5\n"
+      }
+   ],
+   "source": {
+      "discovery": "INTERNAL"
+   }
 }

--- a/2019/6xxx/CVE-2019-6465.json
+++ b/2019/6xxx/CVE-2019-6465.json
@@ -1,18 +1,90 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-6465",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
+   "CVE_data_meta": {
+      "ASSIGNER": "security-officer@isc.org",
+      "DATE_PUBLIC": "2019-02-21T00:00:00.000Z",
+      "ID": "CVE-2019-6465",
+      "STATE": "PUBLIC",
+      "TITLE": "Zone transfer controls for writable DLZ zones were not effective"
+   },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "BIND 9",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_name": "BIND 9",
+                                 "version_value": "BIND 9.9.0 -> 9.10.8-P1, 9.11.0 -> 9.11.5-P2, 9.12.0 -> 9.12.3-P2, and versions 9.9.3-S1 -> 9.11.5-S3 of BIND 9 Supported Preview Edition. Versions 9.13.0 -> 9.13.6 of the 9.13 development branch are also affected. Versions prior to BIND 9.9.0 have not been evaluated for vulnerability to CVE-2019-6465."
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "ISC"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
+         {
+            "lang": "eng",
+            "value": "Controls for zone transfers may not be properly applied to Dynamically Loadable Zones (DLZs) if the zones are writable\n\nVersions affected:  BIND 9.9.0 -> 9.10.8-P1, 9.11.0 -> 9.11.5-P2, 9.12.0 -> 9.12.3-P2, and versions 9.9.3-S1 -> 9.11.5-S3 of BIND 9 Supported Preview Edition. Versions 9.13.0 -> 9.13.6 of the 9.13 development branch are also affected. Versions prior to BIND 9.9.0 have not been evaluated for vulnerability to CVE-2019-6465."
+         }
+      ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "NONE",
+         "baseScore": 5.3,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "LOW",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "A client exercising this defect can request and receive a zone transfer of a DLZ even when not permitted to do so by the allow-transfer ACL."
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "https://kb.isc.org/docs/cve-2019-6465",
+            "refsource": "CONFIRM",
+            "url": "https://kb.isc.org/docs/cve-2019-6465"
+         }
+      ]
+   },
+   "solution": [
+      {
+         "lang": "eng",
+         "value": "Upgrade to the patched release most closely related to your current version of BIND:\n\n>=    BIND 9.11.5-P4\n>=    BIND 9.12.3-P4\n\nBIND Supported Preview Edition is a special feature preview branch of BIND provided to eligible ISC support customers.\n\n>=    BIND 9.11.5-S5\n"
+      }
+   ],
+   "source": {
+      "discovery": "EXTERNAL"
+   }
 }

--- a/2019/6xxx/CVE-2019-6467.json
+++ b/2019/6xxx/CVE-2019-6467.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "security-officer@isc.org",
+        "DATE_PUBLIC": "2019-04-24T23:00:00.000Z",
         "ID": "CVE-2019-6467",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "An error in the nxdomain redirect feature can cause BIND to exit with an INSIST assertion failure in query.c"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "BIND 9",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_name": "BIND 9",
+                                            "version_value": "BIND 9.12.0-> 9.12.4, 9.14.0. Also affects all releases in the 9.13 development branch."
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ISC"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "ISC would like to thank Quad9 for reporting this issue."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,63 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A programming error in the nxdomain-redirect feature can cause an assertion failure in query.c if the alternate namespace used by nxdomain-redirect is a descendant of a zone that is served locally.\n\nThe most likely scenario where this might occur is if the server, in addition to performing NXDOMAIN redirection for recursive clients, is also serving a local copy of the root zone or using mirroring to provide the root zone, although other configurations are also possible.\n\nVersions affected: BIND 9.12.0-> 9.12.4, 9.14.0. Also affects all releases in the 9.13 development branch."
             }
         ]
-    }
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.9,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "An attacker who can deliberately trigger the condition on a server with a vulnerable configuration can cause BIND to exit, denying service to other clients."
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://kb.isc.org/docs/cve-2019-6467",
+                "refsource": "CONFIRM",
+                "url": "https://kb.isc.org/docs/cve-2019-6467"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Upgrade to the patched release most closely related to your current version of BIND:\n\n+   BIND 9.12.4-P1\n+   BIND 9.14.1\n\n\n\n\n"
+        }
+    ],
+    "source": {
+        "discovery": "USER"
+    },
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "Exploitation of this defect can be effectively prevented by disabling the nxdomain-redirect feature in the nameserver's configuration."
+        }
+    ]
 }

--- a/2019/6xxx/CVE-2019-6468.json
+++ b/2019/6xxx/CVE-2019-6468.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "security-officer@isc.org",
+        "DATE_PUBLIC": "2019-04-24T23:00:00.000Z",
         "ID": "CVE-2019-6468",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "BIND Supported Preview Edition can exit with an assertion failure if nxdomain-redirect is used"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "BIND 9 Supported Preview Edition",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_name": "BIND 9",
+                                            "version_value": "9.10.5-S1 -> 9.11.5-S5"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ISC"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "ISC would like to thank Quad9 for reporting this issue."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,63 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In BIND Supported Preview Edition, an error in the nxdomain-redirect feature can occur in versions which support EDNS Client Subnet (ECS) features. In those versions which have ECS support, enabling nxdomain-redirect is likely to lead to BIND exiting due to assertion failure.\n\nVersions affected: BIND Supported Preview Edition version 9.10.5-S1 -> 9.11.5-S5. ONLY BIND Supported Preview Edition releases are affected."
             }
         ]
-    }
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "If nxdomain-redirect is enabled (via configuration) in a vulnerable BIND release, a malicious party can cause BIND to exit by deliberately triggering the bug."
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://kb.isc.org/docs/cve-2019-6468",
+                "refsource": "CONFIRM",
+                "url": "https://kb.isc.org/docs/cve-2019-6468"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Upgrade to the patched release most closely related to your current version of BIND:\n\nBIND Supported Preview Edition is a special feature preview branch of BIND provided to eligible ISC support customers.\n\n+    BIND 9.11.5-S6\n+    BIND 9.11.6-S1\n\n\n\n"
+        }
+    ],
+    "source": {
+        "discovery": "USER"
+    },
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "Exploitation of this defect can be effectively prevented by disabling the nxdomain-redirect feature in the nameserver's configuration."
+        }
+    ]
 }

--- a/2019/6xxx/CVE-2019-6469.json
+++ b/2019/6xxx/CVE-2019-6469.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "security-officer@isc.org",
+        "DATE_PUBLIC": "2019-05-29T23:00:00.000Z",
         "ID": "CVE-2019-6469",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "BIND Supported Preview Edition can exit with an assertion failure if ECS is in use"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "BIND 9 Supported Preview Edition",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_name": "BIND 9",
+                                            "version_value": "BIND 9.10.5-S1 -> 9.11.6-S1 of BIND 9 Supported Preview Edition."
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ISC"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "ISC would like to thank Quad9 for reporting this issue."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,63 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An error in the EDNS Client Subnet (ECS) feature for recursive resolvers can cause BIND to exit with an assertion failure when processing a response that has malformed RRSIGs.\n\nVersions affected:  BIND 9.10.5-S1 -> 9.11.6-S1 of BIND 9 Supported Preview Edition."
             }
         ]
-    }
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.9,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "An attacker who is able to cause a server to perform a query whose answer will be accompanied by malformed RRSIGs can deliberately cause a server to exit if it is using the recursive ECS feature."
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://kb.isc.org/docs/cve-2019-6469",
+                "refsource": "CONFIRM",
+                "url": "https://kb.isc.org/docs/cve-2019-6469"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Upgrade to the patched release most closely related to your current version of BIND:\n\nBIND Supported Preview Edition is a special feature preview branch of BIND provided to eligible ISC support customers.\n\n>=    BIND 9.11.7-S1\n"
+        }
+    ],
+    "source": {
+        "discovery": "USER"
+    },
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "Only servers which have enabled the EDNS Client Subnet (ECS) feature can be affected by this defect; it can be prevented by disabling ECS options in the server's configuration."
+        }
+    ]
 }

--- a/2019/6xxx/CVE-2019-6471.json
+++ b/2019/6xxx/CVE-2019-6471.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "security-officer@isc.org",
+        "DATE_PUBLIC": "2019-06-19T23:00:00.000Z",
         "ID": "CVE-2019-6471",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "A race condition when discarding malformed packets can cause BIND to exit with an assertion failure"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "BIND 9",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_name": "BIND 9",
+                                            "version_value": "BIND 9.11.0 -> 9.11.7, 9.12.0 -> 9.12.4-P1, 9.14.0 -> 9.14.2. Also all releases of the BIND 9.13 development branch and version 9.15.0 of the BIND 9.15 development branch and BIND Supported Preview Edition versions 9.11.3-S1 -> 9.11.7-S1."
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ISC"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "ISC would like to thank CERN for helping us to discover this issue."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A race condition which may occur when discarding malformed packets can result in BIND exiting due to a REQUIRE assertion failure in dispatch.c.\n\nVersions affected: BIND 9.11.0 -> 9.11.7, 9.12.0 -> 9.12.4-P1, 9.14.0 -> 9.14.2. Also all releases of the BIND 9.13 development branch and version 9.15.0 of the BIND 9.15 development branch and BIND Supported Preview Edition versions 9.11.3-S1 -> 9.11.7-S1."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.9,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "An attacker who can cause a resolver to perform queries which will be answered by a server which responds with deliberately malformed answers can cause named to exit, denying service to clients."
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://kb.isc.org/docs/cve-2019-6471",
+                "refsource": "CONFIRM",
+                "url": "https://kb.isc.org/docs/cve-2019-6471"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Upgrade to the patched release most closely related to your current version of BIND:\n\n    BIND 9.11.8\n    BIND 9.12.4-P2\n    BIND 9.14.3\n    BIND 9.15.1\n\nBIND Supported Preview Edition is a special feature preview branch of BIND provided to eligible ISC support customers.\n\n    BIND 9.11.8-S1"
+        }
+    ],
+    "source": {
+        "discovery": "USER"
     }
 }


### PR DESCRIPTION
Resubmitting (via github) previously-submitted CVE list updates that were rejected
because e-mail submission is no longer supported.