### PR TITLE
add CVE-2019-16763

### DIFF
--- a/2019/16xxx/CVE-2019-16763.json
+++ b/2019/16xxx/CVE-2019-16763.json
@@ -92,13 +92,6 @@
                         "value": "CWE-79 Cross-site Scripting (XSS)"
                     }
                 ]
-            },
-            {
-                "description": [
-                    {
-                        "lang": "eng"
-                    }
-                ]
             }
         ]
     },

--- a/2019/16xxx/CVE-2019-16763.json
+++ b/2019/16xxx/CVE-2019-16763.json
@@ -1,0 +1,129 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
+        "ID": "CVE-2019-16763",
+        "STATE": "PUBLIC",
+        "TITLE": "XSS in Pannellum from 2.5.0 through 2.5.4"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "pannellum",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "=",
+                                            "version_name": "2.5.0",
+                                            "version_value": "2.5.0"
+                                        },
+                                        {
+                                            "version_affected": "=",
+                                            "version_name": "2.5.1",
+                                            "version_value": "2.5.1"
+                                        },
+                                        {
+                                            "version_affected": "=",
+                                            "version_name": "2.5.2",
+                                            "version_value": "2.5.2"
+                                        },
+                                        {
+                                            "version_affected": "=",
+                                            "version_name": "2.5.3",
+                                            "version_value": "2.5.3"
+                                        },
+                                        {
+                                            "version_affected": "=",
+                                            "version_name": "2.5.4",
+                                            "version_value": "2.5.4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "mpretroff"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Thank you to Max Schaefer of GitHub Security Lab for reporting this issue."
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "In Pannellum from 2.5.0 through 2.5.4 URLs were not sanitized for data URIs (or vbscript:), allowing for potential XSS attacks. Such an attack would require a user to click on a hot spot to execute and would require an attacker-provided configuration. The most plausible potential attack would be if pannellum.htm was hosted on a domain that shared cookies with the targeted site's user authentication; an &lt;iframe&gt; could then be embedded on the attacker's site using pannellum.htm from the targeted site, which would allow the attacker to potentially access information from the targeted site as the authenticated user (or worse if the targeted site did not have adequate CSRF protections) if the user clicked on a hot spot in the attacker's embedded panorama viewer.\n\nThis was patched in version 2.5.5."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.8,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:H/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79 Cross-site Scripting (XSS)"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/mpetroff/pannellum/security/advisories/GHSA-m52x-29pq-w3vv",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/mpetroff/pannellum/security/advisories/GHSA-m52x-29pq-w3vv"
+            },
+            {
+                "name": "https://github.com/mpetroff/pannellum/commit/cc2f3d99953de59db908e0c6efd1c2c17f7c6914",
+                "refsource": "MISC",
+                "url": "https://github.com/mpetroff/pannellum/commit/cc2f3d99953de59db908e0c6efd1c2c17f7c6914"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-m52x-29pq-w3vv",
+        "discovery": "EXTERNAL"
+    },
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "Don't host pannellum.htm on a domain that shares cookies with user authentication."
+        }
+    ]
+}


### PR DESCRIPTION
Adding this advisory: https://github.com/mpetroff/pannellum/security/advisories/GHSA-m52x-29pq-w3vv

This has been assigned CVE-2019-16763 by the GitHub CNA