### PR TITLE
update CVE-2019-16771 with correct reference

### DIFF
--- a/2019/16xxx/CVE-2019-16771.json
+++ b/2019/16xxx/CVE-2019-16771.json
@@ -77,9 +77,9 @@
                 "url": "https://github.com/line/armeria/security/advisories/GHSA-35fr-h7jr-hh86"
             },
             {
-                "name": "https://github.com/line/armeria/commit/80310b36196b6fa6efd15af61635d2aa48c44418",
+                "name": "https://github.com/line/armeria/commit/b597f7a865a527a84ee3d6937075cfbb4470ed20",
                 "refsource": "MISC",
-                "url": "https://github.com/line/armeria/commit/80310b36196b6fa6efd15af61635d2aa48c44418"
+                "url": "https://github.com/line/armeria/commit/b597f7a865a527a84ee3d6937075cfbb4470ed20"
             }
         ]
     },


### PR DESCRIPTION
Correcting a mistake in the github commit that was initially linked from CVE-2019-16771.

Now the CVE links to https://github.com/line/armeria/commit/b597f7a865a527a84ee3d6937075cfbb4470ed20 which is the correct fix commit for GHSA-35fr-h7jr-hh86.

Thanks `@JLLeitschuh` for notifying us about this innacuracy 🙇 