### PR TITLE
add CVE-2019-16786 for GHSA-g2xc-35jw-c63p

### DIFF
--- a/2019/16xxx/CVE-2019-16786.json
+++ b/2019/16xxx/CVE-2019-16786.json
@@ -1,0 +1,95 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
+        "ID": "CVE-2019-16786",
+        "STATE": "PUBLIC",
+        "TITLE": "HTTP Request Smuggling: Invalid Transfer-Encoding in Waitress"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Waitress",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "<= 1.3.1",
+                                            "version_value": "1.3.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Pylons"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "Waitress through version 1.3.1 would parse the Transfer-Encoding header and only look for a single string value, if that value was not chunked it would fall through and use the Content-Length header instead.\n\nAccording to the HTTP standard Transfer-Encoding should be a comma separated list, with the inner-most encoding first, followed by any further transfer codings, ending with chunked.\n\nRequests sent with: \"Transfer-Encoding: gzip, chunked\" would incorrectly get ignored, and the request would use a Content-Length header instead to determine the body size of the HTTP message.\n\nThis could allow for Waitress to treat a single request as multiple requests in the case of HTTP pipelining.\n\nThis issue is fixed in Waitress 1.4.0."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-444 Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/Pylons/waitress/security/advisories/GHSA-g2xc-35jw-c63p",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/Pylons/waitress/security/advisories/GHSA-g2xc-35jw-c63p"
+            },
+            {
+                "name": "https://docs.pylonsproject.org/projects/waitress/en/latest/#security-fixes",
+                "refsource": "MISC",
+                "url": "https://docs.pylonsproject.org/projects/waitress/en/latest/#security-fixes"
+            },
+            {
+                "name": "https://github.com/Pylons/waitress/commit/f11093a6b3240fc26830b6111e826128af7771c3",
+                "refsource": "MISC",
+                "url": "https://github.com/Pylons/waitress/commit/f11093a6b3240fc26830b6111e826128af7771c3"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-g2xc-35jw-c63p",
+        "discovery": "UNKNOWN"
+    }
+}


### PR DESCRIPTION
add CVE-2019-16786 for GHSA-g2xc-35jw-c63p