### PR TITLE
correct mistake in CVE-2019-16780 version_data

### DIFF
--- a/2019/16xxx/CVE-2019-16780.json
+++ b/2019/16xxx/CVE-2019-16780.json
@@ -17,8 +17,8 @@
                                     "version_data": [
                                         {
                                             "version_affected": "<",
-                                            "version_name": "< 3.5.1",
-                                            "version_value": "3.5.1"
+                                            "version_name": "< 5.3.1",
+                                            "version_value": "5.3.1"
                                         }
                                     ]
                                 }


### PR DESCRIPTION
in the initial submission, the version value was "3.5.1".  This corrects it to 5.3.1.