### PR TITLE
add CVE-2020-5207 for GHSA-xrr9-rh8p-433v

### DIFF
--- a/2020/5xxx/CVE-2020-5207.json
+++ b/2020/5xxx/CVE-2020-5207.json
@@ -1,18 +1,88 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-5207",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Request smuggling is possible in Ktor when both chunked TE and content length specified"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Ktor",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.3.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Ktor.io"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Ktor before 1.3.0, request smuggling is possible when running behind a proxy that doesn't handle Content-Length and Transfer-Encoding properly or doesn't handle \\n as a headers separator."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-444 Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/ktorio/ktor/security/advisories/GHSA-xrr9-rh8p-433v",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/ktorio/ktor/security/advisories/GHSA-xrr9-rh8p-433v"
+            },
+            {
+                "name": "https://github.com/ktorio/ktor/pull/1547",
+                "refsource": "MISC",
+                "url": "https://github.com/ktorio/ktor/pull/1547"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-xrr9-rh8p-433v",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
add CVE-2020-5207 for GHSA-xrr9-rh8p-433v