### PR TITLE
update description of CVE-2019-16770 with correct fix version

### DIFF
--- a/2019/16xxx/CVE-2019-16770.json
+++ b/2019/16xxx/CVE-2019-16770.json
@@ -37,7 +37,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In Puma before version 4.3.2, a poorly-behaved client could use keepalive requests to monopolize Puma's reactor and create a denial of service attack. If more keepalive connections to Puma are opened than there are threads available, additional connections will wait permanently if the attacker sends requests frequently enough."
+                "value": "In Puma before versions 3.12.2 and 4.3.1, a poorly-behaved client could use keepalive requests to monopolize Puma's reactor and create a denial of service attack. If more keepalive connections to Puma are opened than there are threads available, additional connections will wait permanently if the attacker sends requests frequently enough.\n\nThis vulnerability is patched in Puma 4.3.1 and 3.12.2."
             }
         ]
     },


### PR DESCRIPTION
This updates description of CVE-2019-16770 to note the correct affected versions, and patched versions of the Puma package.

This is in response to a message from MITRE that someone noted the incorrect data.