### PR TITLE
ISC.org: reject additional unused allocated numbers

### DIFF
--- a/2017/3xxx/CVE-2017-3146.json
+++ b/2017/3xxx/CVE-2017-3146.json
@@ -2,7 +2,7 @@
     "CVE_data_meta": {
         "ASSIGNER": "cve@mitre.org",
         "ID": "CVE-2017-3146",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. Reason: The CNA or individual who requested this candidate did not associate it with any vulnerability during 2019."
             }
         ]
     }

--- a/2017/3xxx/CVE-2017-3147.json
+++ b/2017/3xxx/CVE-2017-3147.json
@@ -2,7 +2,7 @@
     "CVE_data_meta": {
         "ASSIGNER": "cve@mitre.org",
         "ID": "CVE-2017-3147",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. Reason: The CNA or individual who requested this candidate did not associate it with any vulnerability during 2019."
             }
         ]
     }

--- a/2017/3xxx/CVE-2017-3148.json
+++ b/2017/3xxx/CVE-2017-3148.json
@@ -2,7 +2,7 @@
     "CVE_data_meta": {
         "ASSIGNER": "cve@mitre.org",
         "ID": "CVE-2017-3148",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. Reason: The CNA or individual who requested this candidate did not associate it with any vulnerability during 2019."
             }
         ]
     }

--- a/2017/3xxx/CVE-2017-3149.json
+++ b/2017/3xxx/CVE-2017-3149.json
@@ -2,7 +2,7 @@
     "CVE_data_meta": {
         "ASSIGNER": "cve@mitre.org",
         "ID": "CVE-2017-3149",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. Reason: The CNA or individual who requested this candidate did not associate it with any vulnerability during 2019."
             }
         ]
     }

--- a/2018/5xxx/CVE-2018-5746.json
+++ b/2018/5xxx/CVE-2018-5746.json
@@ -2,7 +2,7 @@
     "CVE_data_meta": {
         "ASSIGNER": "cve@mitre.org",
         "ID": "CVE-2018-5746",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. Reason: The CNA or individual who requested this candidate did not associate it with any vulnerability during 2019."
             }
         ]
     }

--- a/2019/6xxx/CVE-2019-6466.json
+++ b/2019/6xxx/CVE-2019-6466.json
@@ -2,7 +2,7 @@
     "CVE_data_meta": {
         "ASSIGNER": "cve@mitre.org",
         "ID": "CVE-2019-6466",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. Reason: The CNA or individual who requested this candidate did not associate it with any vulnerability during 2019."
             }
         ]
     }


### PR DESCRIPTION
Rejecting 6 additional numbers allocated in 2017, 2018, and 2019