### PR TITLE
add CVE-2020-5239 for GHSA-2467-p5gv-58q6

### DIFF
--- a/2020/5xxx/CVE-2020-5239.json
+++ b/2020/5xxx/CVE-2020-5239.json
@@ -1,18 +1,88 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-5239",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Unspecified vulnerability in the fetchmail script in Mailu"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Mailu",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.7"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Mailu"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Mailu before version 1.7, an authenticated user can exploit a vulnerability in Mailu fetchmail script and gain full access to a Mailu instance. Mailu servers that have open registration or untrusted users are most impacted.\n\nThe master and 1.7 branches are patched on our git repository. All Docker images published on docker.io/mailu for tags 1.5, 1.6, 1.7 and master are patched. For detailed instructions about patching and securing the server afterwards, see https://github.com/Mailu/Mailu/issues/1354"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 8.7,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-863: Incorrect Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/Mailu/Mailu/security/advisories/GHSA-2467-p5gv-58q6",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/Mailu/Mailu/security/advisories/GHSA-2467-p5gv-58q6"
+            },
+            {
+                "name": "https://github.com/Mailu/Mailu/issues/1354",
+                "refsource": "MISC",
+                "url": "https://github.com/Mailu/Mailu/issues/1354"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-2467-p5gv-58q6",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
add CVE-2020-5239 for GHSA-2467-p5gv-58q6