### PR TITLE
2020-02-14

### DIFF
--- a/2019/19xxx/CVE-2019-19757.json
+++ b/2019/19xxx/CVE-2019-19757.json
@@ -1,18 +1,92 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "psirt@lenovo.com",
+        "DATE_PUBLIC": "2020-02-14T17:00:00.000Z",
         "ID": "CVE-2019-19757",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "XClarity Administrator (LXCA)",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "2.6.6"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Lenovo"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An internal product security audit of Lenovo XClarity Administrator (LXCA) discovered a Document Object Model (DOM) based cross-site scripting vulnerability in versions prior to 2.6.6 that could allow JavaScript code to be executed in the user's web browser if a specially crafted link is visited. The JavaScript code is executed on the user's system, not executed on LXCA itself."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79 Cross-site Scripting (XSS)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://support.lenovo.com/us/en/product_security/LEN-29477"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update your LXCA installation to version 2.6.6 or later. Installation note:  You will need to update to LXCA 2.6.0 before installing the latest fix bundle (v 2.6.6)."
+        }
+    ],
+    "source": {
+        "advisory": "LEN-29477",
+        "discovery": "UNKNOWN"
     }
 }

--- a/2019/19xxx/CVE-2019-19758.json
+++ b/2019/19xxx/CVE-2019-19758.json
@@ -1,18 +1,109 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "psirt@lenovo.com",
+        "DATE_PUBLIC": "2020-02-14T17:00:00.000Z",
         "ID": "CVE-2019-19758",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "EZ Media & Backup Center ix2",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "4.1.406.34763"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "product_name": "EZ Media & Backup Center ix2-dl",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "4.1.406.34763"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Lenovo"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Lenovo thanks Mostafa Noureldin for reporting this issue."
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A vulnerability in the web interface of Lenovo EZ Media & Backup Center, ix2 & ix2-dl version 4.1.406.34763 and prior could allow an unauthenticated, remote attacker to redirect a user to an untrusted web page."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.1,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-601 URL Redirection to Untrusted Site ('Open Redirect')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://support.lenovo.com/us/en/product_security/LEN-30242"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Lenovo has ended support for Lenovo EZ Media & Backup Center, ix2 & ix2-dl as of March 31, 2019, therefore Lenovo recommends discontinuation of use. If it is not feasible to discontinue use, Lenovo recommends using the device only on trusted networks and clicking on device URLs only from trustworthy sources."
+        }
+    ],
+    "source": {
+        "advisory": "LEN-30242",
+        "discovery": "UNKNOWN"
     }
 }

--- a/2019/19xxx/CVE-2019-19762.json
+++ b/2019/19xxx/CVE-2019-19762.json
@@ -5,13 +5,13 @@
     "CVE_data_meta": {
         "ID": "CVE-2019-19762",
         "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** Unused CVE for 2019."
             }
         ]
     }

--- a/2019/19xxx/CVE-2019-19763.json
+++ b/2019/19xxx/CVE-2019-19763.json
@@ -5,13 +5,13 @@
     "CVE_data_meta": {
         "ID": "CVE-2019-19763",
         "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** Unused CVE for 2019."
             }
         ]
     }

--- a/2019/19xxx/CVE-2019-19764.json
+++ b/2019/19xxx/CVE-2019-19764.json
@@ -5,13 +5,13 @@
     "CVE_data_meta": {
         "ID": "CVE-2019-19764",
         "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** Unused CVE for 2019."
             }
         ]
     }

--- a/2019/19xxx/CVE-2019-19765.json
+++ b/2019/19xxx/CVE-2019-19765.json
@@ -5,13 +5,13 @@
     "CVE_data_meta": {
         "ID": "CVE-2019-19765",
         "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** Unused CVE for 2019."
             }
         ]
     }

--- a/2019/6xxx/CVE-2019-6190.json
+++ b/2019/6xxx/CVE-2019-6190.json
@@ -1,8 +1,33 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "psirt@lenovo.com",
+        "DATE_PUBLIC": "2020-02-14T17:00:00.000Z",
         "ID": "CVE-2019-6190",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "BIOS",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "=",
+                                            "version_value": "various"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Lenovo"
+                }
+            ]
+        }
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,8 +36,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Lenovo was notified of a potential denial of service vulnerability, affecting various versions of BIOS for Lenovo Desktop, Desktop - All in One, and ThinkStation, that could cause PCRs to be cleared intermittently after resuming from sleep (S3) on systems with Intel TXT enabled."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "denial of service"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://support.lenovo.com/us/en/product_security/LEN-28078"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update system firmware to the version (or newer) indicated for your model in the Product Impact section of LEN-28078."
+        }
+    ],
+    "source": {
+        "advisory": "LEN-28078",
+        "discovery": "UNKNOWN"
     }
 }

--- a/2019/6xxx/CVE-2019-6193.json
+++ b/2019/6xxx/CVE-2019-6193.json
@@ -1,8 +1,33 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "psirt@lenovo.com",
+        "DATE_PUBLIC": "2020-02-14T17:00:00.000Z",
         "ID": "CVE-2019-6193",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "XClarity Administrator (LXCA)",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "2.6.6"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Lenovo"
+                }
+            ]
+        }
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,8 +36,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An information disclosure vulnerability was reported in Lenovo XClarity Administrator (LXCA) versions prior to 2.6.6 that could allow unauthenticated access to some configuration files which may contain usernames, license keys, IP addresses, and encrypted password hashes."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-284 Improper Access Control"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://support.lenovo.com/us/en/product_security/LEN-29477"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update your LXCA installation to version 2.6.6 or later. Installation note:  You will need to update to LXCA 2.6.0 before installing the latest fix bundle (v 2.6.6)."
+        }
+    ],
+    "source": {
+        "advisory": "LEN-29477",
+        "discovery": "UNKNOWN"
     }
 }

--- a/2019/6xxx/CVE-2019-6194.json
+++ b/2019/6xxx/CVE-2019-6194.json
@@ -1,8 +1,33 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "psirt@lenovo.com",
+        "DATE_PUBLIC": "2020-02-14T17:00:00.000Z",
         "ID": "CVE-2019-6194",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "XClarity Administrator (LXCA)",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "2.6.6"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Lenovo"
+                }
+            ]
+        }
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,8 +36,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An XML External Entity (XXE) processing vulnerability was reported in Lenovo XClarity Administrator (LXCA) versions prior to 2.6.6 that could allow information disclosure."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.7,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-611 Improper Restriction of XML External Entity Reference ('XXE')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://support.lenovo.com/us/en/product_security/LEN-29477"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update your LXCA installation to version 2.6.6 or later. Installation note:  You will need to update to LXCA 2.6.0 before installing the latest fix bundle (v 2.6.6)."
+        }
+    ],
+    "source": {
+        "advisory": "LEN-29477",
+        "discovery": "UNKNOWN"
     }
 }

--- a/2019/6xxx/CVE-2019-6195.json
+++ b/2019/6xxx/CVE-2019-6195.json
@@ -1,8 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "psirt@lenovo.com",
+        "DATE_PUBLIC": "2020-02-14T17:00:00.000Z",
         "ID": "CVE-2019-6195",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "XClarity Controller (XCC)",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "3.08 CDI340V"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "3.01 TEI392O"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "1.71 PSI328N"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Lenovo"
+                }
+            ]
+        }
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,8 +44,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An authorization bypass exists in Lenovo XClarity Controller (XCC) versions prior to 3.08 CDI340V, 3.01 TEI392O, 1.71 PSI328N where a valid authenticated user with lesser privileges may be granted read-only access to higher-privileged information if 1) “LDAP Authentication Only with Local Authorization” mode is configured and used by XCC, and 2) a lesser privileged user logs into XCC within 1 minute of a higher privileged user logging out. The authorization bypass does not exist when “Local Authentication and Authorization” or “LDAP Authentication and Authorization” modes are configured and used by XCC."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.8,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-264 Permissions, Privileges, and Access Controls"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://support.lenovo.com/us/en/product_security/LEN-29116"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update to Lenovo XClarity Controller (XCC) version 3.08 CDI340V, 3.01 TEI392O, 1.71 PSI328N or higher."
+        }
+    ],
+    "source": {
+        "advisory": "LEN-29116",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Populated CVEs for February advisories and set unused 2019 CVEs to REJECT.