### PR TITLE
Update our URLs to point to the new Palo Alto Networks advisory website.

### DIFF
--- a/2011/4xxx/CVE-2011-4108.json
+++ b/2011/4xxx/CVE-2011-4108.json
@@ -158,9 +158,9 @@
                 "url": "http://secunia.com/advisories/57353"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/17",
+                "name": "https://security.paloaltonetworks.com/CVE-2011-4108",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/17"
+                "url": "https://security.paloaltonetworks.com/CVE-2011-4108"
             },
             {
                 "name": "SSRT100891",

--- a/2012/6xxx/CVE-2012-6590.json
+++ b/2012/6xxx/CVE-2012-6590.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/1",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6590",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/1"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6590"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6591.json
+++ b/2012/6xxx/CVE-2012-6591.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/2",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6591",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/2"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6591"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6592.json
+++ b/2012/6xxx/CVE-2012-6592.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/3",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6592",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/3"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6592"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6593.json
+++ b/2012/6xxx/CVE-2012-6593.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/4",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6593",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/4"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6593"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6594.json
+++ b/2012/6xxx/CVE-2012-6594.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/5",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6594",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/5"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6594"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6595.json
+++ b/2012/6xxx/CVE-2012-6595.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/6",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6595",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/6"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6595"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6596.json
+++ b/2012/6xxx/CVE-2012-6596.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/7",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6596",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/7"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6596"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6597.json
+++ b/2012/6xxx/CVE-2012-6597.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/8",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6597",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/8"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6597"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6598.json
+++ b/2012/6xxx/CVE-2012-6598.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/9",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6598",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/9"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6598"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6599.json
+++ b/2012/6xxx/CVE-2012-6599.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/10",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6599",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/10"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6599"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6600.json
+++ b/2012/6xxx/CVE-2012-6600.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/11",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6600",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/11"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6600"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6601.json
+++ b/2012/6xxx/CVE-2012-6601.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/12",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6601",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/12"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6601"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6602.json
+++ b/2012/6xxx/CVE-2012-6602.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/13",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6602",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/13"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6602"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6603.json
+++ b/2012/6xxx/CVE-2012-6603.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/14",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6603",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/14"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6603"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6604.json
+++ b/2012/6xxx/CVE-2012-6604.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/15",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6604",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/15"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6604"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6605.json
+++ b/2012/6xxx/CVE-2012-6605.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/16",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6605",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/16"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6605"
             }
         ]
     }

--- a/2012/6xxx/CVE-2012-6606.json
+++ b/2012/6xxx/CVE-2012-6606.json
@@ -58,9 +58,9 @@
                 "url": "http://archives.neohapsis.com/archives/bugtraq/2012-10/0100.html"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/18",
+                "name": "https://security.paloaltonetworks.com/CVE-2012-6606",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/18"
+                "url": "https://security.paloaltonetworks.com/CVE-2012-6606"
             }
         ]
     }

--- a/2013/5xxx/CVE-2013-5663.json
+++ b/2013/5xxx/CVE-2013-5663.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/19",
+                "name": "https://security.paloaltonetworks.com/CVE-2013-5663",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/19"
+                "url": "https://security.paloaltonetworks.com/CVE-2013-5663"
             },
             {
                 "name": "http://researchcenter.paloaltonetworks.com/2013/01/app-id-cache-pollution-update/",

--- a/2013/5xxx/CVE-2013-5664.json
+++ b/2013/5xxx/CVE-2013-5664.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/20",
+                "name": "https://security.paloaltonetworks.com/CVE-2013-5664",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/20"
+                "url": "https://security.paloaltonetworks.com/CVE-2013-5664"
             }
         ]
     }

--- a/2014/3xxx/CVE-2014-3764.json
+++ b/2014/3xxx/CVE-2014-3764.json
@@ -58,9 +58,9 @@
                 "url": "http://secunia.com/advisories/61811"
             },
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/27",
+                "name": "https://security.paloaltonetworks.com/CVE-2014-3764",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/27"
+                "url": "https://security.paloaltonetworks.com/CVE-2014-3764"
             }
         ]
     }

--- a/2014/9xxx/CVE-2014-9708.json
+++ b/2014/9xxx/CVE-2014-9708.json
@@ -98,9 +98,9 @@
                 "url": "http://seclists.org/fulldisclosure/2015/Mar/158"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/60",
+                "name": "https://security.paloaltonetworks.com/CVE-2014-9708",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/60"
+                "url": "https://security.paloaltonetworks.com/CVE-2014-9708"
             }
         ]
     }

--- a/2015/2xxx/CVE-2015-2223.json
+++ b/2015/2xxx/CVE-2015-2223.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/34",
+                "name": "https://security.paloaltonetworks.com/CVE-2015-2223",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/34"
+                "url": "https://security.paloaltonetworks.com/CVE-2015-2223"
             },
             {
                 "name": "20150329 CVE-2015-2223: Palo Alto Traps Server Stored XSS",

--- a/2015/4xxx/CVE-2015-4162.json
+++ b/2015/4xxx/CVE-2015-4162.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/31",
+                "name": "https://security.paloaltonetworks.com/CVE-2015-4162",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/31"
+                "url": "https://security.paloaltonetworks.com/CVE-2015-4162"
             },
             {
                 "name": "74941",

--- a/2016/10xxx/CVE-2016-10229.json
+++ b/2016/10xxx/CVE-2016-10229.json
@@ -68,9 +68,9 @@
                 "url": "https://github.com/torvalds/linux/commit/197c949e7798fbf28cfadc69d9ca0c2abbf93191"
             },
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/88",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-10229",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/88"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-10229"
             },
             {
                 "name": "http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=197c949e7798fbf28cfadc69d9ca0c2abbf93191",

--- a/2016/1xxx/CVE-2016-1712.json
+++ b/2016/1xxx/CVE-2016-1712.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/45",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-1712",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/45"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-1712"
             },
             {
                 "name": "1036326",

--- a/2016/2xxx/CVE-2016-2219.json
+++ b/2016/2xxx/CVE-2016-2219.json
@@ -58,9 +58,9 @@
                 "url": "http://www.securitytracker.com/id/1036192"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/42",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-2219",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/42"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-2219"
             }
         ]
     }

--- a/2016/3xxx/CVE-2016-3654.json
+++ b/2016/3xxx/CVE-2016-3654.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/35",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-3654",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/35"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-3654"
             }
         ]
     }

--- a/2016/3xxx/CVE-2016-3655.json
+++ b/2016/3xxx/CVE-2016-3655.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/36",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-3655",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/36"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-3655"
             }
         ]
     }

--- a/2016/3xxx/CVE-2016-3656.json
+++ b/2016/3xxx/CVE-2016-3656.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/37",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-3656",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/37"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-3656"
             }
         ]
     }

--- a/2016/3xxx/CVE-2016-3657.json
+++ b/2016/3xxx/CVE-2016-3657.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/38",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-3657",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/38"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-3657"
             }
         ]
     }

--- a/2016/4xxx/CVE-2016-4971.json
+++ b/2016/4xxx/CVE-2016-4971.json
@@ -88,9 +88,9 @@
                 "url": "http://git.savannah.gnu.org/cgit/wget.git/commit/?id=e996e322ffd42aaa051602da182d03178d0f13e1"
             },
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/86",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-4971",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/86"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-4971"
             },
             {
                 "name": "RHSA-2016:2587",

--- a/2016/5xxx/CVE-2016-5195.json
+++ b/2016/5xxx/CVE-2016-5195.json
@@ -198,9 +198,9 @@
                 "url": "https://github.com/torvalds/linux/commit/19be0eaffa3ac7d8eb6784ad9bdbc7d67ed8e619"
             },
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/73",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-5195",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/73"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-5195"
             },
             {
                 "name": "https://help.ecostruxureit.com/display/public/UADCO8x/StruxureWare+Data+Center+Operation+Software+Vulnerability+Fixes",

--- a/2016/5xxx/CVE-2016-5696.json
+++ b/2016/5xxx/CVE-2016-5696.json
@@ -118,9 +118,9 @@
                 "url": "http://www.ubuntu.com/usn/USN-3070-2"
             },
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/85",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-5696",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/85"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-5696"
             },
             {
                 "name": "RHSA-2016:1815",

--- a/2016/8xxx/CVE-2016-8610.json
+++ b/2016/8xxx/CVE-2016-8610.json
@@ -98,9 +98,9 @@
                 "url": "https://access.redhat.com/errata/RHSA-2017:1413"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/87",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-8610",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/87"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-8610"
             },
             {
                 "name": "RHSA-2017:2494",

--- a/2016/9xxx/CVE-2016-9149.json
+++ b/2016/9xxx/CVE-2016-9149.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/70",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-9149",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/70"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-9149"
             },
             {
                 "name": "1037379",

--- a/2016/9xxx/CVE-2016-9150.json
+++ b/2016/9xxx/CVE-2016-9150.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/68",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-9150",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/68"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-9150"
             },
             {
                 "name": "1037382",

--- a/2016/9xxx/CVE-2016-9151.json
+++ b/2016/9xxx/CVE-2016-9151.json
@@ -63,9 +63,9 @@
                 "url": "https://www.exploit-db.com/exploits/40788/"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/67",
+                "name": "https://security.paloaltonetworks.com/CVE-2016-9151",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/67"
+                "url": "https://security.paloaltonetworks.com/CVE-2016-9151"
             },
             {
                 "name": "94400",

--- a/2017/12xxx/CVE-2017-12416.json
+++ b/2017/12xxx/CVE-2017-12416.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/93",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-12416",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/93"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-12416"
             },
             {
                 "name": "1039255",

--- a/2017/15xxx/CVE-2017-15870.json
+++ b/2017/15xxx/CVE-2017-15870.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/108",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-15870",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/108"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-15870"
             },
             {
                 "name": "102083",

--- a/2017/15xxx/CVE-2017-15940.json
+++ b/2017/15xxx/CVE-2017-15940.json
@@ -58,9 +58,9 @@
                 "url": "http://www.securitytracker.com/id/1040006"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/105",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-15940",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/105"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-15940"
             },
             {
                 "name": "102076",

--- a/2017/15xxx/CVE-2017-15941.json
+++ b/2017/15xxx/CVE-2017-15941.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/111",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-15941",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/111"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-15941"
             },
             {
                 "name": "102446",

--- a/2017/15xxx/CVE-2017-15942.json
+++ b/2017/15xxx/CVE-2017-15942.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/96",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-15942",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/96"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-15942"
             },
             {
                 "name": "1040004",

--- a/2017/15xxx/CVE-2017-15943.json
+++ b/2017/15xxx/CVE-2017-15943.json
@@ -58,9 +58,9 @@
                 "url": "http://www.securitytracker.com/id/1040005"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/99",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-15943",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/99"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-15943"
             },
             {
                 "name": "102074",

--- a/2017/15xxx/CVE-2017-15944.json
+++ b/2017/15xxx/CVE-2017-15944.json
@@ -73,9 +73,9 @@
                 "url": "https://www.exploit-db.com/exploits/43342/"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/102",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-15944",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/102"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-15944"
             }
         ]
     }

--- a/2017/16xxx/CVE-2017-16878.json
+++ b/2017/16xxx/CVE-2017-16878.json
@@ -58,9 +58,9 @@
                 "url": "http://www.securitytracker.com/id/1040148"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/114",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-16878",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/114"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-16878"
             }
         ]
     }

--- a/2017/17xxx/CVE-2017-17841.json
+++ b/2017/17xxx/CVE-2017-17841.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/117",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-17841",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/117"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-17841"
             },
             {
                 "name": "102458",

--- a/2017/3xxx/CVE-2017-3731.json
+++ b/2017/3xxx/CVE-2017-3731.json
@@ -190,9 +190,9 @@
                 "url": "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03838en_us"
             },
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/82",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-3731",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/82"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-3731"
             },
             {
                 "name": "RHSA-2018:2187",

--- a/2017/5xxx/CVE-2017-5328.json
+++ b/2017/5xxx/CVE-2017-5328.json
@@ -58,9 +58,9 @@
                 "url": "http://www.securityfocus.com/bid/95823"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/72",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-5328",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/72"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-5328"
             }
         ]
     }

--- a/2017/5xxx/CVE-2017-5329.json
+++ b/2017/5xxx/CVE-2017-5329.json
@@ -63,9 +63,9 @@
                 "url": "https://www.exploit-db.com/exploits/41176/"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/71",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-5329",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/71"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-5329"
             }
         ]
     }

--- a/2017/5xxx/CVE-2017-5583.json
+++ b/2017/5xxx/CVE-2017-5583.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/75",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-5583",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/75"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-5583"
             },
             {
                 "name": "96370",

--- a/2017/5xxx/CVE-2017-5584.json
+++ b/2017/5xxx/CVE-2017-5584.json
@@ -63,9 +63,9 @@
                 "url": "http://www.securitytracker.com/id/1037889"
             },
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/74",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-5584",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/74"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-5584"
             }
         ]
     }

--- a/2017/5xxx/CVE-2017-5715.json
+++ b/2017/5xxx/CVE-2017-5715.json
@@ -239,9 +239,9 @@
                 "url": "http://www.securityfocus.com/bid/102376"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/121",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-5715",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/121"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-5715"
             },
             {
                 "name": "https://developer.arm.com/support/arm-security-updates/speculative-processor-vulnerability",

--- a/2017/6xxx/CVE-2017-6356.json
+++ b/2017/6xxx/CVE-2017-6356.json
@@ -58,9 +58,9 @@
                 "url": "http://www.securityfocus.com/bid/96925"
             },
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/76",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-6356",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/76"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-6356"
             }
         ]
     }

--- a/2017/6xxx/CVE-2017-6460.json
+++ b/2017/6xxx/CVE-2017-6460.json
@@ -58,9 +58,9 @@
                 "url": "http://www.securitytracker.com/id/1038123"
             },
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/92",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-6460",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/92"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-6460"
             },
             {
                 "name": "https://support.apple.com/HT208144",

--- a/2017/7xxx/CVE-2017-7216.json
+++ b/2017/7xxx/CVE-2017-7216.json
@@ -58,9 +58,9 @@
                 "url": "http://www.securityfocus.com/bid/97590"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/80",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-7216",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/80"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-7216"
             }
         ]
     }

--- a/2017/7xxx/CVE-2017-7217.json
+++ b/2017/7xxx/CVE-2017-7217.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/78",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-7217",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/78"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-7217"
             },
             {
                 "name": "1038247",

--- a/2017/7xxx/CVE-2017-7218.json
+++ b/2017/7xxx/CVE-2017-7218.json
@@ -58,9 +58,9 @@
                 "url": "http://www.securitytracker.com/id/1038248"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/79",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-7218",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/79"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-7218"
             },
             {
                 "name": "97592",

--- a/2017/7xxx/CVE-2017-7408.json
+++ b/2017/7xxx/CVE-2017-7408.json
@@ -58,9 +58,9 @@
                 "url": "https://www.paloaltonetworks.com/documentation/34/endpoint/traps-release-notes/traps-3-4-4-addressed-issues.html"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/77",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-7408",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/77"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-7408"
             },
             {
                 "name": "97533",

--- a/2017/7xxx/CVE-2017-7409.json
+++ b/2017/7xxx/CVE-2017-7409.json
@@ -58,9 +58,9 @@
                 "url": "http://www.securitytracker.com/id/1038355"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/81",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-7409",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/81"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-7409"
             },
             {
                 "name": "97953",

--- a/2017/7xxx/CVE-2017-7644.json
+++ b/2017/7xxx/CVE-2017-7644.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/83",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-7644",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/83"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-7644"
             }
         ]
     }

--- a/2017/7xxx/CVE-2017-7945.json
+++ b/2017/7xxx/CVE-2017-7945.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/84",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-7945",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/84"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-7945"
             }
         ]
     }

--- a/2017/8xxx/CVE-2017-8390.json
+++ b/2017/8xxx/CVE-2017-8390.json
@@ -58,9 +58,9 @@
                 "url": "http://www.securityfocus.com/bid/99911"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/91",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-8390",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/91"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-8390"
             },
             {
                 "name": "1038976",

--- a/2017/9xxx/CVE-2017-9458.json
+++ b/2017/9xxx/CVE-2017-9458.json
@@ -63,9 +63,9 @@
                 "url": "http://www.securityfocus.com/bid/100614"
             },
             {
-                "name": "http://securityadvisories.paloaltonetworks.com/Home/Detail/94",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-9458",
                 "refsource": "CONFIRM",
-                "url": "http://securityadvisories.paloaltonetworks.com/Home/Detail/94"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-9458"
             }
         ]
     }

--- a/2017/9xxx/CVE-2017-9459.json
+++ b/2017/9xxx/CVE-2017-9459.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/89",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-9459",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/89"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-9459"
             },
             {
                 "name": "1038974",

--- a/2017/9xxx/CVE-2017-9467.json
+++ b/2017/9xxx/CVE-2017-9467.json
@@ -63,9 +63,9 @@
                 "url": "http://www.securitytracker.com/id/1038975"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/90",
+                "name": "https://security.paloaltonetworks.com/CVE-2017-9467",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/90"
+                "url": "https://security.paloaltonetworks.com/CVE-2017-9467"
             }
         ]
     }

--- a/2018/10xxx/CVE-2018-10139.json
+++ b/2018/10xxx/CVE-2018-10139.json
@@ -60,9 +60,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/128",
+                "name": "https://security.paloaltonetworks.com/CVE-2018-10139",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/128"
+                "url": "https://security.paloaltonetworks.com/CVE-2018-10139"
             },
             {
                 "name": "105111",

--- a/2018/10xxx/CVE-2018-10140.json
+++ b/2018/10xxx/CVE-2018-10140.json
@@ -59,9 +59,9 @@
                 "url": "http://www.securityfocus.com/bid/105107"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/129",
+                "name": "https://security.paloaltonetworks.com/CVE-2018-10140",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/129"
+                "url": "https://security.paloaltonetworks.com/CVE-2018-10140"
             },
             {
                 "name": "1041545",

--- a/2018/10xxx/CVE-2018-10141.json
+++ b/2018/10xxx/CVE-2018-10141.json
@@ -54,9 +54,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/134",
+                "name": "https://security.paloaltonetworks.com/CVE-2018-10141",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/134"
+                "url": "https://security.paloaltonetworks.com/CVE-2018-10141"
             }
         ]
     }

--- a/2018/10xxx/CVE-2018-10142.json
+++ b/2018/10xxx/CVE-2018-10142.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/135",
+                "name": "https://security.paloaltonetworks.com/CVE-2018-10142",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/135"
+                "url": "https://security.paloaltonetworks.com/CVE-2018-10142"
             },
             {
                 "name": "106069",

--- a/2018/10xxx/CVE-2018-10143.json
+++ b/2018/10xxx/CVE-2018-10143.json
@@ -63,9 +63,9 @@
                 "url": "https://doddsecurity.com/234/command-injection-on-palo-alto-networks-expedition/"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/138",
+                "name": "https://security.paloaltonetworks.com/CVE-2018-10143",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/138"
+                "url": "https://security.paloaltonetworks.com/CVE-2018-10143"
             }
         ]
     }

--- a/2018/14xxx/CVE-2018-14634.json
+++ b/2018/14xxx/CVE-2018-14634.json
@@ -159,8 +159,8 @@
             },
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/143",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/143"
+                "name": "https://security.paloaltonetworks.com/CVE-2018-14634",
+                "url": "https://security.paloaltonetworks.com/CVE-2018-14634"
             },
             {
                 "refsource": "CONFIRM",

--- a/2018/18xxx/CVE-2018-18065.json
+++ b/2018/18xxx/CVE-2018-18065.json
@@ -94,8 +94,8 @@
             },
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/144",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/144"
+                "name": "https://security.paloaltonetworks.com/CVE-2018-18065",
+                "url": "https://security.paloaltonetworks.com/CVE-2018-18065"
             },
             {
                 "refsource": "BID",

--- a/2018/3xxx/CVE-2018-3665.json
+++ b/2018/3xxx/CVE-2018-3665.json
@@ -170,8 +170,8 @@
             },
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/154",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/154"
+                "name": "https://security.paloaltonetworks.com/CVE-2018-3665",
+                "url": "https://security.paloaltonetworks.com/CVE-2018-3665"
             }
         ]
     }

--- a/2018/7xxx/CVE-2018-7636.json
+++ b/2018/7xxx/CVE-2018-7636.json
@@ -63,9 +63,9 @@
                 "url": "http://www.securityfocus.com/bid/104673"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/122",
+                "name": "https://security.paloaltonetworks.com/CVE-2018-7636",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/122"
+                "url": "https://security.paloaltonetworks.com/CVE-2018-7636"
             }
         ]
     }

--- a/2018/8xxx/CVE-2018-8715.json
+++ b/2018/8xxx/CVE-2018-8715.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/127",
+                "name": "https://security.paloaltonetworks.com/CVE-2018-8715",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/127"
+                "url": "https://security.paloaltonetworks.com/CVE-2018-8715"
             },
             {
                 "name": "https://github.com/embedthis/appweb/issues/610",

--- a/2018/9xxx/CVE-2018-9242.json
+++ b/2018/9xxx/CVE-2018-9242.json
@@ -63,9 +63,9 @@
                 "url": "http://www.securityfocus.com/bid/104676"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/123",
+                "name": "https://security.paloaltonetworks.com/CVE-2018-9242",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/123"
+                "url": "https://security.paloaltonetworks.com/CVE-2018-9242"
             }
         ]
     }

--- a/2018/9xxx/CVE-2018-9334.json
+++ b/2018/9xxx/CVE-2018-9334.json
@@ -63,9 +63,9 @@
                 "url": "http://www.securityfocus.com/bid/104677"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/124",
+                "name": "https://security.paloaltonetworks.com/CVE-2018-9334",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/124"
+                "url": "https://security.paloaltonetworks.com/CVE-2018-9334"
             }
         ]
     }

--- a/2018/9xxx/CVE-2018-9335.json
+++ b/2018/9xxx/CVE-2018-9335.json
@@ -63,9 +63,9 @@
                 "url": "http://www.securitytracker.com/id/1041241"
             },
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/126",
+                "name": "https://security.paloaltonetworks.com/CVE-2018-9335",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/126"
+                "url": "https://security.paloaltonetworks.com/CVE-2018-9335"
             }
         ]
     }

--- a/2018/9xxx/CVE-2018-9337.json
+++ b/2018/9xxx/CVE-2018-9337.json
@@ -53,9 +53,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/125",
+                "name": "https://security.paloaltonetworks.com/CVE-2018-9337",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/125"
+                "url": "https://security.paloaltonetworks.com/CVE-2018-9337"
             },
             {
                 "name": "1041240",

--- a/2019/15xxx/CVE-2019-15014.json
+++ b/2019/15xxx/CVE-2019-15014.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/167",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/167"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-15014",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-15014"
             }
         ]
     },

--- a/2019/15xxx/CVE-2019-15015.json
+++ b/2019/15xxx/CVE-2019-15015.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/170",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/170"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-15015",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-15015"
             }
         ]
     },

--- a/2019/15xxx/CVE-2019-15016.json
+++ b/2019/15xxx/CVE-2019-15016.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/173",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/173"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-15016",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-15016"
             }
         ]
     },

--- a/2019/15xxx/CVE-2019-15017.json
+++ b/2019/15xxx/CVE-2019-15017.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/176",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/176"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-15017",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-15017"
             }
         ]
     },

--- a/2019/15xxx/CVE-2019-15018.json
+++ b/2019/15xxx/CVE-2019-15018.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/179",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/179"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-15018",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-15018"
             }
         ]
     },

--- a/2019/15xxx/CVE-2019-15019.json
+++ b/2019/15xxx/CVE-2019-15019.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/182",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/182"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-15019",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-15019"
             }
         ]
     },

--- a/2019/15xxx/CVE-2019-15020.json
+++ b/2019/15xxx/CVE-2019-15020.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/185",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/185"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-15020",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-15020"
             }
         ]
     },

--- a/2019/15xxx/CVE-2019-15021.json
+++ b/2019/15xxx/CVE-2019-15021.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/188",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/188"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-15021",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-15021"
             }
         ]
     },

--- a/2019/15xxx/CVE-2019-15022.json
+++ b/2019/15xxx/CVE-2019-15022.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/191",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/191"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-15022",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-15022"
             }
         ]
     },

--- a/2019/15xxx/CVE-2019-15023.json
+++ b/2019/15xxx/CVE-2019-15023.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/194",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/194"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-15023",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-15023"
             }
         ]
     },

--- a/2019/17xxx/CVE-2019-17435.json
+++ b/2019/17xxx/CVE-2019-17435.json
@@ -49,8 +49,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/197",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/197"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-17435",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-17435"
             }
         ]
     },

--- a/2019/17xxx/CVE-2019-17436.json
+++ b/2019/17xxx/CVE-2019-17436.json
@@ -49,8 +49,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/200",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/200"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-17436",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-17436"
             }
         ]
     },

--- a/2019/17xxx/CVE-2019-17440.json
+++ b/2019/17xxx/CVE-2019-17440.json
@@ -106,8 +106,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/203",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/203"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-17440",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-17440"
             }
         ]
     },

--- a/2019/1xxx/CVE-2019-1565.json
+++ b/2019/1xxx/CVE-2019-1565.json
@@ -54,9 +54,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/139",
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1565",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/139"
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1565"
             },
             {
                 "name": "106752",

--- a/2019/1xxx/CVE-2019-1567.json
+++ b/2019/1xxx/CVE-2019-1567.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/141",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/141"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1567",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1567"
             }
         ]
     },

--- a/2019/1xxx/CVE-2019-1568.json
+++ b/2019/1xxx/CVE-2019-1568.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/148",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/148"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1568",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1568"
             }
         ]
     },

--- a/2019/1xxx/CVE-2019-1572.json
+++ b/2019/1xxx/CVE-2019-1572.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/145",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/145"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1572",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1572"
             },
             {
                 "refsource": "BID",

--- a/2019/1xxx/CVE-2019-1573.json
+++ b/2019/1xxx/CVE-2019-1573.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/146",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/146"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1573",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1573"
             },
             {
                 "refsource": "CERT-VN",

--- a/2019/1xxx/CVE-2019-1574.json
+++ b/2019/1xxx/CVE-2019-1574.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/147",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/147"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1574",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1574"
             },
             {
                 "refsource": "BID",

--- a/2019/1xxx/CVE-2019-1575.json
+++ b/2019/1xxx/CVE-2019-1575.json
@@ -55,8 +55,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/157",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/157"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1575",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1575"
             },
             {
                 "refsource": "BID",

--- a/2019/1xxx/CVE-2019-1576.json
+++ b/2019/1xxx/CVE-2019-1576.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/156",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/156"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1576",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1576"
             }
         ]
     },

--- a/2019/1xxx/CVE-2019-1577.json
+++ b/2019/1xxx/CVE-2019-1577.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/152",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/152"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1577",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1577"
             },
             {
                 "refsource": "BID",

--- a/2019/1xxx/CVE-2019-1578.json
+++ b/2019/1xxx/CVE-2019-1578.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/153",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/153"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1578",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1578"
             },
             {
                 "refsource": "BID",

--- a/2019/1xxx/CVE-2019-1579.json
+++ b/2019/1xxx/CVE-2019-1579.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/158",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/158"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1579",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1579"
             },
             {
                 "refsource": "BID",

--- a/2019/1xxx/CVE-2019-1580.json
+++ b/2019/1xxx/CVE-2019-1580.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/home/detail/159",
-                "url": "https://securityadvisories.paloaltonetworks.com/home/detail/159"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1580",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1580"
             }
         ]
     },

--- a/2019/1xxx/CVE-2019-1581.json
+++ b/2019/1xxx/CVE-2019-1581.json
@@ -102,9 +102,9 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://securityadvisories.paloaltonetworks.com/home/detail/160",
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1581",
                 "refsource": "CONFIRM",
-                "url": "https://securityadvisories.paloaltonetworks.com/home/detail/160"
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1581"
             }
         ]
     },

--- a/2019/1xxx/CVE-2019-1582.json
+++ b/2019/1xxx/CVE-2019-1582.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/home/detail/161",
-                "url": "https://securityadvisories.paloaltonetworks.com/home/detail/161"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1582",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1582"
             }
         ]
     },

--- a/2019/1xxx/CVE-2019-1583.json
+++ b/2019/1xxx/CVE-2019-1583.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "CONFIRM",
-                "name": "https://securityadvisories.paloaltonetworks.com/home/detail/162",
-                "url": "https://securityadvisories.paloaltonetworks.com/home/detail/162"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1583",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1583"
             }
         ]
     },

--- a/2019/1xxx/CVE-2019-1584.json
+++ b/2019/1xxx/CVE-2019-1584.json
@@ -46,8 +46,8 @@
         "reference_data": [
             {
                 "refsource": "MISC",
-                "name": "https://securityadvisories.paloaltonetworks.com/Home/Detail/164",
-                "url": "https://securityadvisories.paloaltonetworks.com/Home/Detail/164"
+                "name": "https://security.paloaltonetworks.com/CVE-2019-1584",
+                "url": "https://security.paloaltonetworks.com/CVE-2019-1584"
             }
         ]
     },


### PR DESCRIPTION
We recently updated our security advisory website. This commit replaces links to our old website with new simplified URLs.