### PR TITLE
Publish details of DWF CVEs for HHVM from 2016

### DIFF
--- a/2016/1000xxx/CVE-2016-1000004.json
+++ b/2016/1000xxx/CVE-2016-1000004.json
@@ -1,8 +1,53 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "cve-assign@fb.com",
+        "DATE_ASSIGNED": "2016-06-21",
         "ID": "CVE-2016-1000004",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "HHVM",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "3.14.2"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "3.13.0"
+                                        },
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "3.12.4"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "3.10.0"
+                                        },
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "3.9.5"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "3.9.4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Facebook"
+                }
+            ]
+        }
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,7 +56,33 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Insufficient type checks were employed prior to casting input data in SimpleXMLElement_exportNode and simplexml_import_dom. This issue affects HHVM versions prior to 3.9.5, all versions between 3.10.0 and 3.12.3 (inclusive), and all versions between 3.13.0 and 3.14.1 (inclusive)."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "name": "https://github.com/facebook/hhvm/commit/8e7266fef1f329b805b37f32c9ad0090215ab269",
+                "url": "https://github.com/facebook/hhvm/commit/8e7266fef1f329b805b37f32c9ad0090215ab269"
+            },
+            {
+                "refsource": "CONFIRM",
+                "name": "https://www.facebook.com/security/advisories/cve-2016-1000004",
+                "url": "https://www.facebook.com/security/advisories/cve-2016-1000004"
             }
         ]
     }

--- a/2016/1000xxx/CVE-2016-1000005.json
+++ b/2016/1000xxx/CVE-2016-1000005.json
@@ -1,8 +1,53 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "cve-assign@fb.com",
+        "DATE_ASSIGNED": "2016-06-21",
         "ID": "CVE-2016-1000005",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "HHVM",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "3.14.2"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "3.13.0"
+                                        },
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "3.12.4"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "3.10.0"
+                                        },
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "3.9.5"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "3.9.4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Facebook"
+                }
+            ]
+        }
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,7 +56,33 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "mcrypt_get_block_size did not enforce that the provided \"module\" parameter was a string, leading to type confusion if other types of data were passed in. This issue affects HHVM versions prior to 3.9.5, all versions between 3.10.0 and 3.12.3 (inclusive), and all versions between 3.13.0 and 3.14.1 (inclusive)."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "name": "https://github.com/facebook/hhvm/commit/39e7e177473350b3a5c34e8824af3b98e25efa89",
+                "url": "https://github.com/facebook/hhvm/commit/39e7e177473350b3a5c34e8824af3b98e25efa89"
+            },
+            {
+                "refsource": "CONFIRM",
+                "name": "https://www.facebook.com/security/advisories/cve-2016-1000005",
+                "url": "https://www.facebook.com/security/advisories/cve-2016-1000005"
             }
         ]
     }

--- a/2016/1000xxx/CVE-2016-1000109.json
+++ b/2016/1000xxx/CVE-2016-1000109.json
@@ -1,8 +1,53 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "cve-assign@fb.com",
+        "DATE_ASSIGNED": "2016-07-17",
         "ID": "CVE-2016-1000109",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "HHVM",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "3.14.3"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "3.13.0"
+                                        },
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "3.12.5"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "3.10.0"
+                                        },
+                                        {
+                                            "version_affected": "!=>",
+                                            "version_value": "3.9.6"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "3.9.5"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Facebook"
+                }
+            ]
+        }
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -11,7 +56,38 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "HHVM does not attempt to address RFC 3875 section 4.1.18 namespace conflicts and therefore does not protect CGI applications from the presence of untrusted client data in the HTTP_PROXY environment variable, which might allow remote attackers to redirect a CGI application's outbound HTTP traffic to an arbitrary proxy server via a crafted Proxy header in an HTTP request, aka an \"httpoxy\" issue. This issue affects HHVM versions prior to 3.9.6, all versions between 3.10.0 and 3.12.4 (inclusive), and all versions between 3.13.0 and 3.14.2 (inclusive)."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-454: External Initialization of Trusted Variables or Data Stores"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "name": "https://github.com/facebook/hhvm/commit/423b4b719afd5ef4e6e19d8447fbf7b6bc0d0a25",
+                "url": "https://github.com/facebook/hhvm/commit/423b4b719afd5ef4e6e19d8447fbf7b6bc0d0a25"
+            },
+            {
+                "refsource": "MISC",
+                "name": "https://httpoxy.org/",
+                "url": "https://httpoxy.org/"
+            },
+            {
+                "refsource": "CONFIRM",
+                "name": "https://www.facebook.com/security/advisories/cve-2016-1000109",
+                "url": "https://www.facebook.com/security/advisories/cve-2016-1000109"
             }
         ]
     }


### PR DESCRIPTION
Per email from MITRE, these are old CVEs which were requested on behalf of Facebook via the Distributed Weakness Filing Project (DWF) but were never published. Lets publish those details as we would today.