### PR TITLE
Updating Cisco CVE-2019-1950

### DIFF
--- a/2019/1xxx/CVE-2019-1950.json
+++ b/2019/1xxx/CVE-2019-1950.json
@@ -4,7 +4,7 @@
         "DATE_PUBLIC": "2020-02-19T16:00:00-0800",
         "ID": "CVE-2019-1950",
         "STATE": "PUBLIC",
-        "TITLE": "Multiple Cisco UCS-Based Products UEFI Secure Boot Bypass Vulnerability"
+        "TITLE": "Cisco IOS XE SD-WAN Software Default Credentials Vulnerability"
     },
     "affects": {
         "vendor": {
@@ -13,12 +13,12 @@
                     "product": {
                         "product_data": [
                             {
-                                "product_name": "Cisco Unified Computing System (Managed) ",
+                                "product_name": "Cisco IOS XE SD-WAN Software",
                                 "version": {
                                     "version_data": [
                                         {
                                             "affected": "<",
-                                            "version_value": "4.0.2h"
+                                            "version_value": "16.11"
                                         }
                                     ]
                                 }
@@ -37,7 +37,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A vulnerability in the firmware of the Cisco UCS C-Series Rack Servers could allow an authenticated, physical attacker to bypass Unified Extensible Firmware Interface (UEFI) Secure Boot validation checks and load a compromised software image on an affected device. The vulnerability is due to improper validation of the server firmware upgrade images. An attacker could exploit this vulnerability by installing a server firmware version that would allow the attacker to disable UEFI Secure Boot. A successful exploit could allow the attacker to bypass the signature validation checks that are done by UEFI Secure Boot technology and load a compromised software image on the affected device. A compromised software image is any software image that has not been digitally signed by Cisco."
+                "value": "A vulnerability in Cisco IOS XE SD-WAN Software could allow an unauthenticated, local attacker to gain unauthorized access to an affected device. The vulnerability is due to the existence of default credentials within the default configuration of an affected device. An attacker who has access to an affected device could log in with elevated privileges. A successful exploit could allow the attacker to take complete control of the device. This vulnerability affects Cisco devices that are running Cisco IOS XE SD-WAN Software releases 16.11 and earlier."
             }
         ]
     },
@@ -49,8 +49,8 @@
     ],
     "impact": {
         "cvss": {
-            "baseScore": "6.2",
-            "vectorString": "CVSS:3.0/AV:P/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+            "baseScore": "8.4",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
             "version": "3.0"
         }
     },
@@ -69,19 +69,17 @@
     "references": {
         "reference_data": [
             {
-                "name": "20200219 Multiple Cisco UCS-Based Products UEFI Secure Boot Bypass Vulnerability",
+                "name": "20200219 Cisco IOS XE SD-WAN Software Default Credentials Vulnerability",
                 "refsource": "CISCO",
-                "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20200219-ucs-boot-bypass"
+                "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sd-wan-cred-EVGSF259"
             }
         ]
     },
     "source": {
-        "advisory": "cisco-sa-20200219-ucs-boot-bypass",
+        "advisory": "cisco-sa-sd-wan-cred-EVGSF259",
         "defect": [
             [
-                "CSCvn09490",
-                "CSCvq27796",
-                "CSCvq27803"
+                "CSCvk59282"
             ]
         ],
         "discovery": "INTERNAL"

--- a/2019/1xxx/CVE-2019-1950.json
+++ b/2019/1xxx/CVE-2019-1950.json
@@ -1,7 +1,7 @@
 {
     "CVE_data_meta": {
         "ASSIGNER": "psirt@cisco.com",
-        "DATE_PUBLIC": "2020-02-19T16:00:00-0800",
+        "DATE_PUBLIC": "2020-01-22T16:00:00.000Z",
         "ID": "CVE-2019-1950",
         "STATE": "PUBLIC",
         "TITLE": "Cisco IOS XE SD-WAN Software Default Credentials Vulnerability"
@@ -17,7 +17,7 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "affected": "<",
+                                            "version_affected": "<=",
                                             "version_value": "16.11"
                                         }
                                     ]
@@ -37,21 +37,33 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A vulnerability in Cisco IOS XE SD-WAN Software could allow an unauthenticated, local attacker to gain unauthorized access to an affected device. The vulnerability is due to the existence of default credentials within the default configuration of an affected device. An attacker who has access to an affected device could log in with elevated privileges. A successful exploit could allow the attacker to take complete control of the device. This vulnerability affects Cisco devices that are running Cisco IOS XE SD-WAN Software releases 16.11 and earlier."
+                "value": "A vulnerability in Cisco IOS XE SD-WAN Software could allow an unauthenticated, local attacker to gain unauthorized access to an affected device.\n\nThe vulnerability is due to the existence of default credentials within the default configuration of an affected device. An attacker who has access to an affected device could log in with elevated privileges. A successful exploit could allow the attacker to take complete control of the device.\n\nThis vulnerability affects Cisco devices that are running Cisco IOS XE SD-WAN Software releases 16.11 and earlier.\n\n"
             }
         ]
     },
     "exploit": [
         {
             "lang": "eng",
-            "value": "The Cisco Product Security Incident Response Team (PSIRT) is not aware of any public announcements or malicious use of the vulnerability that is described in this advisory."
+            "value": "The Cisco Product Security Incident Response Team (PSIRT) is not aware of any public announcements or malicious use of the vulnerability that is described in this advisory.\n\n"
         }
     ],
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
     "impact": {
         "cvss": {
-            "baseScore": "8.4",
-            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.4,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
         }
     },
     "problemtype": {
@@ -60,7 +72,7 @@
                 "description": [
                     {
                         "lang": "eng",
-                        "value": "CWE-347"
+                        "value": "CWE-255 Credentials Management"
                     }
                 ]
             }
@@ -69,19 +81,29 @@
     "references": {
         "reference_data": [
             {
-                "name": "20200219 Cisco IOS XE SD-WAN Software Default Credentials Vulnerability",
-                "refsource": "CISCO",
+                "name": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sd-wan-cred-EVGSF259",
+                "refsource": "CONFIRM",
                 "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sd-wan-cred-EVGSF259"
             }
         ]
     },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Cisco fixed this vulnerability in Cisco IOS XE SD-WAN Software Release 16.12.1."
+        }
+    ],
     "source": {
-        "advisory": "cisco-sa-sd-wan-cred-EVGSF259",
+        "advisory": " cisco-sa-sd-wan-cred-EVGSF259",
         "defect": [
-            [
-                "CSCvk59282"
-            ]
+            "CSCvk59282"
         ],
-        "discovery": "INTERNAL"
-    }
+        "discovery": "UNKNOWN"
+    },
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "To check for the presence of default credentials, customers can use the show running-configuration | include username admin command within the Cisco IOS XE SD-WAN Software command line. To remove the default credentials, customers can use the config-transaction and no username admin commands.\n\n"
+        }
+    ]
 }


### PR DESCRIPTION
The CVE entry was incorrect and was pointing to the wrong vulnerability. 