### PR TITLE
update CVE-2020-5234 with correct fix versions

### DIFF
--- a/2020/5xxx/CVE-2020-5234.json
+++ b/2020/5xxx/CVE-2020-5234.json
@@ -16,10 +16,10 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "< 1.9.3"
+                                            "version_value": "< 1.9.11"
                                         },
                                         {
-                                            "version_value": ">= 2.0.0, < 2.1.80"
+                                            "version_value": ">= 2.0.0, < 2.1.90"
                                         }
                                     ]
                                 }
@@ -29,10 +29,10 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "< 1.9.3"
+                                            "version_value": "< 1.9.11"
                                         },
                                         {
-                                            "version_value": ">= 2.0.0, < 2.1.80"
+                                            "version_value": ">= 2.0.0, < 2.1.90"
                                         }
                                     ]
                                 }
@@ -42,10 +42,10 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "< 1.9.3"
+                                            "version_value": "< 1.9.11"
                                         },
                                         {
-                                            "version_value": ">= 2.0.0, < 2.1.80"
+                                            "version_value": ">= 2.0.0, < 2.1.90"
                                         }
                                     ]
                                 }
@@ -55,10 +55,10 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "< 1.9.3"
+                                            "version_value": "< 1.9.11"
                                         },
                                         {
-                                            "version_value": "\t >= 2.0.0, < 2.1.80"
+                                            "version_value": ">= 2.0.0, < 2.1.90"
                                         }
                                     ]
                                 }
@@ -77,7 +77,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "MessagePack for C# and Unity before version 1.9.3 and 2.1.80 has a vulnerability where untrusted data can lead to DoS attack due to hash collisions and stack overflow. Review the linked GitHub Security Advisory for more information and remediation steps."
+                "value": "MessagePack for C# and Unity before version 1.9.11 and 2.1.90 has a vulnerability where untrusted data can lead to DoS attack due to hash collisions and stack overflow. Review the linked GitHub Security Advisory for more information and remediation steps."
             }
         ]
     },
@@ -120,6 +120,16 @@
                 "name": "https://github.com/neuecc/MessagePack-CSharp/commit/56fa86219d01d0a183babbbbcb34abbdea588a02",
                 "refsource": "MISC",
                 "url": "https://github.com/neuecc/MessagePack-CSharp/commit/56fa86219d01d0a183babbbbcb34abbdea588a02"
+            },
+            {
+                "name": "https://github.com/neuecc/MessagePack-CSharp/issues/810",
+                "refsource": "MISC",
+                "url": "https://github.com/neuecc/MessagePack-CSharp/issues/810"
+            },
+            {
+                "name": "https://github.com/neuecc/MessagePack-CSharp/commit/f88684078698386df02204f13faeff098a61f007",
+                "refsource": "MISC",
+                "url": "https://github.com/neuecc/MessagePack-CSharp/commit/f88684078698386df02204f13faeff098a61f007"
             }
         ]
     },


### PR DESCRIPTION
update CVE-2020-5234 with correct fix versions

https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf was updated with new info about fix versions.  This PR changes the CVE info so it has the latest info from the maintainer.