### PR TITLE
readme: add links wiki.m.o and MFSA for Fx products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## Firefox Security Advisories
+
+Security Advisories for Firefox and other client applications will use:
+https://wiki.mozilla.org/Security/Firefox/Security_Bug_Life_Cycle/Security_Advisories
+and be published to: https://www.mozilla.org/en-US/security/advisories/
+
 # CVE Automation Working Group Git Pilot
 
 The [CVE Automation Working


### PR DESCRIPTION
Adds a note and links to the Fx advisory process and MFSA, since this repo shouldn't be used for Fx and client app advisories.

This only applies to the Mozilla fork, so I'm not sure how we'd want to handle that. Maybe a `mozilla-master` default branch. Locally I can `git pull --rebase` from master.