### PR TITLE
update description of CVE-2020-5247 - correct version

### DIFF
--- a/2020/5xxx/CVE-2020-5247.json
+++ b/2020/5xxx/CVE-2020-5247.json
@@ -38,7 +38,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In Puma (RubyGem) before 4.3.2 and 3.12.2, if an application using Puma allows untrusted input in a response header, an attacker can use newline characters (i.e. `CR`, `LF` or`/r`, `/n`) to end the header and inject malicious content, such as additional headers or an entirely new response body. This vulnerability is known as HTTP Response Splitting. While not an attack in itself, response splitting is a vector for several other attacks, such as cross-site scripting (XSS). This is related to CVE-2019-16254, which fixed this vulnerability for the WEBrick Ruby web server. This has been fixed in versions 4.3.2 and 3.12.3 by checking all headers for line endings and rejecting headers with those characters."
+                "value": "In Puma (RubyGem) before 4.3.2 and before 3.12.3, if an application using Puma allows untrusted input in a response header, an attacker can use newline characters (i.e. `CR`, `LF` or`/r`, `/n`) to end the header and inject malicious content, such as additional headers or an entirely new response body. This vulnerability is known as HTTP Response Splitting. While not an attack in itself, response splitting is a vector for several other attacks, such as cross-site scripting (XSS). This is related to CVE-2019-16254, which fixed this vulnerability for the WEBrick Ruby web server. This has been fixed in versions 4.3.2 and 3.12.3 by checking all headers for line endings and rejecting headers with those characters."
             }
         ]
     },


### PR DESCRIPTION
update description of CVE-2020-5247 - correct version

We received a request from a CVE user to update the description for CVE-2020-5247 to note the proper fix version in the description of 3.12.3.  This updates that description.