### PR TITLE
add CVE-2020-5258 for GHSA-jxfh-8wgv-vfr2

### DIFF
--- a/2020/5xxx/CVE-2020-5258.json
+++ b/2020/5xxx/CVE-2020-5258.json
@@ -1,18 +1,100 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-5258",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Prototype pollution in dojo"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "dojo",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.12.8"
+                                        },
+                                        {
+                                            "version_value": ">= 1.13.0, < 1.13.7"
+                                        },
+                                        {
+                                            "version_value": ">= 1.14.0, < 1.14.6"
+                                        },
+                                        {
+                                            "version_value": ">= 1.15.0, < 1.15.3"
+                                        },
+                                        {
+                                            "version_value": ">= 1.16.0, < 1.16.2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "dojo"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In affected versions of dojo (NPM package), the deepCopy method is vulnerable to Prototype Pollution.\n\nPrototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.\nAn attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. \n\nThis has been patched in versions 1.12.8, 1.13.7, 1.14.6, 1.15.3 and 1.16.2"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.7,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-94: Improper Control of Generation of Code ('Code Injection')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2"
+            },
+            {
+                "name": "https://github.com/dojo/dojo/commit/20a00afb68f5587946dc76fbeaa68c39bda2171d",
+                "refsource": "MISC",
+                "url": "https://github.com/dojo/dojo/commit/20a00afb68f5587946dc76fbeaa68c39bda2171d"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-jxfh-8wgv-vfr2",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
add CVE-2020-5258 for GHSA-jxfh-8wgv-vfr2