### PR TITLE
Update the entry for CVE-2019-1551

### DIFF
--- a/2019/1xxx/CVE-2019-1551.json
+++ b/2019/1xxx/CVE-2019-1551.json
@@ -17,10 +17,10 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "Fixed in OpenSSL 1.1.1e-dev (Affected 1.1.1-1.1.1d)"
-                                        },
+                                            "version_value": "Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d)"
+                                        }, 
                                         {
-                                            "version_value": "Fixed in OpenSSL 1.0.2u-dev (Affected 1.0.2-1.0.2t)"
+                                            "version_value": "Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t)"
                                         }
                                     ]
                                 }
@@ -44,8 +44,8 @@
     "description": {
         "description_data": [
             {
-                "lang": "eng",
-                "value": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e-dev (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u-dev (Affected 1.0.2-1.0.2t)."
+                "lang": "eng", 
+                "value": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t)."
             }
         ]
     },


### PR DESCRIPTION
OpenSSL 1.1.1e/1.0.2u are now released so the "-dev" tag is no longer appropriate.