### PR TITLE
Adding CVE-2020-8910

### DIFF
--- a/2020/8xxx/CVE-2020-8910.json
+++ b/2020/8xxx/CVE-2020-8910.json
@@ -17,7 +17,7 @@
                                     "version_data": [
                                         {
                                             "version_affected": "<=",
-                                            "version_name": "v20200224"
+                                            "version_name": "v20200224",
                                             "version_value": "v20200224"
                                         }
                                     ]

--- a/2020/8xxx/CVE-2020-8910.json
+++ b/2020/8xxx/CVE-2020-8910.json
@@ -46,7 +46,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A URL parsing issue in goog.uri of the Google Closure Library versions up to and including v20200224 allows an attacker to send malicious URLs to be parsed by the library and return the wrong authority. Mitigation: update your library to version v2020????"
+                "value": "A URL parsing issue in goog.uri of the Google Closure Library versions up to and including v20200224 allows an attacker to send malicious URLs to be parsed by the library and return the wrong authority. Mitigation: update your library to version v20200315."
             }
         ]
     },
@@ -94,12 +94,12 @@
             {
                 "name": "Release Notes",
                 "refsource": "CONFIRM",
-                "url": "https://github.com/google/closure-library/releases"
+                "url": "https://github.com/google/closure-library/commit/294fc00b01d248419d8f8de37580adf2a0024fc9"
             },
             {
                 "name": "CONFIRM",
                 "refsource": "CONFIRM",
-                "url": "https://github.com/google/closure-library/commit/294fc00b01d248419d8f8de37580adf2a0024fc9"
+                "url": "https://github.com/google/closure-library/releases/tag/v20200315"
             }
         ]
     },

--- a/2020/8xxx/CVE-2020-8910.json
+++ b/2020/8xxx/CVE-2020-8910.json
@@ -1,27 +1,3 @@
-drive.web-frontend_20200311.00_p1
-CVE-2020-8910.json
-Who has access
-
-H
-System Properties
-Type
-Unknown File
-Size
-3 KB (3,262 bytes)
-Storage used
-3 KB (3,262 bytes)
-Location
-CVE-2020
-Owner
-me
-Modified
-2:38 PM by me
-Opened
-4:06 PM by me
-Created
-2:38 PM with Google Drive Web
-Add a description
-Viewers can download
 {
     "CVE_data_meta": {
         "ASSIGNER": "cve-coordination@google.com",
@@ -66,7 +42,7 @@ Viewers can download
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A URL parsing issue in goog.uri of the Google Closure Library versions v20200224 and prior versions allows a malicious attacker to send malicious URLs to be parsed by the library and return the wrong authority.\\n\\nMitigation: update your library to version v2020????"
+                "value": "A URL parsing issue in goog.uri of the Google Closure Library versions up to and including v20200224 allows an attacker to send malicious URLs to be parsed by the library and return the wrong authority. Mitigation: update your library to version v2020????"
             }
         ]
     },

--- a/2020/8xxx/CVE-2020-8910.json
+++ b/2020/8xxx/CVE-2020-8910.json
@@ -18,6 +18,7 @@
                                         {
                                             "version_affected": "<=",
                                             "version_name": "v20200224"
+                                            "version_value": "v20200224"
                                         }
                                     ]
                                 }

--- a/2020/8xxx/CVE-2020-8910.json
+++ b/2020/8xxx/CVE-2020-8910.json
@@ -93,12 +93,12 @@
     "references": {
         "reference_data": [
             {
-                "name": "Release Notes",
+                "name": "https://github.com/google/closure-library/commit/294fc00b01d248419d8f8de37580adf2a0024fc9",
                 "refsource": "CONFIRM",
                 "url": "https://github.com/google/closure-library/commit/294fc00b01d248419d8f8de37580adf2a0024fc9"
             },
             {
-                "name": "CONFIRM",
+                "name": "https://github.com/google/closure-library/releases/tag/v20200315",
                 "refsource": "CONFIRM",
                 "url": "https://github.com/google/closure-library/releases/tag/v20200315"
             }

--- a/2020/8xxx/CVE-2020-8910.json
+++ b/2020/8xxx/CVE-2020-8910.json
@@ -1,18 +1,130 @@
+drive.web-frontend_20200311.00_p1
+CVE-2020-8910.json
+Who has access
+
+H
+System Properties
+Type
+Unknown File
+Size
+3 KB (3,262 bytes)
+Storage used
+3 KB (3,262 bytes)
+Location
+CVE-2020
+Owner
+me
+Modified
+2:38 PM by me
+Opened
+4:06 PM by me
+Created
+2:38 PM with Google Drive Web
+Add a description
+Viewers can download
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "cve-coordination@google.com",
         "ID": "CVE-2020-8910",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Auth Bypass in Google's Closure-Library"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Closure-Library",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "v20200224"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Google"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "reportersnametobefilled"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A URL parsing issue in goog.uri of the Google Closure Library versions v20200224 and prior versions allows a malicious attacker to send malicious URLs to be parsed by the library and return the wrong authority.\\n\\nMitigation: update your library to version v2020????"
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "cwe-625"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Bad URL parsing"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "Release Notes",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/google/closure-library/releases"
+            },
+            {
+                "name": "CONFIRM",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/google/closure-library/commit/294fc00b01d248419d8f8de37580adf2a0024fc9"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }
+

--- a/2020/8xxx/CVE-2020-8910.json
+++ b/2020/8xxx/CVE-2020-8910.json
@@ -32,7 +32,11 @@
     "credit": [
         {
             "lang": "eng",
-            "value": "reportersnametobefilled"
+            "value": "David Schütz"
+        },
+        {
+            "lang": "eng",
+            "value": "François Lajeunesse-Robert"
         }
     ],
     "data_format": "MITRE",

--- a/2020/8xxx/CVE-2020-8910.json
+++ b/2020/8xxx/CVE-2020-8910.json
@@ -53,15 +53,15 @@
         "cvss": {
             "attackComplexity": "LOW",
             "attackVector": "NETWORK",
-            "availabilityImpact": "HIGH",
-            "baseScore": 9.8,
-            "baseSeverity": "CRITICAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
             "confidentialityImpact": "HIGH",
-            "integrityImpact": "HIGH",
+            "integrityImpact": "NONE",
             "privilegesRequired": "NONE",
             "scope": "UNCHANGED",
-            "userInteraction": "NONE",
-            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N",
             "version": "3.1"
         }
     },


### PR DESCRIPTION
Committing CVE-2020-8910 on Closure-Library.

https://github.com/google/closure-library/releases/tag/v20200315