### PR TITLE
updated description for CVE-2020-5261

### DIFF
--- a/2020/5xxx/CVE-2020-5261.json
+++ b/2020/5xxx/CVE-2020-5261.json
@@ -16,7 +16,7 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "< 2.5.0"
+                                            "version_value": ">= 2.0.0, < 2.5.0"
                                         }
                                     ]
                                 }
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Saml2 Authentication services for ASP.NET (NuGet package Sustainsys.Saml2) before version 2.5.0 has a faulty implementation of Token Replay Detection. Token Replay Detection is an important defence in depth measure for Single Sign On solutions. The 2.5.0 version is patched."
+                "value": "Saml2 Authentication services for ASP.NET (NuGet package Sustainsys.Saml2) greater than 2.0.0, and less than version 2.5.0 has a faulty implementation of Token Replay Detection. Token Replay Detection is an important defence in depth measure for Single Sign On solutions. The 2.5.0 version is patched. Note that version 1.0.1 is not affected. It has a correct Token Replay Implementation and is safe to use.\nSaml2 Authentication services for ASP.NET (NuGet package Sustainsys.Saml2) greater than 2.0.0, and less than version 2.5.0 have a faulty implementation of Token Replay Detection.\n\nToken Replay Detection is an important defense measure for Single Sign On solutions.\n\nThe 2.5.0 version is patched. Note that version 1.0.1 and prior versions are not affected. These versions have a correct Token Replay Implementation and are safe to use."
             }
         ]
     },


### PR DESCRIPTION
The prior description failed to note that this vulnerability does not affect versions before 2.0.0.  This new description notes that, and also has some other wording changes for more readability.