### PR TITLE
correct versions for CVE-2020-5255

### DIFF
--- a/2020/5xxx/CVE-2020-5255.json
+++ b/2020/5xxx/CVE-2020-5255.json
@@ -16,7 +16,10 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "< 4.4"
+                                            "version_value": ">= 4.4.0, < 4.4.7"
+                                        },
+                                        {
+                                            "version_value": ">= 5.0.0, < 5.0.7"
                                         }
                                     ]
                                 }
@@ -35,7 +38,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In Symfony before version 4.4, when a `Response` does not contain a `Content-Type` header,\naffected versions of Symfony can fallback to the format defined in the `Accept` header of the request,\nleading to a possible mismatch between the response&#39;s content and `Content-Type` header.\nWhen the response is cached, this can prevent the use of the website by other users.\n\nThis has been patched in version 4.4."
+                "value": "In Symfony before versions 4.4.7 and 5.0.7, when a `Response` does not contain a `Content-Type` header,\naffected versions of Symfony can fallback to the format defined in the `Accept` header of the request,\nleading to a possible mismatch between the response&#39;s content and `Content-Type` header.\nWhen the response is cached, this can prevent the use of the website by other users.\n\nThis has been patched in versions 4.4.7 and 5.0.7."
             }
         ]
     },


### PR DESCRIPTION
correct versions for CVE-2020-5255 / https://github.com/symfony/symfony/security/advisories/GHSA-mcx4-f5f5-4859