### PR TITLE
Canonical CNA: add CVE-2020-8835 / linux kernel / USN-4313-1

### DIFF
--- a/2020/8xxx/CVE-2020-8835.json
+++ b/2020/8xxx/CVE-2020-8835.json
@@ -1,18 +1,140 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2020-03-30T16:00:00.000Z",
         "ID": "CVE-2020-8835",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Linux kernel bpf verifier vulnerability"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Linux kernel",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "5.6.0",
+                                            "version_value": "5.6.0"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "5.5-stable",
+                                            "version_value": "5.5.13"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_name": "5.4-stable",
+                                            "version_value": "5.4.7"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "5.4-stable",
+                                            "version_value": "5.4.28"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Linux kernel"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Manfred Paul"
+        },
+        {
+            "lang": "eng",
+            "value": "Anatoly Trosinenko"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In the Linux kernel 5.5.0 and newer, the bpf verifier (kernel/bpf/verifier.c) did not properly restrict the register bounds for 32-bit operations, leading to out-of-bounds reads and writes in kernel memory. The vulnerability also affects the Linux 5.4 stable series, starting with v5.4.7, as the introducing commit was backported to that branch. (aka ZDI-CAN-10780)"
             }
         ]
-    }
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://www.thezdi.com/blog/2020/3/19/pwn2own-2020-day-one-results"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://lore.kernel.org/bpf/20200330160324.15259-1-daniel@iogearbox.net/T/"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://www.openwall.com/lists/oss-security/2020/03/30/3"
+            },
+            {
+                "refsource": "UBUNTU",
+                "url": "https://usn.ubuntu.com/usn/usn-4313-1"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=f2d67fec0b43edce8c416101cdc52e71145b5fef"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Revert commit 581738a681b6 (\"bpf: Provide better register bounds after jmp32 instructions\")."
+        }
+    ],
+    "source": {
+        "discovery": "EXTERNAL"
+    },
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "Mitigation for this vulnerability is available by setting the kernel.unprivileged_bpf_disabled sysctl to 1:\n\n   $ sudo sysctl kernel.unprivileged_bpf_disabled=1\n   $ echo kernel.unprivileged_bpf_disabled=1 |  sudo tee /etc/sysctl.d/90-CVE-2020-8835.conf\n\nThis issue is also mitigated on systems that use secure boot with the kernel lockdown feature which blocks BPF program loading."
+        }
+    ]
 }

--- a/2020/8xxx/CVE-2020-8835.json
+++ b/2020/8xxx/CVE-2020-8835.json
@@ -17,14 +17,14 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_affected": "<=",
-                                            "version_name": "5.6.0",
-                                            "version_value": "5.6.0"
+                                            "version_affected": "<",
+                                            "version_name": "5.6-stable",
+                                            "version_value": "5.6.1"
                                         },
                                         {
-                                            "version_affected": "<=",
+                                            "version_affected": "<",
                                             "version_name": "5.5-stable",
-                                            "version_value": "5.5.13"
+                                            "version_value": "5.5.14"
                                         },
                                         {
                                             "version_affected": ">=",
@@ -32,9 +32,9 @@
                                             "version_value": "5.4.7"
                                         },
                                         {
-                                            "version_affected": "<=",
+                                            "version_affected": "<",
                                             "version_name": "5.4-stable",
-                                            "version_value": "5.4.28"
+                                            "version_value": "5.4.29"
                                         }
                                     ]
                                 }
@@ -63,7 +63,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In the Linux kernel 5.5.0 and newer, the bpf verifier (kernel/bpf/verifier.c) did not properly restrict the register bounds for 32-bit operations, leading to out-of-bounds reads and writes in kernel memory. The vulnerability also affects the Linux 5.4 stable series, starting with v5.4.7, as the introducing commit was backported to that branch. (aka ZDI-CAN-10780)"
+                "value": "In the Linux kernel 5.5.0 and newer, the bpf verifier (kernel/bpf/verifier.c) did not properly restrict the register bounds for 32-bit operations, leading to out-of-bounds reads and writes in kernel memory. The vulnerability also affects the Linux 5.4 stable series, starting with v5.4.7, as the introducing commit was backported to that branch. This vulnerability was fixed in 5.6.1, 5.5.14, and 5.4.29. (issue is aka ZDI-CAN-10780)"
             }
         ]
     },
@@ -119,6 +119,10 @@
             {
                 "refsource": "CONFIRM",
                 "url": "https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=f2d67fec0b43edce8c416101cdc52e71145b5fef"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f2d67fec0b43edce8c416101cdc52e71145b5fef"
             }
         ]
     },


### PR DESCRIPTION

Signed-off-by: Steve Beattie <steve.beattie@canonical.com>