### PR TITLE
Dispute CVE-2019-19770

### DIFF
--- a/2019/19xxx/CVE-2019-19770.json
+++ b/2019/19xxx/CVE-2019-19770.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In the Linux kernel 4.19.83, there is a use-after-free (read) in the debugfs_remove function in fs/debugfs/inode.c (which is used to remove a file or directory in debugfs that was previously created with a call to another debugfs function such as debugfs_create_file)."
+                "value": "** DISPUTED ** In the Linux kernel 4.19.83, there is a use-after-free (read) in the debugfs_remove function in fs/debugfs/inode.c (which is used to remove a file or directory in debugfs that was previously created with a call to another debugfs function such as debugfs_create_file). NOTE: Linux kernel developers dispute this issue as not being an issue with debugfs, instead this is an issue with misuse of debugfs within blktrace, a reproducer and fixes are being reviewed, a pointer to the URL and reproducer has been provided on the bugzilla entry filed for the CVE. The severity of the issue is also reduced to only a misuse of blktrace under very specific scenarios:, you must be root to use blktrace, and one must race add/remove of a block device while issuing a BLKTRACESETUP without a BLKTRACETEARDOWN, this can either happen using a hotswappable drive, using virsh and adding/removing a drive, or using the local loopback drive; you then need to use a blktrace inappropriately as root. If this CVE is considered valid then many version of Linux would be affected as the blame is being put on debugfs_remove(), the dispute shows this is not the root case of the crash found. \u201d"
             }
         ]
     },
@@ -61,6 +61,16 @@
                 "refsource": "CONFIRM",
                 "name": "https://security.netapp.com/advisory/ntap-20200103-0001/",
                 "url": "https://security.netapp.com/advisory/ntap-20200103-0001/"
+            },
+            {
+                "refsource": "MISC",
+                "name": "https://github.com/mcgrof/break-blktrace",
+                "url": "https://github.com/mcgrof/break-blktrace"
+            },
+            {
+                "refsource": "MISC",
+                "name": "https://lore.kernel.org/linux-block/20200402000002.7442-1-mcgrof@kernel.org/",
+                "url": "https://lore.kernel.org/linux-block/20200402000002.7442-1-mcgrof@kernel.org/"
             }
         ]
     }


### PR DESCRIPTION
We at SUSE would like to dispute CVE-2019-19770. Patches have been posted to address this, however, this work has revealed that the claims of the CVE are incorrect, the issue is just a blktrace bug, and the severity is only exposed if running block trace incorrectly as root on a block device which appears / reappears.

Signed-off-by: Luis Chamberlain <mcgrof@kernel.org>