### PR TITLE
Update CVE-2020-1630.json

### DIFF
--- a/2020/1xxx/CVE-2020-1630.json
+++ b/2020/1xxx/CVE-2020-1630.json
@@ -43,7 +43,7 @@
                                         },
                                         {
                                             "version_affected": "<",
-                                            "version_name": "15.1X49",
+                                            "version_name": "15.1X53",
                                             "version_value": "15.1X53-D592"
                                         },
                                         {
@@ -128,7 +128,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A privilege escalation vulnerability in Juniper Networks Junos OS devices configured with dual Routing Engines (RE), Virtual Chassis (VC) or high-availability cluster may allow a local authenticated low-privileged user with access to the shell to perform unauthorized configuration modification.\n\nThis issue does not affect Junos OS device with single RE or stand-alone configuration.\n\nThis issue affects Juniper Networks Junos OS\n12.3 versions prior to 12.3R12-S14;\n12.3X48 versions prior to 12.3X48-D86, 12.3X48-D90;\n14.1X53 versions prior to 14.1X53-D51;\n15.1 versions prior to 15.1R7-S6;\n15.1X49 versions prior to 15.1X49-D181, 15.1X49-D190;\n15.1X49 versions prior to 15.1X53-D592;\n16.1 versions prior to 16.1R4-S13, 16.1R7-S6;\n16.2 versions prior to 16.2R2-S10;\n17.1 versions prior to 17.1R2-S11, 17.1R3-S1;\n17.2 versions prior to 17.2R1-S9, 17.2R3-S3;\n17.3 versions prior to 17.3R3-S6;\n17.4 versions prior to 17.4R2-S6, 17.4R3;\n18.1 versions prior to 18.1R3-S7;\n18.2 versions prior to 18.2R2-S5, 18.2R3-S1;\n18.2 versions prior to 18.2X75-D12, 18.2X75-D33, 18.2X75-D420, 18.2X75-D60, 18.2X75-D411;\n18.3 versions prior to 18.3R1-S5, 18.3R2-S1, 18.3R3;\n18.4 versions prior to 18.4R1-S4, 18.4R2-S1, 18.4R3;\n19.1 versions prior to 19.1R1-S2, 19.1R2;\n19.2 versions prior to 19.2R1-S1, 19.2R2."
+                "value": "A privilege escalation vulnerability in Juniper Networks Junos OS devices configured with dual Routing Engines (RE), Virtual Chassis (VC) or high-availability cluster may allow a local authenticated low-privileged user with access to the shell to perform unauthorized configuration modification.\n\nThis issue does not affect Junos OS device with single RE or stand-alone configuration.\n\nThis issue affects Juniper Networks Junos OS\n12.3 versions prior to 12.3R12-S14;\n12.3X48 versions prior to 12.3X48-D86, 12.3X48-D90;\n14.1X53 versions prior to 14.1X53-D51;\n15.1 versions prior to 15.1R7-S6;\n15.1X49 versions prior to 15.1X49-D181, 15.1X49-D190;\n15.1X53 versions prior to 15.1X53-D592;\n16.1 versions prior to 16.1R4-S13, 16.1R7-S6;\n16.2 versions prior to 16.2R2-S10;\n17.1 versions prior to 17.1R2-S11, 17.1R3-S1;\n17.2 versions prior to 17.2R1-S9, 17.2R3-S3;\n17.3 versions prior to 17.3R3-S6;\n17.4 versions prior to 17.4R2-S6, 17.4R3;\n18.1 versions prior to 18.1R3-S7;\n18.2 versions prior to 18.2R2-S5, 18.2R3-S1;\n18.2 versions prior to 18.2X75-D12, 18.2X75-D33, 18.2X75-D420, 18.2X75-D60, 18.2X75-D411;\n18.3 versions prior to 18.3R1-S5, 18.3R2-S1, 18.3R3;\n18.4 versions prior to 18.4R1-S4, 18.4R2-S1, 18.4R3;\n19.1 versions prior to 19.1R1-S2, 19.1R2;\n19.2 versions prior to 19.2R1-S1, 19.2R2."
             }
         ]
     },


### PR DESCRIPTION
correction on 15.1X53 instead of 15.1X49