### PR TITLE
ZDI assigns the following CVEs:

### DIFF
--- a/2020/10xxx/CVE-2020-10889.json
+++ b/2020/10xxx/CVE-2020-10889.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10889",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10889",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.0.29478"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Anonymous",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.0.29478. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of the DuplicatePages command of the communication API. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-9828."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-511/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10890.json
+++ b/2020/10xxx/CVE-2020-10890.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10890",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10890",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.0.29478"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Anonymous",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.0.29478. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the communication API. The issue lies in the handling of the ConvertToPDF command, which allows an arbitrary file write with attacker controlled data. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-9829."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-352: Cross-Site Request Forgery (CSRF)"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-512/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10891.json
+++ b/2020/10xxx/CVE-2020-10891.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10891",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10891",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.0.29478"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Anonymous",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.0.29478. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of the Save command of the communication API. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-9831."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-514/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10892.json
+++ b/2020/10xxx/CVE-2020-10892.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10892",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10892",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.0.29478"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Anonymous",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.0.29478. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the communication API. The issue lies in the handling of the CombineFiles command, which allows an arbitrary file write with attacker controlled data. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-9830."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-352: Cross-Site Request Forgery (CSRF)"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-513/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10893.json
+++ b/2020/10xxx/CVE-2020-10893.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10893",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10893",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of U3D objects embedded in a PDF. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-10189."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-521/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10894.json
+++ b/2020/10xxx/CVE-2020-10894.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10894",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10894",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit PhantomPDF 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of U3D objects embedded in a PDF. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-10190."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-522/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10895.json
+++ b/2020/10xxx/CVE-2020-10895.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10895",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10895",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of U3D objects in PDF files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-10191."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-523/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10896.json
+++ b/2020/10xxx/CVE-2020-10896.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10896",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10896",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of U3D objects in PDF files. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a heap-based buffer. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-10192."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-122: Heap-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-524/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10897.json
+++ b/2020/10xxx/CVE-2020-10897.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10897",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10897",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of U3D objects in PDF files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated object. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-10193."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-525/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10898.json
+++ b/2020/10xxx/CVE-2020-10898.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10898",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10898",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of U3D objects in PDF files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-10195."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-526/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10899.json
+++ b/2020/10xxx/CVE-2020-10899.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10899",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10899",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Reader",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "hungtt28 of Viettel Cyber Security",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Reader 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the processing of XFA templates. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-10132."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-416: Use After Free"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-527/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10900.json
+++ b/2020/10xxx/CVE-2020-10900.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10900",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10900",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Reader",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Anonymous",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Reader 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the processing of AcroForms. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-10142."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-416: Use After Free"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-528/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10901.json
+++ b/2020/10xxx/CVE-2020-10901.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10901",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10901",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit PhantomPDF 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of U3D objects in PDF files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-10461."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-529/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10902.json
+++ b/2020/10xxx/CVE-2020-10902.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10902",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10902",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of U3D objects in PDF files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-10462."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-530/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10903.json
+++ b/2020/10xxx/CVE-2020-10903.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10903",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10903",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit PhantomPDF 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of U3D objects embedded in a PDF. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-10463."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-531/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10904.json
+++ b/2020/10xxx/CVE-2020-10904.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10904",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10904",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of U3D objects in PDF files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated object. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-10464."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-532/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10905.json
+++ b/2020/10xxx/CVE-2020-10905.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10905",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10905",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit PhantomPDF 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of vertices in U3D objects. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated object. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-10568."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-533/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10906.json
+++ b/2020/10xxx/CVE-2020-10906.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10906",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10906",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Reader",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "@hungtt28",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Reader 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the resetForm method. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-10614."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-416: Use After Free"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-534/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10907.json
+++ b/2020/10xxx/CVE-2020-10907.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10907",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10907",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Reader",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.1.29511"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Peter Nguyen Vu Hoang of STAR Labs",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Reader 9.7.1.29511. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of widgets in XFA forms. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-10650."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-416: Use After Free"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-535/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10908.json
+++ b/2020/10xxx/CVE-2020-10908.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10908",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10908",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.0.29478"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Anonymous",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.0.29478. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of the Export command of the communication API. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-9865."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-515/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10909.json
+++ b/2020/10xxx/CVE-2020-10909.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10909",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10909",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.0.29478"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.0.29478. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of the AddWatermark command of the communication API. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-9942."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-516/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10910.json
+++ b/2020/10xxx/CVE-2020-10910.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10910",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10910",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.0.29478"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.0.29478. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of the RotatePage command of the communication API. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-9943."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-517/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10911.json
+++ b/2020/10xxx/CVE-2020-10911.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10911",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10911",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.0.29478"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.0.29478. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of the GetFieldValue command of the communication API. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-9944."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-518/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10912.json
+++ b/2020/10xxx/CVE-2020-10912.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10912",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10912",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.0.29478"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.0.29478. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of the SetFieldValue command of the communication API. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-9945."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-519/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10913.json
+++ b/2020/10xxx/CVE-2020-10913.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10913",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10913",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PhantomPDF",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.7.0.29478"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PhantomPDF 9.7.0.29478. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of the OCRAndExportToExcel command of the communication API. The issue results from the lack of proper validation of user-supplied data, which can result in a type confusion condition. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-9946."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-520/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.php"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10914.json
+++ b/2020/10xxx/CVE-2020-10914.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10914",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10914",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "One Agent",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.5.4.4587"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "VEEAM"
+        }
+      ]
     }
+  },
+  "credit": "Michael Zanetta & Edgar Boda-Majer from Bugscale",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of VEEAM One Agent 9.5.4.4587. Authentication is not required to exploit this vulnerability. \n\nThe specific flaw exists within the PerformHandshake method. The issue results from the lack of proper validation of user-supplied data, which can result in deserialization of untrusted data. An attacker can leverage this vulnerability to execute code in the context of the service account. Was ZDI-CAN-10400."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-502: Deserialization of Untrusted Data"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-545/"
+      },
+      {
+        "url": "https://www.veeam.com/kb3144"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/10xxx/CVE-2020-10915.json
+++ b/2020/10xxx/CVE-2020-10915.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10915",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-10915",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "One Agent",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "9.5.4.4587"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "VEEAM"
+        }
+      ]
     }
+  },
+  "credit": "Michael Zanetta & Edgar Boda-Majer from Bugscale",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of VEEAM One Agent 9.5.4.4587. Authentication is not required to exploit this vulnerability. \n\nThe specific flaw exists within the HandshakeResult method. The issue results from the lack of proper validation of user-supplied data, which can result in deserialization of untrusted data. An attacker can leverage this vulnerability to execute code in the context of the service account. Was ZDI-CAN-10401."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-502: Deserialization of Untrusted Data"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-546/"
+      },
+      {
+        "url": "https://www.veeam.com/kb3144"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/8xxx/CVE-2020-8867.json
+++ b/2020/8xxx/CVE-2020-8867.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-8867",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-8867",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "UA .NET Standard",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "1.04.358.30"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "OPC Foundation"
+        }
+      ]
     }
+  },
+  "credit": "Steven Seeley (mr_me) and Chris Anastasio (muffin) ",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to create a denial-of-service condition on affected installations of OPC Foundation UA .NET Standard 1.04.358.30. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the handling of sessions. The issue results from the lack of proper locking when performing operations on an object. An attacker can leverage this vulnerability to create a denial-of-service condition against the application. Was ZDI-CAN-10295."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-367: Time-of-check Time-of-use (TOCTOU) Race Condition"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-536/"
+      },
+      {
+        "url": "https://opcfoundation.org/SecurityBulletins/OPC%20Foundation%20Security%20Bulletin%20CVE-2020-8867.pdf"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+      "version": "3.0"
+    }
+  }
 }


### PR DESCRIPTION
All are Foxit except the last 3, as indicated below 
M 2020/10xxx/CVE-2020-10889.json
 M 2020/10xxx/CVE-2020-10890.json
 M 2020/10xxx/CVE-2020-10891.json
 M 2020/10xxx/CVE-2020-10892.json
 M 2020/10xxx/CVE-2020-10893.json
 M 2020/10xxx/CVE-2020-10894.json
 M 2020/10xxx/CVE-2020-10895.json
 M 2020/10xxx/CVE-2020-10896.json
 M 2020/10xxx/CVE-2020-10897.json
 M 2020/10xxx/CVE-2020-10898.json
 M 2020/10xxx/CVE-2020-10899.json
 M 2020/10xxx/CVE-2020-10900.json
 M 2020/10xxx/CVE-2020-10901.json
 M 2020/10xxx/CVE-2020-10902.json
 M 2020/10xxx/CVE-2020-10903.json
 M 2020/10xxx/CVE-2020-10904.json
 M 2020/10xxx/CVE-2020-10905.json
 M 2020/10xxx/CVE-2020-10906.json
 M 2020/10xxx/CVE-2020-10907.json
 M 2020/10xxx/CVE-2020-10908.json
 M 2020/10xxx/CVE-2020-10909.json
 M 2020/10xxx/CVE-2020-10910.json
 M 2020/10xxx/CVE-2020-10911.json
 M 2020/10xxx/CVE-2020-10912.json
 M 2020/10xxx/CVE-2020-10913.json
 M 2020/10xxx/CVE-2020-10914.json (VEAM)
 M 2020/10xxx/CVE-2020-10915.json (VEAM)
 M 2020/8xxx/CVE-2020-8867.json (OPC Foundation)