### PR TITLE
Clarify Metasploit version numbers

### DIFF
--- a/2020/7xxx/CVE-2020-7350.json
+++ b/2020/7xxx/CVE-2020-7350.json
@@ -17,9 +17,9 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_affected": "<=",
-                                            "version_name": "5.0.84",
-                                            "version_value": "5.0.84"
+                                            "version_affected": "<",
+                                            "version_name": "5.0.85",
+                                            "version_value": "5.0.85"
                                         }
                                     ]
                                 }
@@ -44,7 +44,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Rapid7 Metasploit Framework version 5.0.84 and prior suffers from an instance of CWE-78: OS Command Injection, wherein the libnotify plugin accepts untrusted user-supplied data via a remote computer's hostname or service name. An attacker can create a specially-crafted hostname or service name to be imported by Metasploit from a variety of sources and trigger a command injection on the operator's terminal. Note, only the Metasploit Framework and products that expose the plugin system is susceptible to this issue -- notably, this does not include Rapid7 Metasploit Pro. Also note, this vulnerability cannot be triggered through a normal scan operation -- the attacker would have to supply a file that is processed with the db_import command."
+                "value": "Rapid7 Metasploit Framework versions before 5.0.85 suffers from an instance of CWE-78: OS Command Injection, wherein the libnotify plugin accepts untrusted user-supplied data via a remote computer's hostname or service name. An attacker can create a specially-crafted hostname or service name to be imported by Metasploit from a variety of sources and trigger a command injection on the operator's terminal. Note, only the Metasploit Framework and products that expose the plugin system is susceptible to this issue -- notably, this does not include Rapid7 Metasploit Pro. Also note, this vulnerability cannot be triggered through a normal scan operation -- the attacker would have to supply a file that is processed with the db_import command."
             }
         ]
     },


### PR DESCRIPTION
Instead of "5.0.84 and prior," the requested terminology was "before 5.0.85."

See CVEProject/cvelist#3663 wherein @iamleot requested this change, which is fine by me.