### PR TITLE
Canonical CNAs: Ubuntu shiftfs cves

### DIFF
--- a/2019/15xxx/CVE-2019-15791.json
+++ b/2019/15xxx/CVE-2019-15791.json
@@ -1,0 +1,114 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2019-11-12 18:00:00 UTC",
+        "ID": "CVE-2019-15791",
+        "STATE": "PUBLIC",
+        "TITLE": "Reference count underflow in shiftfs"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Shiftfs in the Linux kernel",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_name": "5.3 kernel",
+                                            "version_value": "5.3.0-11.12"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.3 kernel",
+                                            "version_value": "5.3.0-22.24"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.0 kernel",
+                                            "version_value": "5.0.0-35.38"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Ubuntu"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Jann Horn of Google Project Zero"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "In shiftfs, a non-upstream patch to the Linux kernel included in the Ubuntu 5.0 and 5.3 kernel series, shiftfs_btrfs_ioctl_fd_replace() installs an fd referencing a file from the lower filesystem without taking an additional reference to that file. After the btrfs ioctl completes this fd is closed, which then puts a reference to that file, leading to a refcount underflow."
+            }
+        ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-672 Operation on a Resource after Expiration or Release"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "UBUNTU",
+                "url": "https://usn.ubuntu.com/usn/usn-4183-1"
+            },
+            {
+                "refsource": "UBUNTU",
+                "url": "https://usn.ubuntu.com/usn/usn-4184-1"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/eoan/commit/?id=601a64857b3d7040ca15c39c929e6b9db3373ec1"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1850867"
+        ],
+        "discovery": "EXTERNAL"
+    }
+}

--- a/2019/15xxx/CVE-2019-15792.json
+++ b/2019/15xxx/CVE-2019-15792.json
@@ -1,0 +1,114 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2019-11-12 18:00:00 UTC",
+        "ID": "CVE-2019-15792",
+        "STATE": "PUBLIC",
+        "TITLE": "Type confusion in shiftfs"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Shiftfs in the Linux kernel",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_name": "5.3 kernel",
+                                            "version_value": "5.3.0-11.12"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.3 kernel",
+                                            "version_value": "5.3.0-22.24"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.0 kernel",
+                                            "version_value": "5.0.0-35.38"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Ubuntu"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Jann Horn of Google Project Zero"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "In shiftfs, a non-upstream patch to the Linux kernel included in the Ubuntu 5.0 and 5.3 kernel series, shiftfs_btrfs_ioctl_fd_replace() calls fdget(oldfd), then without further checks passes the resulting file* into shiftfs_real_fdget(), which casts file->private_data, a void* that points to a filesystem-dependent type, to a \"struct shiftfs_file_info *\". As the private_data is not required to be a pointer, an attacker can use this to cause a denial of service or possibly execute arbitrary code."
+            }
+        ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-843 Access of Resource Using Incompatible Type ('Type Confusion')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "UBUNTU",
+                "url": "https://usn.ubuntu.com/usn/usn-4183-1"
+            },
+            {
+                "refsource": "UBUNTU",
+                "url": "https://usn.ubuntu.com/usn/usn-4184-1"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/eoan/commit/?id=5df147c8140efc71ac0879ae3b0057f577226d4c"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1850867"
+        ],
+        "discovery": "EXTERNAL"
+    }
+}

--- a/2019/15xxx/CVE-2019-15793.json
+++ b/2019/15xxx/CVE-2019-15793.json
@@ -1,0 +1,114 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2019-11-12 18:00:00 UTC",
+        "ID": "CVE-2019-15793",
+        "STATE": "PUBLIC",
+        "TITLE": "Mishandling of file-system uid/gid with namespaces in shiftfs"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Shiftfs in the Linux kernel",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_name": "5.3 kernel",
+                                            "version_value": "5.3.0-11.12"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.3 kernel",
+                                            "version_value": "5.3.0-22.24"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.0 kernel",
+                                            "version_value": "5.0.0-35.38"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Ubuntu"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Jann Horn of Google Project Zero"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "In shiftfs, a non-upstream patch to the Linux kernel included in the Ubuntu 5.0 and 5.3 kernel series, several locations which shift ids translate user/group ids before performing operations in the lower filesystem were translating them into init_user_ns, whereas they should have been translated into the s_user_ns for the lower filesystem. This resulted in using ids other than the intended ones in the lower fs, which likely did not map into the shifts s_user_ns. A local attacker could use this to possibly bypass discretionary access control permissions."
+            }
+        ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-538 File and Directory Information Exposure"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "UBUNTU",
+                "url": "https://usn.ubuntu.com/usn/usn-4183-1"
+            },
+            {
+                "refsource": "UBUNTU",
+                "url": "https://usn.ubuntu.com/usn/usn-4184-1"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/eoan/commit/?id=3644b9d5688da86f18e017c9c580b75cf52927bb"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://bugs.launchpad.net/bugs/1850867"
+        ],
+        "discovery": "EXTERNAL"
+    }
+}

--- a/2019/15xxx/CVE-2019-15794.json
+++ b/2019/15xxx/CVE-2019-15794.json
@@ -1,0 +1,113 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2019-11-08T00:00:00.000Z",
+        "ID": "CVE-2019-15794",
+        "STATE": "PUBLIC",
+        "TITLE": "Reference counting error in overlayfs/shiftfs error path when used in conjuction with aufs"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Linux kernel",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.3 kernel",
+                                            "version_value": "5.3.0-24.26"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.0 kernel",
+                                            "version_value": "5.0.0-37.40"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Ubuntu"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Jann Horn of Google Project Zero"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "Overlayfs in the Linux kernel and shiftfs, a non-upstream patch to the Linux kernel included in the Ubuntu 5.0 and 5.3 kernel series, both replace vma->vm_file in their mmap handlers. On error the original value is not restored, and the reference is put for the file to which vm_file points. On upstream kernels this is not an issue, as no callers dereference vm_file following after call_mmap() returns an error. However, the aufs patchs change mmap_region() to replace the fput() using a local variable with vma_fput(), which will fput() vm_file, leading to a refcount underflow."
+            }
+        ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-672 Operation on a Resource after Expiration or Release"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/eoan/commit/?id=270d16ae48a4dbf1c7e25e94cc3e38b4bea37635"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/eoan/commit/?id=ef81780548d20a786cc77ed4203fca146fd81ce3"
+            },
+            {
+                "refsource": "UBUNTU",
+                "url": "https://usn.ubuntu.com/usn/usn-4208-1"
+            },
+            {
+                "refsource": "UBUNTU",
+                "url": "https://usn.ubuntu.com/usn/usn-4209-1"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://bugs.launchpad.net/bugs/1850994"
+        ],
+        "discovery": "EXTERNAL"
+    }
+}


### PR DESCRIPTION
Add CVEs CVE-2019-15791, CVE-2019-15792, CVE-2019-15793, and CVE-2019-15794.