### PR TITLE
Update version number for CVE-2020-11037 for GHSA-jjjr-3jcw-f8v6

### DIFF
--- a/2020/11xxx/CVE-2020-11037.json
+++ b/2020/11xxx/CVE-2020-11037.json
@@ -16,7 +16,7 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "< 2.7.2"
+                                            "version_value": "< 2.7.3"
                                         },
                                         {
                                             "version_value": ">= 2.8, < 2.8.2"
@@ -38,7 +38,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In Wagtail before versions 2.7.2 and 2.8.2, a potential timing attack exists on pages or documents that have been protected with a shared password through Wagtail's \"Privacy\" controls. This password check is performed through a character-by-character string comparison, and so an attacker who is able to measure the time taken by this check to a high degree of accuracy could potentially use timing differences to gain knowledge of the password. This is understood to be feasible on a local network, but not on the public internet.\n\nPrivacy settings that restrict access to pages/documents on a per-user or per-group basis (as opposed to a shared password) are unaffected by this vulnerability.\n\nThis has been patched in 2.7.3, 2.8.2, 2.9."
+                "value": "In Wagtail before versions 2.7.3 and 2.8.2, a potential timing attack exists on pages or documents that have been protected with a shared password through Wagtail's \"Privacy\" controls. This password check is performed through a character-by-character string comparison, and so an attacker who is able to measure the time taken by this check to a high degree of accuracy could potentially use timing differences to gain knowledge of the password. This is understood to be feasible on a local network, but not on the public internet.\n\nPrivacy settings that restrict access to pages/documents on a per-user or per-group basis (as opposed to a shared password) are unaffected by this vulnerability.\n\nThis has been patched in 2.7.3, 2.8.2, 2.9."
             }
         ]
     },


### PR DESCRIPTION
Update version number for CVE-2020-11037 for GHSA-jjjr-3jcw-f8v6