### PR TITLE
revert inadvertant publish of CVE-2020-11037

### DIFF
--- a/2020/11xxx/CVE-2020-11037.json
+++ b/2020/11xxx/CVE-2020-11037.json
@@ -1,86 +1,18 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "security-advisories@github.com",
-        "ID": "CVE-2020-11037",
-        "STATE": "PUBLIC",
-        "TITLE": "Potential Observable Timing Discrepancy in Wagtail"
-    },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Wagtail",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "< 2.7.2"
-                                        },
-                                        {
-                                            "version_value": ">= 2.8, < 2.8.2"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    },
-                    "vendor_name": "wagtail"
-                }
-            ]
-        }
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2020-11037",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "RESERVED"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In Wagtail before versions 2.7.2 and 2.8.2, a potential timing attack exists on pages or documents that have been protected with a shared password through Wagtail's \"Privacy\" controls. This password check is performed through a character-by-character string comparison, and so an attacker who is able to measure the time taken by this check to a high degree of accuracy could potentially use timing differences to gain knowledge of the password. This is understood to be feasible on a local network, but not on the public internet.\n\nPrivacy settings that restrict access to pages/documents on a per-user or per-group basis (as opposed to a shared password) are unaffected by this vulnerability.\n\nThis has been patched in 2.7.3, 2.8.2, 2.9."
+                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
             }
         ]
-    },
-    "impact": {
-        "cvss": {
-            "attackComplexity": "HIGH",
-            "attackVector": "LOCAL",
-            "availabilityImpact": "NONE",
-            "baseScore": 6.1,
-            "baseSeverity": "MEDIUM",
-            "confidentialityImpact": "HIGH",
-            "integrityImpact": "LOW",
-            "privilegesRequired": "HIGH",
-            "scope": "CHANGED",
-            "userInteraction": "NONE",
-            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:C/C:H/I:L/A:N",
-            "version": "3.1"
-        }
-    },
-    "problemtype": {
-        "problemtype_data": [
-            {
-                "description": [
-                    {
-                        "lang": "eng",
-                        "value": "CWE-208: Observable Timing Discrepancy"
-                    }
-                ]
-            }
-        ]
-    },
-    "references": {
-        "reference_data": [
-            {
-                "name": "https://github.com/wagtail/wagtail/security/advisories/GHSA-jjjr-3jcw-f8v6",
-                "refsource": "CONFIRM",
-                "url": "https://github.com/wagtail/wagtail/security/advisories/GHSA-jjjr-3jcw-f8v6"
-            }
-        ]
-    },
-    "source": {
-        "advisory": "GHSA-jjjr-3jcw-f8v6",
-        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
❗We unfortunately made a mistake, and this CVE was disclosed early.  Is it possible to accept this PR to revert this CVE back to the reserved state?