### PR TITLE
Populate CVE-2020-7351

### DIFF
--- a/2020/11xxx/CVE-2020-11021.json
+++ b/2020/11xxx/CVE-2020-11021.json
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Actions Http-Client (NPM @actions/http-client) before version 1.0.8 can disclose Authorization headers to incorrect domain in certain redirect scenarios.\n\nThe conditions in which this happens are if consumers of the http-client:\n  1. make an http request with an authorization header\n  2. that request leads to a redirect (302) and\n  3. the redirect url redirects to another domain or hostname \n\nThen the authorization header will get passed to the other domain.\n    \nThe problem is fixed in version 1.0.8."
+                "value": "Actions Http-Client (NPM @actions/http-client) before version 1.0.8 can disclose Authorization headers to incorrect domain in certain redirect scenarios. The conditions in which this happens are if consumers of the http-client: 1. make an http request with an authorization header 2. that request leads to a redirect (302) and 3. the redirect url redirects to another domain or hostname Then the authorization header will get passed to the other domain. The problem is fixed in version 1.0.8."
             }
         ]
     },

--- a/2020/12xxx/CVE-2020-12465.json
+++ b/2020/12xxx/CVE-2020-12465.json
@@ -1,7 +1,7 @@
 {
     "CVE_data_meta": {
         "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2020-11958",
+        "ID": "CVE-2020-12465",
         "STATE": "PUBLIC"
     },
     "affects": {
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "re2c 1.3 has a heap-based buffer overflow in Scanner::fill in parse/scanner.cc via a long lexeme."
+                "value": "An array overflow was discovered in mt76_add_fragment in drivers/net/wireless/mediatek/mt76/dma.c in the Linux kernel before 5.5.10, aka CID-b102f0c522cf. An oversized packet with too many rx fragments can corrupt memory of adjacent pages."
             }
         ]
     },
@@ -53,34 +53,19 @@
     "references": {
         "reference_data": [
             {
-                "url": "https://blogs.gentoo.org/ago/2020/04/19/re2c-heap-overflow-in-scannerfill-scanner-cc/",
+                "url": "https://github.com/torvalds/linux/commit/b102f0c522cf668c8382c56a4f771b37d011cda2",
                 "refsource": "MISC",
-                "name": "https://blogs.gentoo.org/ago/2020/04/19/re2c-heap-overflow-in-scannerfill-scanner-cc/"
+                "name": "https://github.com/torvalds/linux/commit/b102f0c522cf668c8382c56a4f771b37d011cda2"
             },
             {
-                "url": "https://www.openwall.com/lists/oss-security/2020/04/19/1",
+                "url": "https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=b102f0c522cf668c8382c56a4f771b37d011cda2",
                 "refsource": "MISC",
-                "name": "https://www.openwall.com/lists/oss-security/2020/04/19/1"
+                "name": "https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=b102f0c522cf668c8382c56a4f771b37d011cda2"
             },
             {
-                "url": "https://github.com/skvadrik/re2c/commit/c4603ba5ce229db83a2a4fb93e6d4b4e3ec3776a",
+                "url": "https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.5.10",
                 "refsource": "MISC",
-                "name": "https://github.com/skvadrik/re2c/commit/c4603ba5ce229db83a2a4fb93e6d4b4e3ec3776a"
-            },
-            {
-                "refsource": "MLIST",
-                "name": "[oss-security] 20200421 Re: re2c: heap overflow in Scanner::fill (scanner.cc)",
-                "url": "http://www.openwall.com/lists/oss-security/2020/04/21/1"
-            },
-            {
-                "refsource": "UBUNTU",
-                "name": "USN-4338-1",
-                "url": "https://usn.ubuntu.com/4338-1/"
-            },
-            {
-                "refsource": "UBUNTU",
-                "name": "USN-4338-2",
-                "url": "https://usn.ubuntu.com/4338-2/"
+                "name": "https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.5.10"
             }
         ]
     }


### PR DESCRIPTION
This adds a CVE for Trixbox CE, first disclosed by a Metasploit contributor