### PR TITLE
add historical nvidia cves assigned by canonical

### DIFF
--- a/2012/0xxx/CVE-2012-0952.json
+++ b/2012/0xxx/CVE-2012-0952.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2012-07-13T00:00:00.000Z",
         "ID": "CVE-2012-0952",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": " Heap overflow in control device ioctl"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "graphics drivers",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "295.53"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "nvidia"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Kees Cook"
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,53 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A heap buffer overflow was discovered in the device control ioctl in the Linux driver for Nvidia graphics cards, which may allow an attacker to overflow 49 bytes. This issue was fixed in version 295.53."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "LOW",
+            "baseScore": 5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "HIGH",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:C/C:L/I:L/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-119 Improper Restriction of Operations within the Bounds of a Memory Buffer"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers/+bug/979373"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers/+bug/979373"
+        ],
+        "discovery": "UNKNOWN"
     }
 }

--- a/2012/0xxx/CVE-2012-0953.json
+++ b/2012/0xxx/CVE-2012-0953.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2012-07-13T00:00:00.000Z",
         "ID": "CVE-2012-0953",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Kernel heap contents leak race in ioctl handler"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "graphics drivers",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "295.53"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "nvidia"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Kees Cook"
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,53 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A race condition was discovered in the Linux drivers for Nvidia graphics which allowed an attacker to exfiltrate kernel memory to userspace. This issue was fixed in version 295.53."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "LOW",
+            "baseScore": 5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "HIGH",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:C/C:L/I:L/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-362 Race Condition (Concurrent Execution using Shared Resource with Improper Synchronization)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers/+bug/979373"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers/+bug/979373"
+        ],
+        "discovery": "INTERNAL"
     }
 }


### PR DESCRIPTION
Hello, some of our old assignments are missing from the git tree; here's two nvidia linux kernel driver issues that the Ubuntu Security Team assigned numbers to.

Thanks