### PR TITLE
Adding two CVEs for the ClamAV 0.10.23 security patch

### DIFF
--- a/2020/3xxx/CVE-2020-3327.json
+++ b/2020/3xxx/CVE-2020-3327.json
@@ -1,18 +1,97 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "psirt@cisco.com",
+        "DATE_PUBLIC": "2020-05-12T16:00:00.000Z",
         "ID": "CVE-2020-3327",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "ClamAV ARJ Archive Parsing Denial of Service Vulnerability"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "ClamAV",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "0.102.3"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Cisco"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Special thanks to Daehui Chang and Fady Othman for helping identify the ARJ parsing vulnerability."
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A vulnerability in the ARJ archive parsing module in Clam AntiVirus (ClamAV) Software versions 0.102.2 could allow an unauthenticated, remote attacker to cause a denial of service condition on an affected device. The vulnerability is due to a heap buffer overflow read. An attacker could exploit this vulnerability by sending a crafted ARJ file to an affected device. An exploit could allow the attacker to cause the ClamAV scanning process crash, resulting in a denial of service condition. "
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-20 Improper Input Validation"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://blog.clamav.net/2020/05/clamav-01023-security-patch-released.html",
+                "refsource": "CISCO",
+                "url": "https://blog.clamav.net/2020/05/clamav-01023-security-patch-released.html"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "clamav-01023-security-patch",
+        "defect": [
+            "clamav-01023-security-patch"
+        ],
+        "discovery": "EXTERNAL"
     }
 }

--- a/2020/3xxx/CVE-2020-3341.json
+++ b/2020/3xxx/CVE-2020-3341.json
@@ -1,18 +1,97 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "psirt@cisco.com",
+        "DATE_PUBLIC": "2020-05-12T16:00:00.000Z",
         "ID": "CVE-2020-3341",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "ClamAV PDF Parsing Denial of Service Vulnerability"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "ClamAV",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "0.102.3"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Cisco"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "OSS-Fuzz discovered this vulnerability."
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A vulnerability in the PDF archive parsing module in Clam AntiVirus (ClamAV) Software versions 0.101 - 0.102.2 could allow an unauthenticated, remote attacker to cause a denial of service condition on an affected device.\n\nThe vulnerability is due to a stack buffer overflow read. An attacker could exploit this vulnerability by sending a crafted PDF file to an affected device. An exploit could allow the attacker to cause the ClamAV scanning process crash, resulting in a denial of service condition."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-20 Improper Input Validation"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://blog.clamav.net/2020/05/clamav-01023-security-patch-released.html",
+                "refsource": "CISCO",
+                "url": "https://blog.clamav.net/2020/05/clamav-01023-security-patch-released.html"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "clamav-01023-security-patch",
+        "defect": [
+            "clamav-01023-security-patch"
+        ],
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
Adding two CVEs for the ClamAV 0.10.23 security patch.

- CVE-2020-3327.json
- CVE-2020-3341.json