### PR TITLE
Update affected version numbers

### DIFF
--- a/2020/1xxx/CVE-2020-1998.json
+++ b/2020/1xxx/CVE-2020-1998.json
@@ -57,14 +57,9 @@
                                             "version_value": "9.1.1"
                                         },
                                         {
-                                            "version_affected": "<",
+                                            "version_affected": "=",
                                             "version_name": "8.0",
-                                            "version_value": "8.0.21"
-                                        },
-                                        {
-                                            "version_affected": "!>=",
-                                            "version_name": "8.0",
-                                            "version_value": "8.0.21"
+                                            "version_value": "8.0.*"
                                         }
                                     ]
                                 }
@@ -89,7 +84,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "An improper authorization vulnerability in PAN-OS that mistakenly uses the permissions of local linux users instead of the intended SAML permissions of the account when the username is shared for the purposes of SSO authentication. This can result in authentication bypass and unintended resource access for the user. This issue affects: PAN-OS 7.1 versions earlier than 7.1.26; PAN-OS 8.0 versions earlier than 8.0.21; PAN-OS 8.1 versions earlier than 8.1.13; PAN-OS 9.0 versions earlier than 9.0.6; PAN-OS 9.1 versions earlier than 9.1.1."
+                "value": "An improper authorization vulnerability in PAN-OS that mistakenly uses the permissions of local linux users instead of the intended SAML permissions of the account when the username is shared for the purposes of SSO authentication. This can result in authentication bypass and unintended resource access for the user.\nThis issue affects:\n\nPAN-OS 7.1 versions earlier than 7.1.26;\n\nPAN-OS 8.1 versions earlier than 8.1.13;\n\nPAN-OS 9.0 versions earlier than 9.0.6;\n\nPAN-OS 9.1 versions earlier than 9.1.1;\n\nAll versions of PAN-OS 8.0."
             }
         ]
     },
@@ -127,16 +122,15 @@
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
-                "url": "https://security.paloaltonetworks.com/CVE-2020-1998",
-                "name": "https://security.paloaltonetworks.com/CVE-2020-1998"
+                "refsource": "CONFIRM",
+                "url": "https://security.paloaltonetworks.com/CVE-2020-1998"
             }
         ]
     },
     "solution": [
         {
             "lang": "eng",
-            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.0.21, PAN-OS 8.1.13, PAN-OS 9.0.6, PAN-OS 9.1.1, and all later PAN-OS versions."
+            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.1.13, PAN-OS 9.0.6, PAN-OS 9.1.1, and all later PAN-OS versions.\n\nPAN-OS 8.0 is now end-of-life as of October 31, 2019, and is no longer covered by our Product Security Assurance policies."
         }
     ],
     "source": {

--- a/2020/2xxx/CVE-2020-2001.json
+++ b/2020/2xxx/CVE-2020-2001.json
@@ -37,14 +37,9 @@
                                             "version_value": "9.0.6"
                                         },
                                         {
-                                            "version_affected": "<",
+                                            "version_affected": "=",
                                             "version_name": "8.0",
-                                            "version_value": "8.0.21"
-                                        },
-                                        {
-                                            "version_affected": "!>=",
-                                            "version_name": "8.0",
-                                            "version_value": "8.0.21"
+                                            "version_value": "8.0.*"
                                         },
                                         {
                                             "version_affected": "=",
@@ -74,7 +69,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "An external control of path and data vulnerability in the Palo Alto Networks PAN-OS Panorama XSLT processing logic that allows an unauthenticated user with network access to PAN-OS management interface to write attacker supplied file on the system and elevate privileges. This issue affects: All PAN-OS 7.1 Panorama versions; PAN-OS 8.0 versions earlier than 8.0.21 on Panorama; PAN-OS 8.1 versions earlier than 8.1.12 on Panorama; PAN-OS 9.0 versions earlier than 9.0.6 on Panorama."
+                "value": "An external control of path and data vulnerability in the Palo Alto Networks PAN-OS Panorama XSLT processing logic that allows an unauthenticated user with network access to PAN-OS management interface to write attacker supplied file on the system and elevate privileges.\nThis issue affects:\n\nAll PAN-OS 7.1 Panorama and 8.0 Panorama versions;\n\nPAN-OS 8.1 versions earlier than 8.1.12 on Panorama;\n\nPAN-OS 9.0 versions earlier than 9.0.6 on Panorama."
             }
         ]
     },
@@ -112,16 +107,15 @@
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
-                "url": "https://security.paloaltonetworks.com/CVE-2020-2001",
-                "name": "https://security.paloaltonetworks.com/CVE-2020-2001"
+                "refsource": "CONFIRM",
+                "url": "https://security.paloaltonetworks.com/CVE-2020-2001"
             }
         ]
     },
     "solution": [
         {
             "lang": "eng",
-            "value": "This issue is fixed in PAN-OS 8.0.21, PAN-OS 8.1.12, PAN-OS 9.0.6, and all later PAN-OS versions.\n\nPAN-OS 7.1 is on extended support until June 30, 2020, and is only being considered for critical security vulnerability fixes."
+            "value": "This issue is fixed in PAN-OS 8.1.12, PAN-OS 9.0.6, and all later PAN-OS versions.\n\nPAN-OS 7.1 is on extended support until June 30, 2020, and is only being considered for critical security vulnerability fixes.\n\nPAN-OS 8.0 is now end-of-life as of October 31, 2019, and is no longer covered by our Product Security Assurance policies."
         }
     ],
     "source": {

--- a/2020/2xxx/CVE-2020-2002.json
+++ b/2020/2xxx/CVE-2020-2002.json
@@ -47,14 +47,9 @@
                                             "version_value": "7.1.26"
                                         },
                                         {
-                                            "version_affected": "<",
+                                            "version_affected": "=",
                                             "version_name": "8.0",
-                                            "version_value": "8.0.21"
-                                        },
-                                        {
-                                            "version_affected": "!>=",
-                                            "version_name": "8.0",
-                                            "version_value": "8.0.21"
+                                            "version_value": "8.0.*"
                                         }
                                     ]
                                 }
@@ -79,7 +74,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "An authentication bypass by spoofing vulnerability exists in the authentication daemon and User-ID components of Palo Alto Networks PAN-OS by failing to verify the integrity of the Kerberos key distribution center (KDC) before authenticating users. This affects all forms of authentication that use a Kerberos authentication profile. A man-in-the-middle type of attacker with the ability to intercept communication between PAN-OS and KDC can login to PAN-OS as an administrator. This issue affects: PAN-OS 7.1 versions earlier than 7.1.26; PAN-OS 8.0 versions earlier than 8.0.21; PAN-OS 8.1 versions earlier than 8.1.13; PAN-OS 9.0 versions earlier than 9.0.6."
+                "value": "An authentication bypass by spoofing vulnerability exists in the authentication daemon and User-ID components of Palo Alto Networks PAN-OS by failing to verify the integrity of the Kerberos key distribution center (KDC) before authenticating users. This affects all forms of authentication that use a Kerberos authentication profile. A man-in-the-middle type of attacker with the ability to intercept communication between PAN-OS and KDC can login to PAN-OS as an administrator. \nThis issue affects:\nPAN-OS 7.1 versions earlier than 7.1.26;\nPAN-OS 8.1 versions earlier than 8.1.13;\nPAN-OS 9.0 versions earlier than 9.0.6;\nAll version of PAN-OS 8.0.\n"
             }
         ]
     },
@@ -117,16 +112,15 @@
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
-                "url": "https://security.paloaltonetworks.com/CVE-2020-2002",
-                "name": "https://security.paloaltonetworks.com/CVE-2020-2002"
+                "refsource": "CONFIRM",
+                "url": "https://security.paloaltonetworks.com/CVE-2020-2002"
             }
         ]
     },
     "solution": [
         {
             "lang": "eng",
-            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.0.21, PAN-OS 8.1.13, PAN-OS 9.0.6, and all later PAN-OS versions."
+            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.1.13, PAN-OS 9.0.6, and all later PAN-OS versions.\n\nPAN-OS 8.0 is now end-of-life as of October 31, 2019, and is no longer covered by our Product Security Assurance policies."
         }
     ],
     "source": {

--- a/2020/2xxx/CVE-2020-2003.json
+++ b/2020/2xxx/CVE-2020-2003.json
@@ -79,7 +79,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "An external control of filename vulnerability in the command processing of PAN-OS allows an authenticated administrator to delete arbitrary system files affecting the integrity of the system or causing denial of service to all PAN-OS services. This issue affects: All versions of PAN-OS 7.1; PAN-OS 8.1 versions before 8.1.14; PAN-OS 9.0 versions before 9.0.7; PAN-OS 9.1 versions before 9.1.1."
+                "value": "An external control of filename vulnerability in the command processing of PAN-OS allows an authenticated administrator to delete arbitrary system files affecting the integrity of the system or causing denial of service to all PAN-OS services.\n\nThis issue affects:\nAll versions of PAN-OS 7.1 and 8.0;\nPAN-OS 8.1 versions before 8.1.14;\nPAN-OS 9.0 versions before 9.0.7;\nPAN-OS 9.1 versions before 9.1.1."
             }
         ]
     },
@@ -117,9 +117,8 @@
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
-                "url": "https://security.paloaltonetworks.com/CVE-2020-2003",
-                "name": "https://security.paloaltonetworks.com/CVE-2020-2003"
+                "refsource": "CONFIRM",
+                "url": "https://security.paloaltonetworks.com/CVE-2020-2003"
             }
         ]
     },

--- a/2020/2xxx/CVE-2020-2005.json
+++ b/2020/2xxx/CVE-2020-2005.json
@@ -47,14 +47,9 @@
                                             "version_value": "9.0.7"
                                         },
                                         {
-                                            "version_affected": "<",
+                                            "version_affected": "=",
                                             "version_name": "8.0",
-                                            "version_value": "8.0.21"
-                                        },
-                                        {
-                                            "version_affected": "!>=",
-                                            "version_name": "8.0",
-                                            "version_value": "8.0.21"
+                                            "version_value": "8.0.*"
                                         }
                                     ]
                                 }
@@ -85,7 +80,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A cross-site scripting (XSS) vulnerability exists when visiting malicious websites with the Palo Alto Networks GlobalProtect Clientless VPN that can compromise the user's active session. This issue affects: PAN-OS 7.1 versions earlier than 7.1.26; PAN-OS 8.0 versions earlier than 8.0.21; PAN-OS 8.1 versions earlier than 8.1.13; PAN-OS 9.0 versions earlier than 9.0.7."
+                "value": "A cross-site scripting (XSS) vulnerability exists when visiting malicious websites with the Palo Alto Networks GlobalProtect Clientless VPN that can compromise the user's active session.\nThis issue affects:\n\nPAN-OS 7.1 versions earlier than 7.1.26;\nPAN-OS 8.1 versions earlier than 8.1.13;\nPAN-OS 9.0 versions earlier than 9.0.7;\nAll versions of PAN-OS 8.0."
             }
         ]
     },
@@ -123,16 +118,15 @@
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
-                "url": "https://security.paloaltonetworks.com/CVE-2020-2005",
-                "name": "https://security.paloaltonetworks.com/CVE-2020-2005"
+                "refsource": "CONFIRM",
+                "url": "https://security.paloaltonetworks.com/CVE-2020-2005"
             }
         ]
     },
     "solution": [
         {
             "lang": "eng",
-            "value": "This issue is fixed in PAN-OS 8.0.21, PAN-OS 7.1.26, PAN-OS 8.1.13, PAN-OS 9.0.7, and all later versions of PAN-OS."
+            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.1.13, PAN-OS 9.0.7, and all later versions of PAN-OS.\n\nPAN-OS 8.0 is now end-of-life as of October 31, 2019, and is no longer covered by our Product Security Assurance policies."
         }
     ],
     "source": {

--- a/2020/2xxx/CVE-2020-2013.json
+++ b/2020/2xxx/CVE-2020-2013.json
@@ -28,11 +28,6 @@
                                         },
                                         {
                                             "version_affected": "<",
-                                            "version_name": "8.0",
-                                            "version_value": "8.0.21"
-                                        },
-                                        {
-                                            "version_affected": "<",
                                             "version_name": "8.1",
                                             "version_value": "8.1.13"
                                         },
@@ -53,11 +48,6 @@
                                         },
                                         {
                                             "version_affected": "!>=",
-                                            "version_name": "8.0",
-                                            "version_value": "8.0.21"
-                                        },
-                                        {
-                                            "version_affected": "!>=",
                                             "version_name": "8.1",
                                             "version_value": "8.1.13"
                                         },
@@ -65,6 +55,11 @@
                                             "version_affected": "!>=",
                                             "version_name": "9.1",
                                             "version_value": "9.1.1"
+                                        },
+                                        {
+                                            "version_affected": "=",
+                                            "version_name": "8.0",
+                                            "version_value": "8.0.*"
                                         }
                                     ]
                                 }
@@ -89,7 +84,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A cleartext transmission of sensitive information vulnerability in Palo Alto Networks PAN-OS Panorama that discloses an authenticated PAN-OS administrator's PAN-OS session cookie. When an administrator issues a context switch request into a managed firewall with an affected PAN-OS Panorama version, their PAN-OS session cookie is transmitted over cleartext to the firewall. An attacker with the ability to intercept this network traffic between the firewall and Panorama can access the administrator's account and further manipulate devices managed by Panorama. This issue affects: PAN-OS 7.1 versions earlier than 7.1.26; PAN-OS 8.0 versions earlier than 8.0.21; PAN-OS 8.1 versions earlier than 8.1.13; PAN-OS 9.0 versions earlier than 9.0.6; and PAN-OS 9.1 versions earlier than 9.1.1."
+                "value": "A cleartext transmission of sensitive information vulnerability in Palo Alto Networks PAN-OS Panorama that discloses an authenticated PAN-OS administrator's PAN-OS session cookie. When an administrator issues a context switch request into a managed firewall with an affected PAN-OS Panorama version, their PAN-OS session cookie is transmitted over cleartext to the firewall. An attacker with the ability to intercept this network traffic between the firewall and Panorama can access the administrator's account and further manipulate devices managed by Panorama.\nThis issue affects:\n\nPAN-OS 7.1 versions earlier than 7.1.26;\n\nPAN-OS 8.1 versions earlier than 8.1.13;\n\nPAN-OS 9.0 versions earlier than 9.0.6;\n\nPAN-OS 9.1 versions earlier than 9.1.1;\n\nAll version of PAN-OS 8.0;"
             }
         ]
     },
@@ -127,16 +122,15 @@
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
-                "url": "https://security.paloaltonetworks.com/CVE-2020-2013",
-                "name": "https://security.paloaltonetworks.com/CVE-2020-2013"
+                "refsource": "CONFIRM",
+                "url": "https://security.paloaltonetworks.com/CVE-2020-2013"
             }
         ]
     },
     "solution": [
         {
             "lang": "eng",
-            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.0.21, PAN-OS 8.1.13, PAN-OS 9.0.6, PAN-OS 9.1.1, and all later PAN-OS versions."
+            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.1.13, PAN-OS 9.0.6, PAN-OS 9.1.1, and all later PAN-OS versions.\n\nPAN-OS 8.0 is now end-of-life as of October 31, 2019, and is no longer covered by our Product Security Assurance policies."
         }
     ],
     "source": {
@@ -155,7 +149,7 @@
     "work_around": [
         {
             "lang": "eng",
-            "value": "One possible vulnerability mitigation is to shorten the length of administrator session idle timeout. This reduces the likelihood the exposed administrator\u2019s session cookie is valid at time of attack."
+            "value": "One possible vulnerability mitigation is to shorten the length of administrator session idle timeout. This reduces the likelihood the exposed administrator’s session cookie is valid at time of attack."
         },
         {
             "lang": "eng",

--- a/2020/2xxx/CVE-2020-2015.json
+++ b/2020/2xxx/CVE-2020-2015.json
@@ -28,11 +28,6 @@
                                         },
                                         {
                                             "version_affected": "<",
-                                            "version_name": "8.0",
-                                            "version_value": "8.0.21"
-                                        },
-                                        {
-                                            "version_affected": "<",
                                             "version_name": "8.1",
                                             "version_value": "8.1.13"
                                         },
@@ -53,11 +48,6 @@
                                         },
                                         {
                                             "version_affected": "!>=",
-                                            "version_name": "8.0",
-                                            "version_value": "8.0.21"
-                                        },
-                                        {
-                                            "version_affected": "!>=",
                                             "version_name": "8.1",
                                             "version_value": "8.1.13"
                                         },
@@ -70,6 +60,11 @@
                                             "version_affected": "!>=",
                                             "version_name": "9.2",
                                             "version_value": "9.2.0"
+                                        },
+                                        {
+                                            "version_affected": "=",
+                                            "version_name": "8.0",
+                                            "version_value": "8.0.*"
                                         }
                                     ]
                                 }
@@ -94,7 +89,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A buffer overflow vulnerability in the PAN-OS management server allows authenticated users to crash system processes or potentially execute arbitrary code with root privileges. This issue affects: PAN-OS 7.1 versions earlier than 7.1.26; PAN-OS 8.0 versions earlier than 8.0.21; PAN-OS 8.1 versions earlier than 8.1.13; PAN-OS 9.0 versions earlier than 9.0.7; PAN-OS 9.1 versions earlier than 9.1.1."
+                "value": "A buffer overflow vulnerability in the PAN-OS management server allows authenticated users to crash system processes or potentially execute arbitrary code with root privileges.\n\nThis issue affects:\nPAN-OS 7.1 versions earlier than 7.1.26;\nPAN-OS 8.1 versions earlier than 8.1.13;\nPAN-OS 9.0 versions earlier than 9.0.7;\nPAN-OS 9.1 versions earlier than 9.1.1;\nAll versions of PAN-OS 8.0.\n\n"
             }
         ]
     },
@@ -132,16 +127,15 @@
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
-                "url": "https://security.paloaltonetworks.com/CVE-2020-2015",
-                "name": "https://security.paloaltonetworks.com/CVE-2020-2015"
+                "refsource": "CONFIRM",
+                "url": "https://security.paloaltonetworks.com/CVE-2020-2015"
             }
         ]
     },
     "solution": [
         {
             "lang": "eng",
-            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.0.21, PAN-OS 8.1.13, PAN-OS 9.0.7, PAN-OS 9.1.1, PAN-OS 9.2.0, and all later PAN-OS versions."
+            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.1.13, PAN-OS 9.0.7, PAN-OS 9.1.1, PAN-OS 9.2.0, and all later PAN-OS versions.\n\nPAN-OS 8.0 is now end-of-life as of October 31, 2019, and is no longer covered by our Product Security Assurance policies."
         }
     ],
     "source": {

--- a/2020/2xxx/CVE-2020-2016.json
+++ b/2020/2xxx/CVE-2020-2016.json
@@ -23,11 +23,6 @@
                                         },
                                         {
                                             "version_affected": "<",
-                                            "version_name": "8.0",
-                                            "version_value": "8.0.21"
-                                        },
-                                        {
-                                            "version_affected": "<",
                                             "version_name": "8.1",
                                             "version_value": "8.1.13"
                                         },
@@ -42,9 +37,9 @@
                                             "version_value": "7.1.26"
                                         },
                                         {
-                                            "version_affected": "!>=",
+                                            "version_affected": "=",
                                             "version_name": "8.0",
-                                            "version_value": "8.0.21"
+                                            "version_value": "8.0.*"
                                         },
                                         {
                                             "version_affected": "!>=",
@@ -93,7 +88,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A race condition due to insecure creation of a file in a temporary directory vulnerability in PAN-OS allows for root privilege escalation from a limited linux user account. This allows an attacker who has escaped the restricted shell as a low privilege administrator, possibly by exploiting another vulnerability, to escalate privileges to become root user."
+                "value": "A race condition due to insecure creation of a file in a temporary directory vulnerability in PAN-OS allows for root privilege escalation from a limited linux user account.\n\nThis allows an attacker who has escaped the restricted shell as a low privilege administrator, possibly by exploiting another vulnerability, to escalate privileges to become root user.\nThis issue affects:\nPAN-OS 7.1 versions earlier than 7.1.26;\nPAN-OS 8.1 versions earlier than 8.1.13;\nPAN-OS 9.0 versions earlier than 9.0.6;\nAll versions of PAN-OS 8.0."
             }
         ]
     },
@@ -137,16 +132,15 @@
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
-                "url": "https://security.paloaltonetworks.com/CVE-2020-2016",
-                "name": "https://security.paloaltonetworks.com/CVE-2020-2016"
+                "refsource": "CONFIRM",
+                "url": "https://security.paloaltonetworks.com/CVE-2020-2016"
             }
         ]
     },
     "solution": [
         {
             "lang": "eng",
-            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.0.21, PAN-OS 8.1.13, PAN-OS 9.0.6, PAN-OS 9.1.0, PAN-OS 9.2.0, and all later PAN-OS versions."
+            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.1.13, PAN-OS 9.0.6, PAN-OS 9.1.0, PAN-OS 9.2.0, and all later PAN-OS versions.\n\nPAN-OS 8.0 is now end-of-life as of October 31, 2019, and is no longer covered by our Product Security Assurance policies."
         }
     ],
     "source": {

--- a/2020/2xxx/CVE-2020-2017.json
+++ b/2020/2xxx/CVE-2020-2017.json
@@ -23,11 +23,6 @@
                                         },
                                         {
                                             "version_affected": "<",
-                                            "version_name": "8.0",
-                                            "version_value": "8.0.21"
-                                        },
-                                        {
-                                            "version_affected": "<",
                                             "version_name": "8.1",
                                             "version_value": "8.1.13"
                                         },
@@ -42,9 +37,9 @@
                                             "version_value": "7.1.26"
                                         },
                                         {
-                                            "version_affected": "!>=",
+                                            "version_affected": "=",
                                             "version_name": "8.0",
-                                            "version_value": "8.0.21"
+                                            "version_value": "8.0.*"
                                         },
                                         {
                                             "version_affected": "!>=",
@@ -89,7 +84,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "A DOM-Based Cross Site Scripting Vulnerability exists in PAN-OS and Panorama Management Web Interfaces. A remote attacker able to convince an authenticated administrator to click on a crafted link to PAN-OS and Panorama Web Interfaces could execute arbitrary JavaScript code in the administrator's browser and perform administrative actions. This issue affects: PAN-OS 7.1 versions earlier than 7.1.26; PAN-OS 8.0 versions earlier than 8.0.21; PAN-OS 8.1 versions earlier than 8.1.13; PAN-OS 9.0 versions earlier than 9.0.6."
+                "value": "A DOM-Based Cross Site Scripting Vulnerability exists in PAN-OS and Panorama Management Web Interfaces.\nA remote attacker able to convince an authenticated administrator to click on a crafted link to PAN-OS and Panorama Web Interfaces could execute arbitrary JavaScript code in the administrator's browser and perform administrative actions.\n\nThis issue affects:\nPAN-OS 7.1 versions earlier than 7.1.26;\nPAN-OS 8.1 versions earlier than 8.1.13;\nPAN-OS 9.0 versions earlier than 9.0.6;\nAll versions of PAN-OS 8.0."
             }
         ]
     },
@@ -127,16 +122,15 @@
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
-                "url": "https://security.paloaltonetworks.com/CVE-2020-2017",
-                "name": "https://security.paloaltonetworks.com/CVE-2020-2017"
+                "refsource": "CONFIRM",
+                "url": "https://security.paloaltonetworks.com/CVE-2020-2017"
             }
         ]
     },
     "solution": [
         {
             "lang": "eng",
-            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.0.21, PAN-OS 8.1.13, PAN-OS 9.0.6, PAN-OS 9.1.0, PAN-OS 9.2.0, and all later PAN-OS versions."
+            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.1.13, PAN-OS 9.0.6, PAN-OS 9.1.0, PAN-OS 9.2.0, and all later PAN-OS versions.\n\nPAN-OS 8.0 is now end-of-life as of October 31, 2019, and is no longer covered by our Product Security Assurance policies."
         }
     ],
     "source": {

--- a/2020/2xxx/CVE-2020-2018.json
+++ b/2020/2xxx/CVE-2020-2018.json
@@ -74,7 +74,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "An authentication bypass vulnerability in Palo Alto Networks PAN-OS Panorama proxy service allows an unauthenticated user with network access to Panorama and the knowledge of the Firewall’s serial number to register the PAN-OS firewall to register the device. After the PAN-OS device is registered, the user can further compromise the PAN-OS instances managed by Panorama.\nThis issue affects:\n\nPAN-OS 7.1 versions earlier than 7.1.26;\n\nPAN-OS 8.1 versions earlier than 8.1.12;\n\nPAN-OS 9.0 versions earlier than 9.0.6;\n\nAll versions of PAN-OS 8.0."
+                "value": "An authentication bypass vulnerability in the Panorama context switching feature allows an attacker with network access to a Panorama's management interface to gain privileged access to managed firewalls. An attacker requires some knowledge of managed firewalls to exploit this issue. \nThis issue does not affect Panorama configured with custom certificates authentication for communication between Panorama and managed devices.\nThis issue affects:\n\nPAN-OS 7.1 versions earlier than 7.1.26;\n\nPAN-OS 8.1 versions earlier than 8.1.12;\n\nPAN-OS 9.0 versions earlier than 9.0.6;\n\nAll versions of PAN-OS 8.0."
             }
         ]
     },
@@ -120,7 +120,7 @@
     "solution": [
         {
             "lang": "eng",
-            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.1.12, PAN-OS 9.0.6, and all later PAN-OS versions.\n\nPAN-OS 8.0 is now end-of-life as of October 31, 2019, and is no longer covered by our Product Security Assurance policies."
+            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.1.12, PAN-OS 9.0.6, and all later PAN-OS versions.\n\nUpgrading Panorama to a fixed version is sufficient to resolve the issue.\n\nPAN-OS 8.0 is now end-of-life as of October 31, 2019, and is no longer covered by our Product Security Assurance policies."
         }
     ],
     "source": {
@@ -139,7 +139,7 @@
     "work_around": [
         {
             "lang": "eng",
-            "value": "This issue affects the management interface of PAN-OS and is strongly mitigated by following best practices for securing the PAN-OS management interface. Please review the Best Practices for Securing Administrative Access in the PAN-OS technical documentation, available at: https://docs.paloaltonetworks.com"
+            "value": "This issue can be completely mitigated by enabling custom certificates authentication between Panorama and managed firewalls. See https://docs.paloaltonetworks.com/panorama/8-0/panorama-admin/set-up-panorama/set-up-authentication-using-custom-certificates.html\n\nThis issue affects the management interface of PAN-OS and is strongly mitigated by following best practices for securing the PAN-OS management interface. Please review the Best Practices for Securing Administrative Access in the PAN-OS technical documentation, available at: https://docs.paloaltonetworks.com"
         }
     ]
 }

--- a/2020/2xxx/CVE-2020-2018.json
+++ b/2020/2xxx/CVE-2020-2018.json
@@ -47,14 +47,9 @@
                                             "version_value": "9.0.6"
                                         },
                                         {
-                                            "version_affected": "<",
+                                            "version_affected": "=",
                                             "version_name": "8.0",
-                                            "version_value": "8.0.21"
-                                        },
-                                        {
-                                            "version_affected": "!>=",
-                                            "version_name": "8.0",
-                                            "version_value": "8.0.21"
+                                            "version_value": "8.0.*"
                                         }
                                     ]
                                 }
@@ -79,7 +74,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "An authentication bypass vulnerability in Palo Alto Networks PAN-OS Panorama proxy service allows an unauthenticated user with network access to Panorama and the knowledge of the Firewall\u2019s serial number to register the PAN-OS firewall to register the device. After the PAN-OS device is registered, the user can further compromise the PAN-OS instances managed by Panorama. This issue affects: PAN-OS 7.1 versions earlier than 7.1.26; PAN-OS 8.0 versions earlier than 8.0.21; PAN-OS 8.1 versions earlier than 8.1.12; PAN-OS 9.0 versions earlier than 9.0.6."
+                "value": "An authentication bypass vulnerability in Palo Alto Networks PAN-OS Panorama proxy service allows an unauthenticated user with network access to Panorama and the knowledge of the Firewall’s serial number to register the PAN-OS firewall to register the device. After the PAN-OS device is registered, the user can further compromise the PAN-OS instances managed by Panorama.\nThis issue affects:\n\nPAN-OS 7.1 versions earlier than 7.1.26;\n\nPAN-OS 8.1 versions earlier than 8.1.12;\n\nPAN-OS 9.0 versions earlier than 9.0.6;\n\nAll versions of PAN-OS 8.0."
             }
         ]
     },
@@ -117,16 +112,15 @@
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
-                "url": "https://security.paloaltonetworks.com/CVE-2020-2018",
-                "name": "https://security.paloaltonetworks.com/CVE-2020-2018"
+                "refsource": "CONFIRM",
+                "url": "https://security.paloaltonetworks.com/CVE-2020-2018"
             }
         ]
     },
     "solution": [
         {
             "lang": "eng",
-            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.0.21, PAN-OS 8.1.12, PAN-OS 9.0.6, and all later PAN-OS versions."
+            "value": "This issue is fixed in PAN-OS 7.1.26, PAN-OS 8.1.12, PAN-OS 9.0.6, and all later PAN-OS versions.\n\nPAN-OS 8.0 is now end-of-life as of October 31, 2019, and is no longer covered by our Product Security Assurance policies."
         }
     ],
     "source": {

--- a/2020/2xxx/CVE-2020-2018.json
+++ b/2020/2xxx/CVE-2020-2018.json
@@ -4,7 +4,7 @@
         "DATE_PUBLIC": "2020-05-13T16:00:00.000Z",
         "ID": "CVE-2020-2018",
         "STATE": "PUBLIC",
-        "TITLE": "PAN-OS: Panorama proxy service authorization bypass"
+        "TITLE": "PAN-OS: Panorama authentication bypass vulnerability"
     },
     "affects": {
         "vendor": {
@@ -103,7 +103,7 @@
                 "description": [
                     {
                         "lang": "eng",
-                        "value": "CWE-305 Authentication Bypass by Primary Weakness"
+                        "value": "CWE-287 Improper Authentication"
                     }
                 ]
             }


### PR DESCRIPTION
Updated description of CVE-2020-2016 to include affected versions.
Removed a version that is not generally available. 