### PR TITLE
update CVE-2020-11057 extra reference and cvss

### DIFF
--- a/2020/11xxx/CVE-2020-11057.json
+++ b/2020/11xxx/CVE-2020-11057.json
@@ -44,14 +44,14 @@
             "attackComplexity": "LOW",
             "attackVector": "NETWORK",
             "availabilityImpact": "LOW",
-            "baseScore": 7.4,
-            "baseSeverity": "HIGH",
-            "confidentialityImpact": "LOW",
-            "integrityImpact": "LOW",
+            "baseScore": 9.9,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
             "privilegesRequired": "LOW",
             "scope": "CHANGED",
             "userInteraction": "NONE",
-            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:L",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L",
             "version": "3.1"
         }
     },
@@ -78,6 +78,11 @@
                 "name": "https://jira.xwiki.org/browse/XWIKI-16960",
                 "refsource": "MISC",
                 "url": "https://jira.xwiki.org/browse/XWIKI-16960"
+            },
+            {
+                "name": "https://medium.com/@andrew.levkin/tews-4c47cfc011d1",
+                "refsource": "MISC",
+                "url": "https://medium.com/@andrew.levkin/tews-4c47cfc011d1"
             }
         ]
     },


### PR DESCRIPTION
Per request from the security researcher and maintainer, this updates CVE-2020-11057 to have a reference to the [medium post](https://medium.com/@andrew.levkin/tews-4c47cfc011d1) made by the researcher, and also it changes the CVSS so it is now considered critical severity.
