### PR TITLE
add CVE-2020-11078 for GHSA-gg84-qgv9-w4pq

### DIFF
--- a/2020/11xxx/CVE-2020-11078.json
+++ b/2020/11xxx/CVE-2020-11078.json
@@ -1,18 +1,88 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-11078",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "CRLF injection in httplib2"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "httplib2",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.81.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "httplib2"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In httplib2 before version 0.18.0, an attacker controlling unescaped part of uri for `httplib2.Http.request()` could change request headers and body, send additional hidden requests to same server.\n\nThis vulnerability impacts software that uses httplib2 with uri constructed by string concatenation, as opposed to proper urllib building with escaping.\n\nThis has been fixed in 0.18.0."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.8,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-93: Improper Neutralization of CRLF Sequences ('CRLF Injection')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/httplib2/httplib2/security/advisories/GHSA-gg84-qgv9-w4pq",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/httplib2/httplib2/security/advisories/GHSA-gg84-qgv9-w4pq"
+            },
+            {
+                "name": "https://github.com/httplib2/httplib2/commit/a1457cc31f3206cf691d11d2bf34e98865873e9e",
+                "refsource": "MISC",
+                "url": "https://github.com/httplib2/httplib2/commit/a1457cc31f3206cf691d11d2bf34e98865873e9e"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-gg84-qgv9-w4pq",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
add CVE-2020-11078 for GHSA-gg84-qgv9-w4pq