### PR TITLE
*REJECT* CVE-2020-1703

### DIFF
--- a/2020/1xxx/CVE-2020-1703.json
+++ b/2020/1xxx/CVE-2020-1703.json
@@ -4,15 +4,68 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-1703",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "mrehak@redhat.com"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Red Hat",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "ipa",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "No versions are affected"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-613"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2020-1703",
+                "name": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2020-1703",
+                "refsource": "CONFIRM"
+            }
+        ]
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "*REJECTED*Red Hat Product Security does not consider this as a security flaw. Password changes aren't expected to invalidate existing sessions. Though this is how Kerberos behaves: incrementing kvno will not invalidate any existing service tickets.  This is not a concern because the lifetime on service tickets should be set appropriately (initially only a global, now also more finely configurable with the kdcpolicy plugin).  This belief is reinforced by our use of mod_session: existing sessions there aren't terminated, but instead wait for expiration."
             }
+        ]
+    },
+    "impact": {
+        "cvss": [
+            [
+                {
+                    "vectorString": "3.8/CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N",
+                    "version": "3.0"
+                }
+            ]
         ]
     }
 }


### PR DESCRIPTION
This CVE is rejected. And will be removed from Red Hat pages once rejection is confirmed by Mitre.