### PR TITLE
Add CVE-2020-10516

### DIFF
--- a/2020/10xxx/CVE-2020-10516.json
+++ b/2020/10xxx/CVE-2020-10516.json
@@ -1,18 +1,91 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10516",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "product-cna@github.com",
+    "ID": "CVE-2020-10516",
+    "STATE": "PUBLIC",
+    "TITLE": "Improper access control in GitHub Enterprise Server leading to privilege escalation of organization member"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "GitHub Enterprise Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_name": "2.20",
+                      "version_value": "2.20.9"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "2.19",
+                      "version_value": "2.19.15"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "2.18",
+                      "version_value": "2.18.20"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "GitHub"
+        }
+      ]
     }
+  },
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "Vaibhav Singh"
+    }
+  ],
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "An improper access control vulnerability was identified in the GitHub Enterprise Server API that allowed an organization member to escalate permissions and gain access to unauthorized repositories within an organization. This vulnerability affected all versions of GitHub Enterprise Server prior to 2.21 and was fixed in 2.20.9, 2.19.15, and 2.18.20. This vulnerability was reported via the GitHub Bug Bounty program."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-285: Improper Authorization"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "https://enterprise.github.com/releases/2.20.9/notes"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://enterprise.github.com/releases/2.19.15/notes"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://enterprise.github.com/releases/2.18.20/notes"
+      }
+    ]
+  },
+  "source": {
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
This PR adds CVE-2020-10516, the first published CVE from the GitHub Products CNA which covers issues in GitHub Enterprise Server. Feel free to reach out to product-cna@github.com or directly on this PR with any questions.