### PR TITLE
add CVE-2020-15087 for GHSA-f6pc-crhh-cp96

### DIFF
--- a/2020/15xxx/CVE-2020-15087.json
+++ b/2020/15xxx/CVE-2020-15087.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-15087",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Privilege escalation in Presto"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Presto",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 337"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "prestosql"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Presto before version 337, authenticated users can bypass authorization checks by directly accessing internal APIs. \n\nThis impacts Presto server installations with secure internal communication configured. This does not affect installations that have not configured secure internal communication, as these installations are inherently insecure.\n\nThis only affects Presto server installations. This does NOT affect clients such as the CLI or JDBC driver.\n\nThis vulnerability has been fixed in version 337.\n\nAdditionally, this issue can be mitigated by blocking network access to internal APIs on the coordinator and workers. "
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.4,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-285 Improper Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/prestosql/presto/security/advisories/GHSA-f6pc-crhh-cp96",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/prestosql/presto/security/advisories/GHSA-f6pc-crhh-cp96"
+            },
+            {
+                "name": "https://github.com/prestosql/presto/pull/4199",
+                "refsource": "MISC",
+                "url": "https://github.com/prestosql/presto/pull/4199"
+            },
+            {
+                "name": "https://prestosql.io/docs/current/release/release-337.html#security-changes",
+                "refsource": "MISC",
+                "url": "https://prestosql.io/docs/current/release/release-337.html#security-changes"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-f6pc-crhh-cp96",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
add CVE-2020-15087 for GHSA-f6pc-crhh-cp96