### PR TITLE
update CVE-2020-4074 to fix version number typo

### DIFF
--- a/2020/4xxx/CVE-2020-4074.json
+++ b/2020/4xxx/CVE-2020-4074.json
@@ -16,7 +16,7 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": ">= 1.5.0.0, < 1.7.7.6"
+                                            "version_value": ">= 1.5.0.0, < 1.7.6.6"
                                         }
                                     ]
                                 }
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In PrestaShop from version 1.5.0.0 and before version 1.7.7.6, the authentication system is malformed and an attacker is able to forge requests and execute admin commands. The problem is fixed in 1.7.7.6."
+                "value": "In PrestaShop from version 1.5.0.0 and before version 1.7.6.6, the authentication system is malformed and an attacker is able to forge requests and execute admin commands. The problem is fixed in 1.7.6.6."
             }
         ]
     },


### PR DESCRIPTION
A typo was made on initial submission of CVE-2020-4074 where the version number was specified in several places as `1.7.7.6` instead of the correct `1.7.6.6`.  This PR corrects that.

Reference: https://github.com/PrestaShop/PrestaShop/security/advisories/GHSA-ccvh-jh5x-mpg4
