### PR TITLE
update CVE-2020-11074 to fix version number typo

### DIFF
--- a/2020/11xxx/CVE-2020-11074.json
+++ b/2020/11xxx/CVE-2020-11074.json
@@ -16,7 +16,7 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": ">= 1.5.3.0, < 1.7.7.6"
+                                            "version_value": ">= 1.5.3.0, < 1.7.6.6"
                                         }
                                     ]
                                 }
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In PrestaShop from version 1.5.3.0 and before version 1.7.7.6, there is a stored XSS when using the name of a quick access item. The problem is fixed in 1.7.7.6."
+                "value": "In PrestaShop from version 1.5.3.0 and before version 1.7.6.6, there is a stored XSS when using the name of a quick access item. The problem is fixed in 1.7.6.6."
             }
         ]
     },


### PR DESCRIPTION
A typo was made on initial submission of CVE-2020-11074 where the version number was specified in several places as `1.7.7.6` instead of the correct `1.7.6.6`.  This PR corrects that.

Reference: https://github.com/PrestaShop/PrestaShop/security/advisories/GHSA-v4pg-q2cv-f7x4

Also, this is exactly like the typo fixed for CVE-2020-4074 [here](https://github.com/CVEProject/cvelist/pull/4263)