### PR TITLE
Update CVE-2020-10782.json

### DIFF
--- a/2020/10xxx/CVE-2020-10782.json
+++ b/2020/10xxx/CVE-2020-10782.json
@@ -63,7 +63,8 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "An exposure of sensitive information flaw was found in Ansible Tower before version 3.7.1. sensitive information such as Splunk tokens could be readable in the rsyslog configuration file, which has set the wrong world-readable permissions. The highest threat from this vulnerability is to confidentiality."
+                "value": "An exposure of sensitive information flaw was found in Ansible. Sensitive information, such tokens and other secrets could be readable and exposed from the rsyslog configuration file, which has set the wrong world-readable permissions. The highest threat from this vulnerability is to confidentiality.
+"
             }
         ]
     },

--- a/2020/10xxx/CVE-2020-10782.json
+++ b/2020/10xxx/CVE-2020-10782.json
@@ -63,8 +63,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "An exposure of sensitive information flaw was found in Ansible. Sensitive information, such tokens and other secrets could be readable and exposed from the rsyslog configuration file, which has set the wrong world-readable permissions. The highest threat from this vulnerability is to confidentiality.
-"
+                "value": "An exposure of sensitive information flaw was found in Ansible. Sensitive information, such tokens and other secrets could be readable and exposed from the rsyslog configuration file, which has set the wrong world-readable permissions. The highest threat from this vulnerability is to confidentiality."
             }
         ]
     },


### PR DESCRIPTION
Update doc text to remove reference to Splunk. This takes the current Doc Text directly from:
https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2020-10782