### PR TITLE
CVE-2019-17639

### DIFF
--- a/2019/17xxx/CVE-2019-17639.json
+++ b/2019/17xxx/CVE-2019-17639.json
@@ -1,0 +1,62 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "security@eclipse.org",
+        "ID": "CVE-2019-17639",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "The Eclipse Foundation",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Eclipse OpenJ9",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "<= 0.21"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "In Eclipse OpenJ9 prior to version 0.21 on Power platforms, calling the System.arraycopy method with a length longer than the length of the source or destination array can, in certain specially crafted code patterns, cause the current method to return prematurely with an undefined return value. This allows whatever value happens to be in the return register at that time to be used as if it matches the method's declared return type."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=563998",
+                "refsource": "CONFIRM",
+                "url": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=563998"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Signed-off-by: Wayne Beaton <wayne.beaton@eclipse-foundation.org>