### PR TITLE
Adding ClamAV CVE-2020-3481

### DIFF
--- a/2020/3xxx/CVE-2020-3481.json
+++ b/2020/3xxx/CVE-2020-3481.json
@@ -2,6 +2,8 @@
     "CVE_data_meta": {
         "ID": "CVE-2020-3481",
         "STATE": "PUBLIC",
+        "ASSIGNER": "psirt@cisco.com",
+        "DATE_PUBLIC": "2020-07-20T17:36:00.000Z",
         "TITLE": "Clam AntiVirus (ClamAV) Software Null Pointer Dereference Vulnerability"
     },
     "affects": {

--- a/2020/3xxx/CVE-2020-3481.json
+++ b/2020/3xxx/CVE-2020-3481.json
@@ -1,18 +1,89 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-3481",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Clam AntiVirus (ClamAV) Software Null Pointer Dereference Vulnerability"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "ClamAV",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "0.102.4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Cisco"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A vulnerability in the EGG archive parsing module in Clam AntiVirus (ClamAV) Software versions 0.102.0 - 0.102.3 could allow an unauthenticated, remote attacker to cause a denial of service condition on an affected device. The vulnerability is due to a null pointer dereference. An attacker could exploit this vulnerability by sending a crafted EGG file to an affected device. An exploit could allow the attacker to cause the ClamAV scanning process crash, resulting in a denial of service condition."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-476 NULL Pointer Dereference"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "ClamAV 0.102.4 security patch released",
+                "refsource": "CISCO",
+                "url": "https://blog.clamav.net/2020/07/clamav-01024-security-patch-released.html"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Upgrade to ClamAV version 0.102.4 "
+        }
+    ],
+    "source": {
+        "advisory": "clamav-01024-security-patch",
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
A vulnerability in the EGG archive parsing module in Clam AntiVirus (ClamAV) Software versions 0.102.0 - 0.102.3 could allow an unauthenticated, remote attacker to cause a denial of service condition on an affected device. The vulnerability is due to a null pointer dereference. An attacker could exploit this vulnerability by sending a crafted EGG file to an affected device. An exploit could allow the attacker to cause the ClamAV scanning process crash, resulting in a denial of service condition.