### PR TITLE
Adding Cisco DUO CVE-2020-3442

### DIFF
--- a/2020/3xxx/CVE-2020-3442.json
+++ b/2020/3xxx/CVE-2020-3442.json
@@ -1,18 +1,97 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "psirt@cisco.com",
+        "DATE_PUBLIC": "2020-07-15T20:00:00.000Z",
         "ID": "CVE-2020-3442",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "DuoConnect SSH Connection Vulnerability"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "DUO Connect",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "1.1.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Cisco"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "The DuoConnect client enables users to establish SSH connections to hosts protected by a DNG instance. When a user initiates an SSH connection to a DNG-protected host for the first time using DuoConnect, the user’s browser is opened to a login screen in order to complete authentication determined by the contents of the '-relay' argument. If the ‘-relay’ is set to a URL beginning with \"http://\", then the browser will initially attempt to load the URL over an insecure HTTP connection, before being immediately redirected to HTTPS (in addition to standard redirect mechanisms, the DNG uses HTTP Strict Transport Security headers to enforce this). After successfully authenticating to a DNG, DuoConnect stores an authentication token in a local system cache, so users do not have to complete this browser-based authentication workflow for every subsequent SSH connection. These tokens are valid for a configurable period of time, which defaults to 8 hours. If a user running DuoConnect already has a valid token, then instead of opening a web browser, DuoConnect directly contacts the DNG, again using the configured '-relay' value, and sends this token, as well as the intended SSH server hostname and port numbers. If the '-relay' argument begins with \"http://\", then this request will be sent over an insecure connection, and could be exposed to an attacker who is sniffing the traffic on the same network. The DNG authentication tokens that may be exposed during SSH relay may be used to gain network-level access to the servers and ports protected by that given relay host. The DNG provides network-level access only to the protected SSH servers. It does not interact with the independent SSH authentication and encryption. An attacker cannot use a stolen token on its own to authenticate against a DNG-protected SSH server."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "ADJACENT_NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.8,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:A/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-319 Cleartext Transmission of Sensitive Information"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "DuoConnect SSH Connection Vulnerability",
+                "refsource": "CISCO",
+                "url": "https://duo.com/labs/psa/duo-psa-2020-003"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "The Duo Product team has fixed the issue by updating DuoConnect to version 1.1.1, which rejects relay configurations that do not specify an HTTPS-based relay.\n\nA DNG instance will automatically instruct users to install the latest version of DuoConnect. Duo administrators do not need to perform any manual updates unless their DNG is not able to connect to the internet to download the new version of the software. In that case, administrators should instruct end-users to download the latest DuoConnect version directly using the links below.\n\nSteps required for end-user remediation:\n\nUpdate DuoConnect:\nEnd-users will need to update DuoConnect once prompted to do so by the DNG (users will be prompted to upgrade DuoConnect during authentication in their browser from July 7, 2020 onwards).\nThe updated version of DuoConnect can alternatively be downloaded directly from the following locations at any time: Windows - https://dl.duosecurity.com/DuoConnect-1.1.1.msi\nmacOS - https://dl.duosecurity.com/DuoConnect-1.1.1.pkg\nLinux - https://dl.duosecurity.com/DuoConnect-1.1.1.tar.gz\nThe signature of DuoConnect installer files can be verified at https://duo.com/docs/checksums.\n\nEnd-users will need to update their DuoConnect SSH configuration if they receive the error message shown below:\n\nError: Invalid URL: relay scheme http://server-ssh.example.com invalid: must be https\n\nUpdate the SSH configuration: Locate the http relay in the SSH configuration e.g. “ProxyCommand duoconnect -host=%h:%p -relay=http://server-ssh.example.com” Ensure the relay uses ‘https://’, and not ‘http://’\n\nThe SSH configuration for *nix and macOS operating systems can be located at ~/.ssh/config. The SSH configuration for Windows operating systems can most commonly be found in the user directory C:\\Users\\username.ssh.\n\nAdditionally, you can refer to the “Configure SSH” section in the DuoConnect guide to learn more about steps for SSH configuration should you need further guidance."
+        }
+    ],
+    "source": {
+        "advisory": "DUO-PSA-2020-003",
+        "defect": [
+            "DUO-PSA-2020-003"
+        ],
+        "discovery": "INTERNAL"
     }
 }


### PR DESCRIPTION
The DuoConnect client enables users to establish SSH connections to hosts protected by a DNG instance. When a user initiates an SSH connection to a DNG-protected host for the first time using DuoConnect, the user’s browser is opened to a login screen in order to complete authentication determined by the contents of the '-relay' argument. If the ‘-relay’ is set to a URL beginning with \"http://\", then the browser will initially attempt to load the URL over an insecure HTTP connection, before being immediately redirected to HTTPS (in addition to standard redirect mechanisms, the DNG uses HTTP Strict Transport Security headers to enforce this). After successfully authenticating to a DNG, DuoConnect stores an authentication token in a local system cache, so users do not have to complete this browser-based authentication workflow for every subsequent SSH connection. These tokens are valid for a configurable period of time, which defaults to 8 hours. If a user running DuoConnect already has a valid token, then instead of opening a web browser, DuoConnect directly contacts the DNG, again using the configured '-relay' value, and sends this token, as well as the intended SSH server hostname and port numbers. If the '-relay' argument begins with \"http://\", then this request will be sent over an insecure connection, and could be exposed to an attacker who is sniffing the traffic on the same network. The DNG authentication tokens that may be exposed during SSH relay may be used to gain network-level access to the servers and ports protected by that given relay host. The DNG provides network-level access only to the protected SSH servers. It does not interact with the independent SSH authentication and encryption. An attacker cannot use a stolen token on its own to authenticate against a DNG-protected SSH server.