### PR TITLE
Correct affected versions for cve-2020-8559

### DIFF
--- a/2020/8xxx/CVE-2020-8559.json
+++ b/2020/8xxx/CVE-2020-8559.json
@@ -29,7 +29,7 @@
                                         {
                                             "version_affected": "<=",
                                             "version_name": "1.18",
-                                            "version_value": "1.18.6"
+                                            "version_value": "1.18.5"
                                         },
                                         {
                                             "version_name": "1.6",
@@ -94,7 +94,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "The Kubernetes kube-apiserver in versions v1.6-v1.15, and versions prior to v1.16.13, v1.17.9 and v1.18.7 are vulnerable to an unvalidated redirect on proxied upgrade requests that could allow an attacker to escalate privileges from a node compromise to a full cluster compromise."
+                "value": "The Kubernetes kube-apiserver in versions v1.6-v1.15, and versions prior to v1.16.13, v1.17.9 and v1.18.6 are vulnerable to an unvalidated redirect on proxied upgrade requests that could allow an attacker to escalate privileges from a node compromise to a full cluster compromise."
             }
         ]
     },


### PR DESCRIPTION
Sorry for the mixup.