### PR TITLE
update CVE-2020-15120 so description names affected software

### DIFF
--- a/2020/15xxx/CVE-2020-15120.json
+++ b/2020/15xxx/CVE-2020-15120.json
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "An authenticated member of one project can modify and delete members of another project, without knowledge of this other project's private code. This can be further exploited to access all bills of another project without knowledge of this other project's private code. With the default configuration, anybody is allowed to create a new project. An attacker can create a new project and then use it to become authenticated and exploit this flaw. As such, the exposure is similar to an unauthenticated attack, because it is trivial to become authenticated."
+                "value": "In \"I hate money\" before version 4.1.5, an authenticated member of one project can modify and delete members of another project, without knowledge of this other project's private code. This can be further exploited to access all bills of another project without knowledge of this other project's private code. With the default configuration, anybody is allowed to create a new project. An attacker can create a new project and then use it to become authenticated and exploit this flaw. As such, the exposure is similar to an unauthenticated attack, because it is trivial to become authenticated.\n\nThis is fixed in version 4.1.5."
             }
         ]
     },


### PR DESCRIPTION
Thanks to @iamleot for for [noting in the original submission for CVE-2020-15120](https://github.com/CVEProject/cvelist/pull/4417#issuecomment-664885361) that the description did not name the affected software.  This update adds the affected software name, which happens to be ["I hate money"](https://github.com/spiral-project/ihatemoney) (which is an open source budgeting application).

