### PR TITLE
Add CVE-2020-15136 for GHSA-wr2v-9rpq-c35q

### DIFF
--- a/2020/15xxx/CVE-2020-15136.json
+++ b/2020/15xxx/CVE-2020-15136.json
@@ -1,18 +1,91 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-15136",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Improper authentication in etcd"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "etcd",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 3.4.0, < 3.4.10"
+                                        },
+                                        {
+                                            "version_value": "< 3.3.23"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "etcd-io"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In ectd before versions 3.4.10 and 3.3.23, gateway TLS authentication is only applied to endpoints detected in DNS SRV records. When starting a gateway, TLS authentication will only be attempted on endpoints identified in DNS SRV records for a given domain, which occurs in the discoverEndpoints function. No authentication is performed against endpoints provided in the --endpoints flag.\nThis has been fixed in versions 3.4.10 and 3.3.23 with improved documentation and deprecation of the functionality."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "{\"CWE-287\":\"Improper Authentication\"}"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/etcd-io/etcd/security/advisories/GHSA-wr2v-9rpq-c35q",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/etcd-io/etcd/security/advisories/GHSA-wr2v-9rpq-c35q"
+            },
+            {
+                "name": "https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/gateway.md",
+                "refsource": "MISC",
+                "url": "https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/gateway.md"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-wr2v-9rpq-c35q",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-15136 for GHSA-wr2v-9rpq-c35q