### PR TITLE
Assign CVE-2020-10289

### DIFF
--- a/2020/10xxx/CVE-2020-10289.json
+++ b/2020/10xxx/CVE-2020-10289.json
@@ -1,18 +1,116 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "cve@aliasrobotics.com",
+        "DATE_PUBLIC": "2020-08-20T08:00:46 +00:00",
         "ID": "CVE-2020-10289",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "RVD#2401: Use of unsafe yaml load, ./src/actionlib/tools/library.py:132"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "ros",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ""
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Open Robotics"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Alias Robotics"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Use of unsafe yaml load. Allows instantiation of arbitrary objects. The flaw itself is caused by an unsafe parsing of YAML values which happens whenever an action message is processed to be sent, and allows for the creation of Python objects. Through this flaw in the ROS core package of actionlib, an attacker with local or remote access can make the ROS Master, execute arbitrary code in Python form. Consider yaml.safe_load() instead. Located first in actionlib/tools/library.py:132. See links for more info on the bug."
             }
         ]
+    },
+    "generator": {
+        "engine": "Robot Vulnerability Database (RVD)"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.0,
+            "baseSeverity": "high",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "REQUIRED",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-20"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+    "reference_data": [
+    {
+    "name": "https://github.com/aliasrobotics/RVD/issues/2401",
+    "refsource": "CONFIRM",
+    "url": "https://github.com/aliasrobotics/RVD/issues/2401"
+    }
+    ],
+    "reference_data": [
+    {
+    "name": "https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html",
+    "refsource": "CONFIRM",
+    "url": "https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html"
+    }
+    ],
+    "reference_data": [
+    {
+    "name": "https://github.com/ros/actionlib/pull/170",
+    "refsource": "CONFIRM",
+    "url": "https://github.com/ros/actionlib/pull/170"
+    }
+    ],
+    "reference_data": [
+    {
+    "name": "https://github.com/ros/actionlib/pull/171",
+    "refsource": "CONFIRM",
+    "url": "https://github.com/ros/actionlib/pull/171"
+    }
+    ]
+    },
+    "source": {
+        "defect": [
+            "RVD#2401"
+        ],
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
Our team at @aliasrobotics identified and reported in RVD#2401 the use of
unsafe yaml load (aliasrobotics/RVD#2401).

After triaging the flaw we detected that it was exploitable and could lead to
local (or remote, based on certain common user interaction) code execution.

Specifically, the flaw itself is caused by an unsafe parsing of YAML values which
happens whenever an action message is processed to be sent, and allows for the
creation of Python objects. Through this flaw in ROS, an attacker could build a
malicious payload and execute arbitrary code in Python. A PoC is available but
have decided not to disclose it for now and until this is mitigated and debs are
available.