### PR TITLE
Add CVE-2020-10517

### DIFF
--- a/2020/10xxx/CVE-2020-10517.json
+++ b/2020/10xxx/CVE-2020-10517.json
@@ -1,18 +1,91 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10517",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "product-cna@github.com",
+    "ID": "CVE-2020-10517",
+    "STATE": "PUBLIC",
+    "TITLE": "Improper access control in GitHub Enterprise Server leading to the enumeration of private repository names"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "GitHub Enterprise Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_name": "2.21",
+                      "version_value": "2.21.6"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "2.20",
+                      "version_value": "2.20.15"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "2.19",
+                      "version_value": "2.19.21"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "GitHub"
+        }
+      ]
     }
+  },
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "William Bowling"
+    }
+  ],
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "An improper access control vulnerability was identified in GitHub Enterprise Server that allowed authenticated users of the instance to determine the names of unauthorized private repositories given their numerical IDs. This vulnerability did not allow unauthorized access to any repository content besides the name. This vulnerability affected all versions of GitHub Enterprise Server prior to 2.22 and was fixed in versions 2.21.6, 2.20.15, and 2.19.21. This vulnerability was reported via the GitHub Bug Bounty program."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-285: Improper Authorization"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "https://enterprise.github.com/releases/2.21.6/notes"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://enterprise.github.com/releases/2.20.15/notes"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://enterprise.github.com/releases/2.19.21/notes"
+      }
+    ]
+  },
+  "source": {
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
This PR adds CVE-2020-10517, which was patched and made public in the batch of GitHub Enterprise Server releases that were published yesterday, 8/26/20.