### PR TITLE
Add CVE-2020-10518

### DIFF
--- a/2020/10xxx/CVE-2020-10518.json
+++ b/2020/10xxx/CVE-2020-10518.json
@@ -1,18 +1,91 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-10518",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "product-cna@github.com",
+    "ID": "CVE-2020-10518",
+    "STATE": "PUBLIC",
+    "TITLE": "Unsafe configuration options in GitHub Pages leading to remote code execution on GitHub Enterprise Server"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "GitHub Enterprise Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_name": "2.19",
+                      "version_value": "2.19.21"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "2.20",
+                      "version_value": "2.20.15"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "2.21",
+                      "version_value": "2.21.6"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "GitHub"
+        }
+      ]
     }
+  },
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "William Bowling"
+    }
+  ],
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "A remote code execution vulnerability was identified in GitHub Enterprise Server that could be exploited when building a GitHub Pages site. User-controlled configuration of the underlying parsers used by GitHub Pages were not sufficiently restricted and made it possible to execute commands on the GitHub Enterprise Server instance. To exploit this vulnerability, an attacker would need permission to create and build a GitHub Pages site on the GitHub Enterprise Server instance. This vulnerability affected all versions of GitHub Enterprise Server prior to 2.22 and was fixed in 2.21.6, 2.20.15, and 2.19.21. The underlying issues contributing to this vulnerability were identified both internally and through the GitHub Security Bug Bounty program."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-77: Command Injection - Generic"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "https://enterprise.github.com/releases/2.19.21/notes"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://enterprise.github.com/releases/2.20.15/notes"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://enterprise.github.com/releases/2.21.6/notes"
+      }
+    ]
+  },
+  "source": {
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
This PR adds CVE-2020-10518, which was patched and made public in the batch of GitHub Enterprise Server releases that were published yesterday, 8/26/20.