### PR TITLE
Update CVE-2020-16124: Integer overflow in ros:ros_comm

### DIFF
--- a/2020/16xxx/CVE-2020-16124.json
+++ b/2020/16xxx/CVE-2020-16124.json
@@ -88,7 +88,7 @@
     "references": {
         "reference_data": [
             {
-                "name": "Trap for overly large input to XmlRPCPP #2065",
+                "name": "https://github.com/ros/ros_comm/pull/2065",
                 "refsource": "CONFIRM",
                 "url": "https://github.com/ros/ros_comm/pull/2065"
             }

--- a/2020/16xxx/CVE-2020-16124.json
+++ b/2020/16xxx/CVE-2020-16124.json
@@ -1,18 +1,106 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2020-09-29T15:00:00.000Z",
         "ID": "CVE-2020-16124",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Integer overflow in ROS communications library"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "ros_comm ROS communications packages",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "Noetic",
+                                            "version_value": "Noetic"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "openrobotics"
+                }
+            ]
+        }
+    },
+    "configuration": [
+        {
+            "lang": "eng",
+            "value": "cpe:2.3:a:openrobotics:robot_operating_system:1:*:*:*:*:*:*:*"
+        }
+    ],
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Sid Faber"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "The ROS 1 XMLRPCPP library relies heavily on implicit conversion between signed integers (type int) and unsigned integers (type SIZE_T). This leads to logic errors and unpredictable parsing with overly large input."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 7.3,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-190 Integer Overflow or Wraparound"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "Trap for overly large input to XmlRPCPP #2065",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/ros/ros_comm/pull/2065"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Apply patch https://github.com/ros/ros_comm/pull/2065"
+        }
+    ],
+    "source": {
+        "discovery": "INTERNAL"
     }
 }

--- a/2020/16xxx/CVE-2020-16124.json
+++ b/2020/16xxx/CVE-2020-16124.json
@@ -50,7 +50,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "The ROS 1 XMLRPCPP library relies heavily on implicit conversion between signed integers (type int) and unsigned integers (type SIZE_T). This leads to logic errors and unpredictable parsing with overly large input."
+                "value": "Integer Overflow or Wraparound vulnerability in the XML RPC library of OpenRobotics ros_comm communications packages allows unauthenticated network traffic to cause unexpected behavior.\nThis issue affects:\nOpenRobotics ros_comm communications packages\nNoetic and prior versions.\nFixed in https://github.com/ros/ros_comm/pull/2065."
             }
         ]
     },


### PR DESCRIPTION
Add json file for CVE-2020-16124.