### PR TITLE
CVE-2019-17444

### DIFF
--- a/2019/17xxx/CVE-2019-17444.json
+++ b/2019/17xxx/CVE-2019-17444.json
@@ -54,7 +54,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Jfrog Artifactory uses default passwords (such as \"password\") for administrative accounts and does not require users to change them. This may allow unauthorized network based attackers to completely compromise of Jfrog Artifactory.\nThis issue affects Jfrog Artifactory versions versions prior to 6.17.0."
+                "value": "Jfrog Artifactory uses default passwords (such as \"password\") for administrative accounts and does not require users to change them. This may allow unauthorized network-based attackers to completely compromise of Jfrog Artifactory. This issue affects Jfrog Artifactory versions prior to 6.17.0."
             }
         ]
     },

--- a/2019/17xxx/CVE-2019-17444.json
+++ b/2019/17xxx/CVE-2019-17444.json
@@ -1,0 +1,113 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "psirt@paloaltonetworks.com",
+        "DATE_PUBLIC": "2020-10-12T21:16:00.000Z",
+        "ID": "CVE-2019-17444",
+        "STATE": "PUBLIC",
+        "TITLE": "JFrog Artifactory does not enforce default admin password change"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Artifactory",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "!",
+                                            "version_value": "7.x"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "all",
+                                            "version_value": "6.17.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Jfrog"
+                }
+            ]
+        }
+    },
+    "configuration": [
+        {
+            "lang": "eng",
+            "value": "This issue affects default configuration."
+        }
+    ],
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered by Daniel Shapira of Palo Alto Networks."
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "Jfrog Artifactory uses default passwords (such as \"password\") for administrative accounts and does not require users to change them. This may allow unauthorized network based attackers to completely compromise of Jfrog Artifactory.\nThis issue affects Jfrog Artifactory versions versions prior to 6.17.0."
+            }
+        ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-521: Weak Password Requirements"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "MISC",
+                "url": "https://www.jfrog.com/confluence/display/JFROG/JFrog+Artifactory"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "This is fixed in 6.17, and 7.x and later releases."
+        }
+    ],
+    "source": {
+        "discovery": "EXTERNAL"
+    }
+}


### PR DESCRIPTION
Assigning CVE-2019-17444 for a default password vulnerability found by Palo Alto Networks Researchers on JFrog.