### PR TITLE
Update CVE-2020-15250 description

### DIFF
--- a/2020/15xxx/CVE-2020-15250.json
+++ b/2020/15xxx/CVE-2020-15250.json
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In JUnit4 before version 4.13.1, the test rule TemporaryFolder contains a local information disclosure vulnerability. On Unix like systems, the system's temporary directory is shared between all users on that system. Because of this, when files and directories are written into this directory they are, by default, readable by other users on that same system. This vulnerability does not allow other users to overwrite the contents of these directories or files. This is purely an information disclosure vulnerability. This vulnerability impacts you if the JUnit tests write sensitive information, like API keys or passwords, into the temporary folder, and the JUnit tests execute in an environment where the OS has other untrusted users. Because certain JDK file system APIs were only added in JDK 1.7, this this fix is dependent upon the version of the JDK you are using. For Java 1.7 and higher users: this vulnerability is fixed in 4.13.1. For Java 1.6 and lower users: no patch is available, you must use the workaround below. If you are unable to patch, or are stuck running on Java 1.6, specifying the `java.io.tmpdir` system environment variable to a directory that is exclusively owned by the executing user will fix this vulnerability. For more information, including an example of vulnerable code, see the referenced GitHub Security Advisory."
+                "value": "In JUnit4 from version 4.7 and before 4.13.1, the test rule TemporaryFolder contains a local information disclosure vulnerability. On Unix like systems, the system's temporary directory is shared between all users on that system. Because of this, when files and directories are written into this directory they are, by default, readable by other users on that same system. This vulnerability does not allow other users to overwrite the contents of these directories or files. This is purely an information disclosure vulnerability. This vulnerability impacts you if the JUnit tests write sensitive information, like API keys or passwords, into the temporary folder, and the JUnit tests execute in an environment where the OS has other untrusted users. Because certain JDK file system APIs were only added in JDK 1.7, this this fix is dependent upon the version of the JDK you are using. For Java 1.7 and higher users: this vulnerability is fixed in 4.13.1. For Java 1.6 and lower users: no patch is available, you must use the workaround below. If you are unable to patch, or are stuck running on Java 1.6, specifying the `java.io.tmpdir` system environment variable to a directory that is exclusively owned by the executing user will fix this vulnerability. For more information, including an example of vulnerable code, see the referenced GitHub Security Advisory."
             }
         ]
     },
@@ -90,44 +90,49 @@
                 "url": "https://junit.org/junit4/javadoc/4.13/org/junit/rules/TemporaryFolder.html"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-dev] 20201013 [jira] [Created] (RAT-277) Update junit in all Creadur projects in order to fix CVE-2020-15250 (Low severity)",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/r5f8841507576f595bb783ccec6a7cb285ea90d4e6f5043eae0e61a41@%3Cdev.creadur.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-dev] 20201014 [jira] [Commented] (RAT-277) Update junit in all Creadur projects in order to fix CVE-2020-15250 (Low severity)",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/rbaec90e699bc7c7bd9a053f76707a36fda48b6d558f31dc79147dbf9@%3Cdev.creadur.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-commits] 20201014 [creadur-whisker] branch master updated: Update junit to fix CVE-2020-15250",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/r717877028482c55acf604d7a0106af4ca05da4208c708fb157b53672@%3Ccommits.creadur.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-dev] 20201014 [jira] [Assigned] (RAT-277) Update junit in all Creadur projects in order to fix CVE-2020-15250 (Low severity)",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/rb2771949c676ca984e58a5cd5ca79c2634dee1945e0406e48e0f8457@%3Cdev.creadur.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-commits] 20201014 [creadur-tentacles] branch master updated: Update junit to fix CVE-2020-15250",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/rde385b8b53ed046600ef68dd6b4528dea7566aaddb02c3e702cc28bc@%3Ccommits.creadur.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-dev] 20201014 [jira] [Updated] (RAT-277) Update junit in all Creadur projects in order to fix CVE-2020-15250 (Low severity)",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/rc49cf1547ef6cac1be4b3c92339b2cae0acacf5acaba13cfa429a872@%3Cdev.creadur.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-dev] 20201014 [jira] [Closed] (RAT-277) Update junit in all Creadur projects in order to fix CVE-2020-15250 (Low severity)",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/r500517c23200fb2fdb0b82770a62dd6c88b3521cfb01cfd0c76e3f8b@%3Cdev.creadur.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-commits] 20201014 [creadur-rat] 01/02: RAT-277: Update junit to fix CVE-2020-15250",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/r95f8ef60c4b3a5284b647bb3132cda08e6fadad888a66b84f49da0b0@%3Ccommits.creadur.apache.org%3E"
+            },
+            {
+                "name": "https://github.com/junit-team/junit4/issues/1676",
+                "refsource": "MISC",
+                "url": "https://github.com/junit-team/junit4/issues/1676"
             }
         ]
     },


### PR DESCRIPTION
Per request from maintainer, the description for CVE-2020-15250 to note the floor version of 4.7.  See https://github.com/junit-team/junit4/issues/1676