### PR TITLE
Add CVE-2020-15254 for GHSA-v5m7-53cv-f3hx

### DIFF
--- a/2020/15xxx/CVE-2020-15254.json
+++ b/2020/15xxx/CVE-2020-15254.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-15254",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Undefined Behavior in bounded Crossbeam channel"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "crossbeam",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.4.4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "crossbeam-rs"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Crossbeam is a set of tools for concurrent programming. In crossbeam-channel before version 0.4.4, the bounded channel incorrectly assumes that `Vec::from_iter` has allocated capacity that same as the number of iterator elements. `Vec::from_iter` does not actually guarantee that and may allocate extra memory. The destructor of the `bounded` channel reconstructs `Vec` from the raw pointer based on the incorrect assumes described above. This is unsound and causing deallocation with the incorrect capacity when `Vec::from_iter` has allocated different sizes with the number of iterator elements.\n\nThis has been fixed in crossbeam-channel 0.4.4."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "{\"CWE-119\":\"Improper Restriction of Operations within the Bounds of a Memory Buffer\"}"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/crossbeam-rs/crossbeam/security/advisories/GHSA-v5m7-53cv-f3hx",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/crossbeam-rs/crossbeam/security/advisories/GHSA-v5m7-53cv-f3hx"
+            },
+            {
+                "name": "https://github.com/crossbeam-rs/crossbeam/issues/539",
+                "refsource": "MISC",
+                "url": "https://github.com/crossbeam-rs/crossbeam/issues/539"
+            },
+            {
+                "name": "https://github.com/crossbeam-rs/crossbeam/pull/533",
+                "refsource": "MISC",
+                "url": "https://github.com/crossbeam-rs/crossbeam/pull/533"
+            },
+            {
+                "name": "https://github.com/RustSec/advisory-db/pull/425",
+                "refsource": "MISC",
+                "url": "https://github.com/RustSec/advisory-db/pull/425"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-v5m7-53cv-f3hx",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-15254 for GHSA-v5m7-53cv-f3hx