### PR TITLE
Add CVE-2020-15264 for GHSA-rpgx-h675-r3jf

### DIFF
--- a/2020/15xxx/CVE-2020-15264.json
+++ b/2020/15xxx/CVE-2020-15264.json
@@ -1,18 +1,96 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-15264",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Privilege Escalation in Boxstarter"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "boxstarter",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 2.13.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "chocolatey"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "The Boxstarter installer before version 2.13.0 configures C:\\ProgramData\\Boxstarter to be in the system-wide PATH environment variable. However, this directory is writable by normal, unprivileged users. To exploit the vulnerability, place a DLL in this directory that a privileged service is looking for. For example, WptsExtensions.dll When Windows starts, it'll execute the code in DllMain() with SYSTEM privileges.\nAny unprivileged user can execute code with SYSTEM privileges.\nThe issue is fixed in version 3.13.0"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-668 Exposure of Resource to Wrong Sphere"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-73 External Control of File Name or Path"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/chocolatey/boxstarter/security/advisories/GHSA-rpgx-h675-r3jf",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/chocolatey/boxstarter/security/advisories/GHSA-rpgx-h675-r3jf"
+            },
+            {
+                "name": "https://github.com/chocolatey/boxstarter/commit/67e320491813550b48900e87105a34ceefdcf633",
+                "refsource": "MISC",
+                "url": "https://github.com/chocolatey/boxstarter/commit/67e320491813550b48900e87105a34ceefdcf633"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-rpgx-h675-r3jf",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-15264 for GHSA-rpgx-h675-r3jf