### PR TITLE
CVE-2020-27216

### DIFF
--- a/2020/27xxx/CVE-2020-27216.json
+++ b/2020/27xxx/CVE-2020-27216.json
@@ -4,14 +4,77 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-27216",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security@eclipse.org",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "The Eclipse Foundation",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Eclipse Jetty",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.0 to 9.4.32.v20200930"
+                                        },
+                                        {
+                                            "version_value": "10.0.0.alpha1 to 10.0.0.beta2"
+                                        },
+                                        {
+                                            "version_value": "11.0.0.alpha1 to 11.0.0.beta2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Eclipse Jetty versions 1.0 thru 9.4.32.v20200930, 10.0.0.alpha1 thru 10.0.0.beta2, and 11.0.0.alpha1 thru 11.0.0.beta2O, on Unix like systems, the system's temporary directory is shared between all users on that system. A collocated user can observe the process of creating a temporary sub directory in the shared temporary directory and race to complete the creation of the temporary subdirectory. If the attacker wins the race then they will have read and write permission to the subdirectory used to unpack web applications, including their WEB-INF/lib jar files and JSP files. If any code is ever executed out of this temporary directory, this can lead to a local privilege escalation vulnerability."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-378: Creation of Temporary File With Insecure Permissions"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-379: Creation of Temporary File in Directory with Insecure Permissions"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=567921",
+                "refsource": "CONFIRM",
+                "url": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=567921"
+            },
+            {
+                "name": "https://github.com/eclipse/jetty.project/security/advisories/GHSA-g3wg-6mcf-8jj6#advisory-comment-63053",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/eclipse/jetty.project/security/advisories/GHSA-g3wg-6mcf-8jj6#advisory-comment-63053"
             }
         ]
     }


### PR DESCRIPTION
Signed-off-by: Wayne Beaton <wayne.beaton@eclipse-foundation.org>