### PR TITLE
reject an ubuntu assignment, issue is hardening

### DIFF
--- a/2020/27xxx/CVE-2020-27346.json
+++ b/2020/27xxx/CVE-2020-27346.json
@@ -5,13 +5,13 @@
     "CVE_data_meta": {
         "ID": "CVE-2020-27346",
         "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Notes: none."
             }
         ]
     }


### PR DESCRIPTION
Hello, we had used this cve number in a bug report that may or may not eventually be opened for public viewing. We have decided the issue is hardening, rather than a vulnerability. Thus we thought it best to REJECT this CVE number to avoid confusion.

Incidentally, github tried to send me to `thezdi/cvelist` for this pull request. If I've driven GitHub correctly, I believe this should be against the `CVEProject/cvelist` project. GitHub is still showing me the `It looks like this is your first time opening a pull request in this project!` message even though I've submitted several CVEs through this tool. If this isn't *the* MITRE CVE project, I'm sorry for the noise.

Thanks