### PR TITLE
Add CVEs for 2020-11-04 Jenkins security advisory

### DIFF
--- a/2020/2xxx/CVE-2020-2299.json
+++ b/2020/2xxx/CVE-2020-2299.json
@@ -1,17 +1,69 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2299",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Active Directory Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.44",
+                                            "version_affected": ">="
+                                        },
+                                        {
+                                            "version_value": "2.19",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.16.1",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins Active Directory Plugin 2.19 and earlier allows attackers to log in as any user if a magic constant is used as the password."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-287: Improper Authentication"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2117",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2117",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2300.json
+++ b/2020/2xxx/CVE-2020-2300.json
@@ -1,17 +1,65 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2300",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Active Directory Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.19",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.16.1",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins Active Directory Plugin 2.19 and earlier does not prohibit the use of an empty password in Windows/ADSI mode, which allows attackers to log in to Jenkins as any user depending on the configuration of the Active Directory server."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-287: Improper Authentication"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2099",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2099",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2301.json
+++ b/2020/2xxx/CVE-2020-2301.json
@@ -1,17 +1,65 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2301",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Active Directory Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.19",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.16.1",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins Active Directory Plugin 2.19 and earlier allows attackers to log in as any user with any password while a successful authentication of that user is still in the optional cache when using Windows/ADSI mode."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-287: Improper Authentication"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2123",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2123",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2302.json
+++ b/2020/2xxx/CVE-2020-2302.json
@@ -1,17 +1,65 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2302",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Active Directory Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.19",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.16.1",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A missing permission check in Jenkins Active Directory Plugin 2.19 and earlier allows attackers with Overall/Read permission to access the domain health check diagnostic page."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-862: Missing Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1999",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1999",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2303.json
+++ b/2020/2xxx/CVE-2020-2303.json
@@ -1,17 +1,65 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2303",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Active Directory Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.19",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.16.1",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A cross-site request forgery (CSRF) vulnerability in Jenkins Active Directory Plugin 2.19 and earlier allows attackers to perform connection tests, connecting to attacker-specified or previously configured Active Directory servers using attacker-specified credentials."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-352: Cross-Site Request Forgery (CSRF)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2126",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2126",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2304.json
+++ b/2020/2xxx/CVE-2020-2304.json
@@ -1,17 +1,61 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2304",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Subversion Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.13.1",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins Subversion Plugin 2.13.1 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-611: Improper Restriction of XML External Entity Reference"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2145",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2145",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2305.json
+++ b/2020/2xxx/CVE-2020-2305.json
@@ -1,17 +1,73 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2305",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Mercurial Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.11",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.10.1",
+                                            "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "2.9.1",
+                                            "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "2.8.1",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins Mercurial Plugin 2.11 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-611: Improper Restriction of XML External Entity Reference"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2115",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2115",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2306.json
+++ b/2020/2xxx/CVE-2020-2306.json
@@ -1,17 +1,73 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2306",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Mercurial Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.11",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.10.1",
+                                            "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "2.9.1",
+                                            "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "2.8.1",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A missing permission check in Jenkins Mercurial Plugin 2.11 and earlier allows attackers with Overall/Read permission to obtain a list of names of configured Mercurial installations."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-862: Missing Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2104",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2104",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2307.json
+++ b/2020/2xxx/CVE-2020-2307.json
@@ -1,17 +1,73 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2307",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Kubernetes Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.27.3",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.26.5",
+                                            "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1.25.4.1",
+                                            "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1.21.6",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins Kubernetes Plugin 1.27.3 and earlier allows low-privilege users to access possibly sensitive Jenkins controller environment variables."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1646",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1646",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2308.json
+++ b/2020/2xxx/CVE-2020-2308.json
@@ -1,17 +1,77 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2308",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Kubernetes Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.27.1",
+                                            "version_affected": ">="
+                                        },
+                                        {
+                                            "version_value": "1.27.3",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.26.5",
+                                            "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1.25.4.1",
+                                            "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1.21.6",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A missing permission check in Jenkins Kubernetes Plugin 1.27.3 and earlier allows attackers with Overall/Read permission to list global pod template names."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-862: Missing Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2102",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2102",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2309.json
+++ b/2020/2xxx/CVE-2020-2309.json
@@ -1,17 +1,73 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2309",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Kubernetes Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.27.3",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.26.5",
+                                            "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1.25.4.1",
+                                            "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1.21.6",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A missing/An incorrect permission check in Jenkins Kubernetes Plugin 1.27.3 and earlier allows attackers with Overall/Read permission to enumerate credentials IDs of credentials stored in Jenkins."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-862: Missing Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2103",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2103",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2310.json
+++ b/2020/2xxx/CVE-2020-2310.json
@@ -1,17 +1,61 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2310",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Ansible Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.0",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Missing permission checks in Jenkins Ansible Plugin 1.0 and earlier allow attackers with Overall/Read permission to enumerate credentials IDs of credentials stored in Jenkins."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-862: Missing Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1943",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1943",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2311.json
+++ b/2020/2xxx/CVE-2020-2311.json
@@ -1,17 +1,65 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2311",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins AWS Global Configuration Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.5",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.3.1",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A missing permission check in Jenkins AWS Global Configuration Plugin 1.5 and earlier allows attackers with Overall/Read permission to replace the global AWS configuration."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-862: Missing Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2101",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2101",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2312.json
+++ b/2020/2xxx/CVE-2020-2312.json
@@ -1,17 +1,61 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2312",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins SQLPlus Script Runner Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.0.12",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins SQLPlus Script Runner Plugin 2.0.12 and earlier does not mask a password provided as command line argument in build logs."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-522: Insufficiently Protected Credentials"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2129",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2129",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2313.json
+++ b/2020/2xxx/CVE-2020-2313.json
@@ -1,17 +1,61 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2313",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Azure Key Vault Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.0",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A missing permission check in Jenkins Azure Key Vault Plugin 2.0 and earlier allows attackers with Overall/Read permission to enumerate credentials IDs of credentials stored in Jenkins."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-862: Missing Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2110",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2110",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2314.json
+++ b/2020/2xxx/CVE-2020-2314.json
@@ -1,17 +1,61 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2314",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins AppSpider Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.0.12",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins AppSpider Plugin 1.0.12 and earlier stores a password unencrypted in its global configuration file on the Jenkins controller where it can be viewed by users with access to the Jenkins controller file system."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-256: Unprotected Storage of Credentials"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2058",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2058",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2315.json
+++ b/2020/2xxx/CVE-2020-2315.json
@@ -1,17 +1,61 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2315",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Visualworks Store Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.1.3",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins Visualworks Store Plugin 1.1.3 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-611: Improper Restriction of XML External Entity Reference"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1900",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1900",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2316.json
+++ b/2020/2xxx/CVE-2020-2316.json
@@ -1,17 +1,65 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2316",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Static Analysis Utilities Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.96",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.96",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins Static Analysis Utilities Plugin 1.96 and earlier does not escape the annotation message in tooltips, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1907",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1907",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2317.json
+++ b/2020/2xxx/CVE-2020-2317.json
@@ -1,17 +1,65 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2317",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins FindBugs Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "5.0.0",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "5.0.0",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins FindBugs Plugin 5.0.0 and earlier does not escape the annotation message in tooltips, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to provide report files to Jenkins FindBugs Plugin's post build step."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1918",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1918",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2318.json
+++ b/2020/2xxx/CVE-2020-2318.json
@@ -1,17 +1,65 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2318",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Mail Commander Plugin for Jenkins-ci Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.0.0",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.0.0",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins Mail Commander Plugin for Jenkins-ci Plugin 1.0.0 and earlier stores passwords unencrypted in job config.xml files on the Jenkins controller where they can be viewed by users with Extended Read permission, or access to the Jenkins controller file system."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-256: Unprotected Storage of Credentials"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2085",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2085",
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2020/2xxx/CVE-2020-2319.json
+++ b/2020/2xxx/CVE-2020-2319.json
@@ -1,17 +1,65 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-2319",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins VMware Lab Manager Slaves Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "0.2.8",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "0.2.8",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Jenkins VMware Lab Manager Slaves Plugin 0.2.8 and earlier stores a password unencrypted in the global config.xml file on the Jenkins controller where it can be viewed by users with access to the Jenkins controller file system."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-256: Unprotected Storage of Credentials"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2084",
+                "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2084",
+                "refsource": "CONFIRM"
             }
         ]
     }


### PR DESCRIPTION
https://www.jenkins.io/security/advisory/2020-11-04/

I hope this is still the repo. I also looked in recent emails and no announcement about the end of this pilot went out. Did you delete the previous repo and recreate this?

Opening PRs here is cumbersome, as they target `thezdi`'s repo by default (and some folks already filed PRs there), as that's now the root of the network graph. (With `thezdi`'s approval, this repo can be made the root again by GH support.)
