### PR TITLE
Add redhat fixed .jar version

### DIFF
--- a/2017/12xxx/CVE-2017-12629.json
+++ b/2017/12xxx/CVE-2017-12629.json
@@ -16,6 +16,37 @@
                                     "version_data": [
                                         {
                                             "version_value": "Apache Solr before 7.1 with Apache Lucene before 7.1"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "lucene-solr",
+                                            "version_value": "7.1.0"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "lucene-solr",
+                                            "version_value": "6.6.2"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "lucene-solr",
+                                            "version_value": "5.5.5"
+                                        },
+                                        {
+                                            "version_affected": "!",
+                                            "version_name": "lucene-solr",
+                                            "version_value": "7.2.0"
+                                        },
+                                        {
+                                            "version_affected": "!",
+                                            "version_name": "lucene-solr",
+                                            "version_value": "8.0.0"
+                                        },
+                                        {
+                                            "platform": "redhat",
+                                            "version_affected": "<",
+                                            "version_name": "lucene-solr",
+                                            "version_value": "5.3.1-redhat-2"
                                         }
                                     ]
                                 }


### PR DESCRIPTION
Red Hat backported this fix to an earlier version, 5.3.1.redhat-2. The supporting links are private unfortunately.