### PR TITLE
CVE-2020-27217

### DIFF
--- a/2020/27xxx/CVE-2020-27217.json
+++ b/2020/27xxx/CVE-2020-27217.json
@@ -4,14 +4,61 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-27217",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security@eclipse.org",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "The Eclipse Foundation",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Eclipse Hono",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.3.0"
+                                        },
+                                        {
+                                            "version_value": "1.4.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Eclipse Hono version 1.3.0 and 1.4.0 the AMQP protocol adapter does not verify the size of AMQP messages received from devices. In particular, a device may send messages that are bigger than the max-message-size that the protocol adapter has indicated during link establishment. While the AMQP 1.0 protocol explicitly disallows a peer to send such messages, a hand crafted AMQP 1.0 client could exploit this behavior in order to send a message of unlimited size to the adapter, eventually causing the adapter to fail with an out of memory exception."
+            }
+        ]
+    },
+        "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-1284: Improper Validation of Specified Quantity in Input"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=567068",
+                "refsource": "CONFIRM",
+                "url": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=567068"
             }
         ]
     }


### PR DESCRIPTION
Signed-off-by: Wayne Beaton <wayne.beaton@eclipse-foundation.org>