### PR TITLE
Add reference to CVE-2020-15253

### DIFF
--- a/2020/15xxx/CVE-2020-15253.json
+++ b/2020/15xxx/CVE-2020-15253.json
@@ -88,6 +88,11 @@
                 "name": "https://github.com/grocy/grocy/commit/0df2590de27c60c18b7db6e056347bd2aff5a887",
                 "refsource": "MISC",
                 "url": "https://github.com/grocy/grocy/commit/0df2590de27c60c18b7db6e056347bd2aff5a887"
+            },
+            {
+                "name": "https://www.exploit-db.com/exploits/48792",
+                "refsource": "MISC",
+                "url": "https://www.exploit-db.com/exploits/48792"
             }
         ]
     },


### PR DESCRIPTION
Per request from the security researcher behind this CVE, this update adds a reference to https://www.exploit-db.com/exploits/48792.