### PR TITLE
add reference to CVE-2020-15255

### DIFF
--- a/2020/15xxx/CVE-2020-15255.json
+++ b/2020/15xxx/CVE-2020-15255.json
@@ -80,9 +80,14 @@
                 "url": "https://github.com/anuko/timetracker/commit/d9472904361495f318c9d0294ffd28acaaeae42f"
             },
             {
-                "refsource": "MISC",
                 "name": "http://packetstormsecurity.com/files/159996/Anuko-Time-Tracker-1.19.23.5325-CSV-Injection.html",
+                "refsource": "MISC",
                 "url": "http://packetstormsecurity.com/files/159996/Anuko-Time-Tracker-1.19.23.5325-CSV-Injection.html"
+            },
+            {
+                "name": "https://www.exploit-db.com/exploits/49027",
+                "refsource": "MISC",
+                "url": "https://www.exploit-db.com/exploits/49027"
             }
         ]
     },


### PR DESCRIPTION
Per request from the security researcher behind this CVE, this update adds a reference to https://www.exploit-db.com/exploits/49027