### PR TITLE
Adding Cisco CVE-2020-3470

### DIFF
--- a/2020/3xxx/CVE-2020-3470.json
+++ b/2020/3xxx/CVE-2020-3470.json
@@ -1,18 +1,89 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "psirt@cisco.com",
+        "DATE_PUBLIC": "2020-11-18T16:00:00",
         "ID": "CVE-2020-3470",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Cisco Integrated Management Controller Multiple Remote Code Execution Vulnerabilities"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Cisco Unified Computing System (Standalone) ",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "n/a"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Cisco"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "\r Multiple vulnerabilities in the API subsystem of Cisco Integrated Management Controller (IMC) could allow an unauthenticated, remote attacker to execute arbitrary code with root privileges.\r The vulnerabilities are due to improper boundary checks for certain user-supplied input. An attacker could exploit these vulnerabilities by sending a crafted HTTP request to the API subsystem of an affected system. When this request is processed, an exploitable buffer overflow condition may occur. A successful exploit could allow the attacker to execute arbitrary code with root privileges on the underlying operating system (OS).\r "
             }
         ]
+    },
+    "exploit": [
+        {
+            "lang": "eng",
+            "value": "The Cisco Product Security Incident Response Team (PSIRT) is not aware of any public announcements or malicious use of the vulnerabilities that are described in this advisory. "
+        }
+    ],
+    "impact": {
+        "cvss": {
+            "baseScore": "9.8",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H ",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-119"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "20201118 Cisco Integrated Management Controller Multiple Remote Code Execution Vulnerabilities",
+                "refsource": "CISCO",
+                "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ucs-api-rce-UXwpeDHd"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "cisco-sa-ucs-api-rce-UXwpeDHd",
+        "defect": [
+            [
+                "CSCvu21215",
+                "CSCvu21222",
+                "CSCvu22429",
+                "CSCvu80203"
+            ]
+        ],
+        "discovery": "INTERNAL"
     }
 }


### PR DESCRIPTION
Adding the Cisco CVE in the title. For additional information about Cisco PSIRT and this disclosure go to https://cisco.com/go/psirt.