### PR TITLE
Adding Cisco CVE-2020-26080

### DIFF
--- a/2020/26xxx/CVE-2020-26080.json
+++ b/2020/26xxx/CVE-2020-26080.json
@@ -1,18 +1,86 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "psirt@cisco.com",
+        "DATE_PUBLIC": "2020-11-18T16:00:00",
         "ID": "CVE-2020-26080",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Cisco IoT Field Network Director Improper Domain Access Control Vulnerability"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Cisco IoT Field Network Director (IoT-FND) ",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "n/a"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Cisco"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "\r A vulnerability in the user management functionality of Cisco IoT Field Network Director (FND) could allow an authenticated, remote attacker to manage user information for users in different domains on an affected system.\r The vulnerability is due to improper domain access control. An attacker could exploit this vulnerability by manipulating JSON payloads to target different domains on an affected system. A successful exploit could allow the attacker to manage user information for users in different domains on an affected system.\r "
             }
         ]
+    },
+    "exploit": [
+        {
+            "lang": "eng",
+            "value": "The Cisco Product Security Incident Response Team (PSIRT) is not aware of any public announcements or malicious use of the vulnerability that is described in this advisory. "
+        }
+    ],
+    "impact": {
+        "cvss": {
+            "baseScore": "4.1",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:N/I:L/A:N ",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-284"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "20201118 Cisco IoT Field Network Director Improper Domain Access Control Vulnerability",
+                "refsource": "CISCO",
+                "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-FND-UPWD-dCRPuQ78"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "cisco-sa-FND-UPWD-dCRPuQ78",
+        "defect": [
+            [
+                "CSCvt45294"
+            ]
+        ],
+        "discovery": "INTERNAL"
     }
 }


### PR DESCRIPTION
Adding the Cisco CVE in the title. For additional information about Cisco PSIRT and this disclosure go to https://cisco.com/go/psirt.