### PR TITLE
Adding Cisco CVE-2020-26079

### DIFF
--- a/2020/26xxx/CVE-2020-26079.json
+++ b/2020/26xxx/CVE-2020-26079.json
@@ -1,18 +1,86 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "psirt@cisco.com",
+        "DATE_PUBLIC": "2020-11-18T16:00:00",
         "ID": "CVE-2020-26079",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Cisco IoT Field Network Director Unprotected Storage of Credentials Vulnerability"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Cisco IoT Field Network Director (IoT-FND) ",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "n/a"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Cisco"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "\r A vulnerability in the web UI of Cisco IoT Field Network Director (FND) could allow an authenticated, remote attacker to obtain hashes of user passwords on an affected device.\r The vulnerability is due to insufficient protection of user credentials. An attacker could exploit this vulnerability by logging in as an administrative user and crafting a call for user information. A successful exploit could allow the attacker to obtain hashes of user passwords on an affected device.\r "
             }
         ]
+    },
+    "exploit": [
+        {
+            "lang": "eng",
+            "value": "The Cisco Product Security Incident Response Team (PSIRT) is not aware of any public announcements or malicious use of the vulnerability that is described in this advisory. "
+        }
+    ],
+    "impact": {
+        "cvss": {
+            "baseScore": "4.1",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:L/I:N/A:N ",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-256"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "20201118 Cisco IoT Field Network Director Unprotected Storage of Credentials Vulnerability",
+                "refsource": "CISCO",
+                "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-FND-PWH-yCA6M7p"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "cisco-sa-FND-PWH-yCA6M7p",
+        "defect": [
+            [
+                "CSCvt45257"
+            ]
+        ],
+        "discovery": "INTERNAL"
     }
 }


### PR DESCRIPTION
Adding the Cisco CVE in the title. For additional information about Cisco PSIRT and this disclosure go to https://cisco.com/go/psirt.