### PR TITLE
Add CVE-2020-26240 for GHSA-v592-xf75-856p

### DIFF
--- a/2020/26xxx/CVE-2020-26240.json
+++ b/2020/26xxx/CVE-2020-26240.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-26240",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Erroneous Proof of Work calculation in geth"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "go-ethereum",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.9.24"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ethereum"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Go Ethereum, or \"Geth\", is the official Golang implementation of the Ethereum protocol.\n\nAn ethash mining DAG generation flaw in Geth before version 1.9.24 could cause miners to erroneously calculate PoW in an upcoming epoch (estimated early January, 2021).  This happened on the ETC chain on 2020-11-06. This issue is relevant only for miners, non-mining nodes are unaffected.\n\nThis issue is fixed as of 1.9.24"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-682: Incorrect Calculation"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-v592-xf75-856p",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-v592-xf75-856p"
+            },
+            {
+                "name": "https://github.com/ethereum/go-ethereum/pull/21793",
+                "refsource": "MISC",
+                "url": "https://github.com/ethereum/go-ethereum/pull/21793"
+            },
+            {
+                "name": "https://blog.ethereum.org/2020/11/12/geth_security_release/",
+                "refsource": "MISC",
+                "url": "https://blog.ethereum.org/2020/11/12/geth_security_release/"
+            },
+            {
+                "name": "https://github.com/ethereum/go-ethereum/commit/d990df909d7839640143344e79356754384dcdd0",
+                "refsource": "MISC",
+                "url": "https://github.com/ethereum/go-ethereum/commit/d990df909d7839640143344e79356754384dcdd0"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-v592-xf75-856p",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-26240 for GHSA-v592-xf75-856p