### PR TITLE
Add CVE-2020-26241 for GHSA-69v6-xc2j-r2jf

### DIFF
--- a/2020/26xxx/CVE-2020-26241.json
+++ b/2020/26xxx/CVE-2020-26241.json
@@ -1,18 +1,88 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-26241",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Shallow copy bug in geth"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "go-ethereum",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 1.9.7, < 1.9.17"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ethereum"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Go Ethereum, or \"Geth\", is the official Golang implementation of the Ethereum protocol.\n\nThis is a Consensus vulnerability in Geth before version 1.9.17 which can be used to cause a chain-split where vulnerable nodes reject the canonical chain. \n\nGeth's pre-compiled dataCopy (at 0x00...04) contract did a shallow copy on invocation. An attacker could deploy a contract that writes X to an EVM memory region R, then calls 0x00..04 with R as an argument, then overwrites R to Y, and finally invokes the RETURNDATACOPY opcode.\n\nWhen this contract is invoked, a consensus-compliant node would push X on the EVM stack, whereas Geth would push Y.\n  \nThis is fixed in version 1.9.17."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-682: Incorrect Calculation"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-69v6-xc2j-r2jf",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-69v6-xc2j-r2jf"
+            },
+            {
+                "name": "https://blog.ethereum.org/2020/11/12/geth_security_release/",
+                "refsource": "MISC",
+                "url": "https://blog.ethereum.org/2020/11/12/geth_security_release/"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-69v6-xc2j-r2jf",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-26241 for GHSA-69v6-xc2j-r2jf