### PR TITLE
Add CVE-2020-26245 for GHSA-4v2w-h9jm-mqjg

### DIFF
--- a/2020/26xxx/CVE-2020-26245.json
+++ b/2020/26xxx/CVE-2020-26245.json
@@ -1,18 +1,96 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-26245",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Prototype Pollution leading to Command Injection in systeminformation"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "systeminformation",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 4.30.5"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "sebhildebrandt"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "npm package systeminformation before version 4.30.5 is vulnerable to Prototype Pollution leading to Command Injection. The issue was fixed with a rewrite of shell sanitations to avoid prototyper pollution problems.\nThe issue is fixed in version 4.30.5. If you cannot upgrade, be sure to check or sanitize service parameter strings that are passed to si.inetChecksite()."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 8.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:L/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "{\"CWE-78\":\"Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')\"}"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "{\"CWE-471\":\"Modification of Assumed-Immutable Data (MAID)\"}"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/sebhildebrandt/systeminformation/security/advisories/GHSA-4v2w-h9jm-mqjg",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/sebhildebrandt/systeminformation/security/advisories/GHSA-4v2w-h9jm-mqjg"
+            },
+            {
+                "name": "https://github.com/sebhildebrandt/systeminformation/commit/8113ff0e87b2f422a5756c48f1057575e73af016",
+                "refsource": "MISC",
+                "url": "https://github.com/sebhildebrandt/systeminformation/commit/8113ff0e87b2f422a5756c48f1057575e73af016"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-4v2w-h9jm-mqjg",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-26245 for GHSA-4v2w-h9jm-mqjg