### PR TITLE
CVE-2020-27218

### DIFF
--- a/2020/27xxx/CVE-2020-27218.json
+++ b/2020/27xxx/CVE-2020-27218.json
@@ -4,14 +4,69 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2020-27218",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security@eclipse.org",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "The Eclipse Foundation",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Eclipse Jetty",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "9.4.0.RC0 to 9.4.34.v20201102"
+                                        },
+                                        {
+                                            "version_value": "10.0.0.alpha0 to 10.0.0.beta2"
+                                        },
+                                        {
+                                            "version_value": "11.0.0.alpha0 to 11.0.0.beta2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Eclipse Jetty version 9.4.0.RC0 to 9.4.34.v20201102, 10.0.0.alpha0 to 10.0.0.beta2, and 11.0.0.alpha0 to 11.0.0.beta2, if GZIP request body inflation is enabled and requests from different clients are multiplexed onto a single connection, and if an attacker can send a request with a body that is received entirely but not consumed by the application, then a subsequent request on the same connection will see that body prepended to its body. The attacker will not see any data but may inject data into the body of the subsequent request."
+            }
+        ]
+    },
+        "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-226: Sensitive Information in Resource Not Removed Before Reuse"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=568892",
+                "refsource": "CONFIRM",
+                "url": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=568892"
+            },
+            {
+                "name": "https://github.com/eclipse/jetty.project/security/advisories/GHSA-86wm-rrjm-8wh8",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/eclipse/jetty.project/security/advisories/GHSA-86wm-rrjm-8wh8"
             }
         ]
     }


### PR DESCRIPTION
Signed-off-by: Wayne Beaton <wayne.beaton@eclipse-foundation.org>