### PR TITLE
Add CVE-2020-26264 for GHSA-r33q-22hv-j29q

### DIFF
--- a/2020/26xxx/CVE-2020-26264.json
+++ b/2020/26xxx/CVE-2020-26264.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-26264",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "LES Server DoS via GetProofsV2"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "go-ethereum",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.9.25"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ethereum"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Go Ethereum, or \"Geth\", is the official Golang implementation of the Ethereum protocol. In Geth before version 1.9.25 a denial-of-service vulnerability can make a LES server crash via malicious GetProofsV2 request from a connected LES client.\n\nThis vulnerability only concerns users explicitly enabling les server; disabling les prevents the exploit. \n\nThe vulnerability was patched in version 1.9.25."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-400 Uncontrolled Resource Consumption"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-r33q-22hv-j29q",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-r33q-22hv-j29q"
+            },
+            {
+                "name": "https://github.com/ethereum/go-ethereum/pull/21896",
+                "refsource": "MISC",
+                "url": "https://github.com/ethereum/go-ethereum/pull/21896"
+            },
+            {
+                "name": "https://github.com/ethereum/go-ethereum/commit/bddd103a9f0af27ef533f04e06ea429cf76b6d46",
+                "refsource": "MISC",
+                "url": "https://github.com/ethereum/go-ethereum/commit/bddd103a9f0af27ef533f04e06ea429cf76b6d46"
+            },
+            {
+                "name": "https://github.com/ethereum/go-ethereum/releases/tag/v1.9.25",
+                "refsource": "MISC",
+                "url": "https://github.com/ethereum/go-ethereum/releases/tag/v1.9.25"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-r33q-22hv-j29q",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-26264 for GHSA-r33q-22hv-j29q