### PR TITLE
Add CVE-2020-26290 for GHSA-m9hp-7r99-94h5

### DIFF
--- a/2020/26xxx/CVE-2020-26290.json
+++ b/2020/26xxx/CVE-2020-26290.json
@@ -1,18 +1,118 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-26290",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Critical security issues in XML encoding in Dex"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "dex",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 2.27.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "dexidp"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Dex is a federated OpenID Connect provider written in Go. In Dex before version 2.27.0 there is a critical set of vulnerabilities which impacts users leveraging the SAML connector.\nThe vulnerabilities enables potential signature bypass due to issues with XML encoding in the underlying Go library.\nThe vulnerabilities have been addressed in version 2.27.0 by using the xml-roundtrip-validator from Mattermost (see related references)."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 9.3,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-347: Improper Verification of Cryptographic Signature"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/dexidp/dex/security/advisories/GHSA-m9hp-7r99-94h5",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/dexidp/dex/security/advisories/GHSA-m9hp-7r99-94h5"
+            },
+            {
+                "name": "https://github.com/russellhaering/goxmldsig/security/advisories/GHSA-q547-gmf8-8jr7",
+                "refsource": "MISC",
+                "url": "https://github.com/russellhaering/goxmldsig/security/advisories/GHSA-q547-gmf8-8jr7"
+            },
+            {
+                "name": "https://github.com/dexidp/dex/commit/324b1c886b407594196113a3dbddebe38eecd4e8",
+                "refsource": "MISC",
+                "url": "https://github.com/dexidp/dex/commit/324b1c886b407594196113a3dbddebe38eecd4e8"
+            },
+            {
+                "name": "https://github.com/dexidp/dex/releases/tag/v2.27.0",
+                "refsource": "MISC",
+                "url": "https://github.com/dexidp/dex/releases/tag/v2.27.0"
+            },
+            {
+                "name": "https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-attributes.md",
+                "refsource": "MISC",
+                "url": "https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-attributes.md"
+            },
+            {
+                "name": "https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-directives.md",
+                "refsource": "MISC",
+                "url": "https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-directives.md"
+            },
+            {
+                "name": "https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-elements.md",
+                "refsource": "MISC",
+                "url": "https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-elements.md"
+            },
+            {
+                "name": "https://mattermost.com/blog/coordinated-disclosure-go-xml-vulnerabilities/",
+                "refsource": "MISC",
+                "url": "https://mattermost.com/blog/coordinated-disclosure-go-xml-vulnerabilities/"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-m9hp-7r99-94h5",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-26290 for GHSA-m9hp-7r99-94h5