### PR TITLE
Add CVE-2020-26247 for GHSA-vr8q-g5c7-m54m

### DIFF
--- a/2020/26xxx/CVE-2020-26247.json
+++ b/2020/26xxx/CVE-2020-26247.json
@@ -1,18 +1,103 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-26247",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "XXE in Nokogiri"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "nokogiri",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.11.0.rc4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "sparklemotion"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Nokogiri is a Rubygem providing HTML, XML, SAX, and Reader parsers with XPath and CSS selector support. In Nokogiri before version 1.11.0.rc4 there is an XXE vulnerability.\n\nXML Schemas parsed by Nokogiri::XML::Schema are trusted by default, allowing external resources to be accessed over the network, potentially enabling XXE or SSRF attacks.\n\nThis behavior is counter to the security policy followed by Nokogiri maintainers, which is to treat all input as untrusted by default whenever possible.\n\nThis is fixed in Nokogiri version 1.11.0.rc4."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 2.6,
+            "baseSeverity": "LOW",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-611: Improper Restriction of XML External Entity Reference"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m"
+            },
+            {
+                "name": "https://rubygems.org/gems/nokogiri",
+                "refsource": "MISC",
+                "url": "https://rubygems.org/gems/nokogiri"
+            },
+            {
+                "name": "https://hackerone.com/reports/747489",
+                "refsource": "MISC",
+                "url": "https://hackerone.com/reports/747489"
+            },
+            {
+                "name": "https://github.com/sparklemotion/nokogiri/releases/tag/v1.11.0.rc4",
+                "refsource": "MISC",
+                "url": "https://github.com/sparklemotion/nokogiri/releases/tag/v1.11.0.rc4"
+            },
+            {
+                "name": "https://github.com/sparklemotion/nokogiri/commit/9c87439d9afa14a365ff13e73adc809cb2c3d97b",
+                "refsource": "MISC",
+                "url": "https://github.com/sparklemotion/nokogiri/commit/9c87439d9afa14a365ff13e73adc809cb2c3d97b"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-vr8q-g5c7-m54m",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-26247 for GHSA-vr8q-g5c7-m54m