### PR TITLE
Add CVE-2020-26294 for GHSA-gv2h-gf8m-r68j

### DIFF
--- a/2020/26xxx/CVE-2020-26294.json
+++ b/2020/26xxx/CVE-2020-26294.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-26294",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Exposure of server configuration"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "compiler",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.6.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "go-vela"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Vela is a Pipeline Automation (CI/CD) framework built on Linux container technology written in Golang. In Vela compiler before version 0.6.1 there is a vulnerability which allows exposure of server configuration. It impacts all users of Vela.\n\nAn attacker can use Sprig's `env` function to retrieve configuration information, see referenced GHSA for an example.\n\nThis has been fixed in version 0.6.1.  In addition to upgrading, it is recommended to rotate all secrets.\n"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.4,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-78 OS Command Injection"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/go-vela/compiler/security/advisories/GHSA-gv2h-gf8m-r68j",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/go-vela/compiler/security/advisories/GHSA-gv2h-gf8m-r68j"
+            },
+            {
+                "name": "https://github.com/go-vela/compiler/commit/f1ace5f8a05c95c4d02264556e38a959ee2d9bda",
+                "refsource": "MISC",
+                "url": "https://github.com/go-vela/compiler/commit/f1ace5f8a05c95c4d02264556e38a959ee2d9bda"
+            },
+            {
+                "name": "https://pkg.go.dev/github.com/go-vela/compiler/compiler",
+                "refsource": "MISC",
+                "url": "https://pkg.go.dev/github.com/go-vela/compiler/compiler"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-gv2h-gf8m-r68j",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-26294 for GHSA-gv2h-gf8m-r68j