### PR TITLE
Add CVE-2020-26297 for GHSA-gx5w-rrhp-f436

### DIFF
--- a/2020/26xxx/CVE-2020-26297.json
+++ b/2020/26xxx/CVE-2020-26297.json
@@ -1,18 +1,103 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-26297",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "XSS in mdBook's search page"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "mdBook",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.4.5"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "rust-lang"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "mdBook is a utility to create modern online books from Markdown files and is written in Rust. In mdBook before version 0.4.5, there is a vulnerability affecting the search feature of mdBook, which could allow an attacker to execute arbitrary JavaScript code on the page.\n\nThe search feature of mdBook (introduced in version 0.1.4) was affected by a cross site scripting vulnerability that allowed an attacker to execute arbitrary JavaScript code on an user's browser by tricking the user into typing a malicious search query, or tricking the user into clicking a link to the search page with the malicious search query prefilled.\n\nmdBook 0.4.5 fixes the vulnerability by properly escaping the search query.\n\nOwners of websites built with mdBook have to upgrade to mdBook 0.4.5 or greater and rebuild their website contents with it."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 8.2,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79 Cross-site Scripting (XSS)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/rust-lang/mdBook/security/advisories/GHSA-gx5w-rrhp-f436",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/rust-lang/mdBook/security/advisories/GHSA-gx5w-rrhp-f436"
+            },
+            {
+                "name": "https://groups.google.com/g/rustlang-security-announcements/c/3-sO6of29O0",
+                "refsource": "MISC",
+                "url": "https://groups.google.com/g/rustlang-security-announcements/c/3-sO6of29O0"
+            },
+            {
+                "name": "https://crates.io/crates/mdbook",
+                "refsource": "MISC",
+                "url": "https://crates.io/crates/mdbook"
+            },
+            {
+                "name": "https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-045",
+                "refsource": "MISC",
+                "url": "https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-045"
+            },
+            {
+                "name": "https://github.com/rust-lang/mdBook/commit/32abeef088e98327ca0dfccdad92e84afa9d2e9b",
+                "refsource": "MISC",
+                "url": "https://github.com/rust-lang/mdBook/commit/32abeef088e98327ca0dfccdad92e84afa9d2e9b"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-gx5w-rrhp-f436",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-26297 for GHSA-gx5w-rrhp-f436