### PR TITLE
CVE-2020-5146 and CVE-2020-5147 submission

### DIFF
--- a/2020/5xxx/CVE-2020-5146.json
+++ b/2020/5xxx/CVE-2020-5146.json
@@ -1,18 +1,62 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-5146",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "psirt@sonicwall.com",
+    "ID": "CVE-2020-5146",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "SMA100",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "10.2.0.2-20sv and earlier"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "SonicWall"
+        }
+      ]
     }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "A vulnerability in SonicWall SMA100 appliance allow an authenticated management-user to perform OS command injection using HTTP POST parameters. This vulnerability affected SMA100 Appliance version 10.2.0.2-20sv and earlier."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2020-0022",
+        "refsource": "CONFIRM",
+        "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2020-0022"
+      }
+    ]
+  }
 }

--- a/2020/5xxx/CVE-2020-5147.json
+++ b/2020/5xxx/CVE-2020-5147.json
@@ -1,18 +1,62 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-5147",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "psirt@sonicwall.com",
+    "ID": "CVE-2020-5147",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "SonicWall NetExtender",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "10.2.300 and earlier"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "SonicWall"
+        }
+      ]
     }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "SonicWall NetExtender Windows client vulnerable to unquoted service path vulnerability, this allows a local attacker to gain elevated privileges in the host operating system. This vulnerability impact SonicWall NetExtender Windows client version 10.2.300 and earlier."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-428: Unquoted Search Path or Element"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2020-0023",
+        "refsource": "CONFIRM",
+        "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2020-0023"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Submitting December 2020 two CVEs CVE-2020-5146 and CVE-2020-5147 related to SMA100 and NetExtender SonicWall products.