### PR TITLE
Updated CVSS for CVE-2020-26230

### DIFF
--- a/2020/26xxx/CVE-2020-26230.json
+++ b/2020/26xxx/CVE-2020-26230.json
@@ -47,17 +47,17 @@
     },
     "impact": {
         "cvss": {
-            "attackComplexity": "HIGH",
-            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "attackVector": "ADJACENT_NETWORK",
             "availabilityImpact": "NONE",
-            "baseScore": 5.3,
-            "baseSeverity": "MEDIUM",
+            "baseScore": 7.4,
+            "baseSeverity": "HIGH",
             "confidentialityImpact": "HIGH",
             "integrityImpact": "NONE",
             "privilegesRequired": "NONE",
-            "scope": "UNCHANGED",
-            "userInteraction": "REQUIRED",
-            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
             "version": "3.1"
         }
     },


### PR DESCRIPTION
We received a request from the maintainer to update the CVSS for CVE-2020-26230 to `CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N` which is done with this change