### PR TITLE
Add CVE-2021-21272 for GHSA-g5v4-5x39-vwhx

### DIFF
--- a/2021/21xxx/CVE-2021-21272.json
+++ b/2021/21xxx/CVE-2021-21272.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-21272",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "zip slip in ORAS"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "oras",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 0.4.0, < 0.9.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "deislabs"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "ORAS is open source software which enables a way to push OCI Artifacts to OCI Conformant registries. ORAS is both a CLI for initial testing and a Go Module.\n\nIn ORAS from version 0.4.0 and before version 0.9.0, there is a \"zip-slip\" vulnerability.\n\nThe directory support feature allows the downloaded gzipped tarballs to be automatically extracted to the user-specified directory where the tarball can have symbolic links and hard links.\n\nA well-crafted tarball or tarballs allow malicious artifact providers linking, writing, or overwriting specific files on the host filesystem outside of the user-specified directory unexpectedly with the same permissions as the user who runs `oras pull`. \n\nUsers of the affected versions are impacted if they are `oras` CLI users who runs `oras pull`, or if they are Go programs, which invoke `github.com/deislabs/oras/pkg/content.FileStore`.\n\nThe problem has been fixed in version 0.9.0.\n\nFor `oras` CLI users, there is no workarounds other than pulling from a trusted artifact provider.\n\nFor `oras` package users, the workaround is to not use `github.com/deislabs/oras/pkg/content.FileStore`, and use other content stores instead, or pull from a trusted artifact provider."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.7,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/deislabs/oras/security/advisories/GHSA-g5v4-5x39-vwhx",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/deislabs/oras/security/advisories/GHSA-g5v4-5x39-vwhx"
+            },
+            {
+                "name": "https://github.com/deislabs/oras/commit/96cd90423303f1bb42bd043cb4c36085e6e91e8e",
+                "refsource": "MISC",
+                "url": "https://github.com/deislabs/oras/commit/96cd90423303f1bb42bd043cb4c36085e6e91e8e"
+            },
+            {
+                "name": "https://github.com/deislabs/oras/releases/tag/v0.9.0",
+                "refsource": "MISC",
+                "url": "https://github.com/deislabs/oras/releases/tag/v0.9.0"
+            },
+            {
+                "name": "https://pkg.go.dev/github.com/deislabs/oras/pkg/oras",
+                "refsource": "MISC",
+                "url": "https://pkg.go.dev/github.com/deislabs/oras/pkg/oras"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-g5v4-5x39-vwhx",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-21272 for GHSA-g5v4-5x39-vwhx