### PR TITLE
Correct the version impacted to be exactly 1.9.0 

### DIFF
--- a/2021/3xxx/CVE-2021-3345.json
+++ b/2021/3xxx/CVE-2021-3345.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "_gcry_md_block_write in cipher/hash-common.c in Libgcrypt before 1.9.1 has a heap-based buffer overflow when the digest final function sets a large count value."
+                "value": "_gcry_md_block_write in cipher/hash-common.c in Libgcrypt version 1.9.0 has a heap-based buffer overflow when the digest final function sets a large count value. It is recommended to upgrade to 1.9.1 or later."
             }
         ]
     },


### PR DESCRIPTION
As per linked references, only 1.9.0 is impacted

https://lists.gnupg.org/pipermail/gnupg-announce/2021q1/000455.html
https://lists.gnupg.org/pipermail/gnupg-announce/2021q1/000456.html