### PR TITLE
Update to CVE-2020-27222

### DIFF
--- a/2020/27xxx/CVE-2020-27222.json
+++ b/2020/27xxx/CVE-2020-27222.json
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In Eclipse Californium version 2.3.0 to 2.6.0, the certificate based (x509 and RPK) DTLS handshakes accidentally fails, because it sticks to a wrong internal state. That wrong internal state is set by a previous certificate based DTLS handshakes failure with TLS parameter mismatch. The server must be restarted to recover this. This allow clients to force a DoS."
+                "value": "In Eclipse Californium version 2.3.0 to 2.6.0, the certificate based (x509 and RPK) DTLS handshakes accidentally fails, because the DTLS server side sticks to a wrong internal state. That wrong internal state is set by a previous certificate based DTLS handshake failure with TLS parameter mismatch. The DTLS server side must be restarted to recover this. This allow clients to force a DoS."
             }
         ]
     },


### PR DESCRIPTION
Signed-off-by: Wayne Beaton <wayne.beaton@eclipse-foundation.org>