### PR TITLE
Add CVE-2021-21288 for GHSA-fwcm-636p-68r5

### DIFF
--- a/2021/21xxx/CVE-2021-21288.json
+++ b/2021/21xxx/CVE-2021-21288.json
@@ -1,18 +1,106 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-21288",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Server-side request forgery in CarrierWave"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "carrierwave",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.3.2"
+                                        },
+                                        {
+                                            "version_value": ">= 2.0.0, < 2.1.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "carrierwaveuploader"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "CarrierWave is an open-source RubyGem which provides a simple and flexible way to upload files from Ruby applications. In CarrierWave before versions 1.3.2 and 2.1.1 the download feature has an SSRF vulnerability, allowing attacks to provide DNS entries or IP addresses that are intended for internal use and gather information about the Intranet infrastructure of the platform. This is fixed in versions 1.3.2 and 2.1.1."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-918: Server-Side Request Forgery (SSRF)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-fwcm-636p-68r5",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-fwcm-636p-68r5"
+            },
+            {
+                "name": "https://rubygems.org/gems/carrierwave/",
+                "refsource": "MISC",
+                "url": "https://rubygems.org/gems/carrierwave/"
+            },
+            {
+                "name": "https://github.com/carrierwaveuploader/carrierwave/commit/012702eb3ba1663452aa025831caa304d1a665c0",
+                "refsource": "MISC",
+                "url": "https://github.com/carrierwaveuploader/carrierwave/commit/012702eb3ba1663452aa025831caa304d1a665c0"
+            },
+            {
+                "name": "https://github.com/carrierwaveuploader/carrierwave/blob/master/CHANGELOG.md#132---2021-02-08",
+                "refsource": "MISC",
+                "url": "https://github.com/carrierwaveuploader/carrierwave/blob/master/CHANGELOG.md#132---2021-02-08"
+            },
+            {
+                "name": "https://github.com/carrierwaveuploader/carrierwave/blob/master/CHANGELOG.md#211---2021-02-08",
+                "refsource": "MISC",
+                "url": "https://github.com/carrierwaveuploader/carrierwave/blob/master/CHANGELOG.md#211---2021-02-08"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-fwcm-636p-68r5",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-21288 for GHSA-fwcm-636p-68r5