### PR TITLE
Add CVE-2021-21306 for GHSA-4r62-v4vq-hr96

### DIFF
--- a/2021/21xxx/CVE-2021-21306.json
+++ b/2021/21xxx/CVE-2021-21306.json
@@ -1,18 +1,103 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-21306",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Denial of Service in Marked"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "marked",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 1.1.1, < 2.0.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "markedjs"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Marked is an open-source markdown parser and compiler (npm package \"marked\").  In marked from version 1.1.1 and before version 2.0.0, there is a Regular expression Denial of Service vulnerability. This vulnerability can affect anyone who runs user generated code through marked.\n\nThis vulnerability is fixed in version 2.0.0."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "{\"CWE-400\":\"Uncontrolled Resource Consumption\"}"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/markedjs/marked/security/advisories/GHSA-4r62-v4vq-hr96",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/markedjs/marked/security/advisories/GHSA-4r62-v4vq-hr96"
+            },
+            {
+                "name": "https://github.com/markedjs/marked/issues/1927",
+                "refsource": "MISC",
+                "url": "https://github.com/markedjs/marked/issues/1927"
+            },
+            {
+                "name": "https://github.com/markedjs/marked/pull/1864",
+                "refsource": "MISC",
+                "url": "https://github.com/markedjs/marked/pull/1864"
+            },
+            {
+                "name": "https://github.com/markedjs/marked/commit/7293251c438e3ee968970f7609f1a27f9007bccd",
+                "refsource": "MISC",
+                "url": "https://github.com/markedjs/marked/commit/7293251c438e3ee968970f7609f1a27f9007bccd"
+            },
+            {
+                "name": "https://www.npmjs.com/package/marked",
+                "refsource": "MISC",
+                "url": "https://www.npmjs.com/package/marked"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-4r62-v4vq-hr96",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-21306 for GHSA-4r62-v4vq-hr96