### PR TITLE
ZDI assigns the following Foxit CVEs

### DIFF
--- a/2020/17xxx/CVE-2020-17418.json
+++ b/2020/17xxx/CVE-2020-17418.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17418",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17418",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of EZIX files. A crafted id in a channel element can trigger a write past the end of an allocated buffer. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11197."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1329/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17419.json
+++ b/2020/17xxx/CVE-2020-17419.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17419",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17419",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of NEF files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11192."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1330/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17420.json
+++ b/2020/17xxx/CVE-2020-17420.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17420",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17420",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of NEF files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-11193."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1331/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17421.json
+++ b/2020/17xxx/CVE-2020-17421.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17421",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17421",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of NEF files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11194."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1332/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17422.json
+++ b/2020/17xxx/CVE-2020-17422.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17422",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17422",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of EPS files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-11195."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1333/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17423.json
+++ b/2020/17xxx/CVE-2020-17423.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17423",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17423",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of ARW files. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a heap-based buffer. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11196."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-122: Heap-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1334/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17424.json
+++ b/2020/17xxx/CVE-2020-17424.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17424",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17424",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "10.0.0.35798"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Wen guang Jiao",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 10.0.0.35798. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of EZI files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11247."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1335/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17424.json
+++ b/2020/17xxx/CVE-2020-17424.json
@@ -15,7 +15,7 @@
                 "version": {
                   "version_data": [
                     {
-                      "version_value": "10.0.0.35798"
+                      "version_value": "3.6.6.922"
                     }
                   ]
                 }
@@ -35,7 +35,7 @@
     "description_data": [
       {
         "lang": "eng",
-        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 10.0.0.35798. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of EZI files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11247."
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of EZI files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11247."
       }
     ]
   },

--- a/2020/17xxx/CVE-2020-17425.json
+++ b/2020/17xxx/CVE-2020-17425.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17425",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17425",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of EPS files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11259."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1336/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17426.json
+++ b/2020/17xxx/CVE-2020-17426.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17426",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17426",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Anonymous",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of CR2 files. The issue results from the lack of proper validation of user-supplied data, which can result in a memory corruption condition. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11230."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-119: Improper Restriction of Operations within the Bounds of a Memory Buffer"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1337/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17427.json
+++ b/2020/17xxx/CVE-2020-17427.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17427",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17427",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the processing of NEF files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11334."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1338/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17428.json
+++ b/2020/17xxx/CVE-2020-17428.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17428",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17428",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of CMP files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-11336."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1339/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17429.json
+++ b/2020/17xxx/CVE-2020-17429.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17429",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17429",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the handling of CMP files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-11337."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1340/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17430.json
+++ b/2020/17xxx/CVE-2020-17430.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17430",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17430",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of CR2 files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11332."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1341/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17431.json
+++ b/2020/17xxx/CVE-2020-17431.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17431",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17431",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of CR2 files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11333."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1342/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17432.json
+++ b/2020/17xxx/CVE-2020-17432.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17432",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17432",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of CR2 files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-11335."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1343/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17433.json
+++ b/2020/17xxx/CVE-2020-17433.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17433",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17433",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of CMP files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-11356."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1344/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17434.json
+++ b/2020/17xxx/CVE-2020-17434.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17434",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17434",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of ARW files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-11357."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1345/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17435.json
+++ b/2020/17xxx/CVE-2020-17435.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17435",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17435",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of CR2 files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-11358."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1346/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/17xxx/CVE-2020-17436.json
+++ b/2020/17xxx/CVE-2020-17436.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-17436",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-17436",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of CMP files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-11432."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1347/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/27xxx/CVE-2020-27855.json
+++ b/2020/27xxx/CVE-2020-27855.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-27855",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-27855",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of SR2 files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-11433."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1348/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/27xxx/CVE-2020-27856.json
+++ b/2020/27xxx/CVE-2020-27856.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-27856",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-27856",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of CR2 files. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated structure. An attacker can leverage this in conjunction with other vulnerabilities to execute code in the context of the current process. Was ZDI-CAN-11434."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1349/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2020/27xxx/CVE-2020-27857.json
+++ b/2020/27xxx/CVE-2020-27857.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-27857",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2020-27857",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Studio Photo",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.6.6.922"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Mat Powell of Trend Micro Zero Day Initiative",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit Studio Photo 3.6.6.922. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of NEF files. The issue results from the lack of proper validation of user-supplied data, which can result in a write past the end of an allocated structure. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-11488."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-20-1350/"
+      },
+      {
+        "url": "https://www.foxitsoftware.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }


### PR DESCRIPTION
ZDI assigns the following Foxit CVEs:

M  2020/17xxx/CVE-2020-17418.json
M  2020/17xxx/CVE-2020-17419.json
M  2020/17xxx/CVE-2020-17420.json
M  2020/17xxx/CVE-2020-17421.json
M  2020/17xxx/CVE-2020-17422.json
M  2020/17xxx/CVE-2020-17423.json
M  2020/17xxx/CVE-2020-17424.json
M  2020/17xxx/CVE-2020-17425.json
M  2020/17xxx/CVE-2020-17426.json
M  2020/17xxx/CVE-2020-17427.json
M  2020/17xxx/CVE-2020-17428.json
M  2020/17xxx/CVE-2020-17429.json
M  2020/17xxx/CVE-2020-17430.json
M  2020/17xxx/CVE-2020-17431.json
M  2020/17xxx/CVE-2020-17432.json
M  2020/17xxx/CVE-2020-17433.json
M  2020/17xxx/CVE-2020-17434.json
M  2020/17xxx/CVE-2020-17435.json
M  2020/17xxx/CVE-2020-17436.json
M  2020/27xxx/CVE-2020-27855.json
M  2020/27xxx/CVE-2020-27856.json
M  2020/27xxx/CVE-2020-27857.json