### PR TITLE
Update CVE-2020-11979 with additional reference and CWE

### DIFF
--- a/2020/11xxx/CVE-2020-11979.json
+++ b/2020/11xxx/CVE-2020-11979.json
@@ -1,17 +1,13 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
-        "ID": "CVE-2020-11979",
         "ASSIGNER": "security@apache.org",
+        "ID": "CVE-2020-11979",
         "STATE": "PUBLIC"
     },
     "affects": {
         "vendor": {
             "vendor_data": [
                 {
-                    "vendor_name": "n/a",
                     "product": {
                         "product_data": [
                             {
@@ -25,10 +21,22 @@
                                 }
                             }
                         ]
-                    }
+                    },
+                    "vendor_name": "n/a"
                 }
             ]
         }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "As mitigation for CVE-2020-1945 Apache Ant 1.10.8 changed the permissions of temporary files it created so that only the current user was allowed to access them. Unfortunately the fixcrlf task deleted the temporary file and created a new one without said protection, effectively nullifying the effort. This would still allow an attacker to inject modified source files into the build process."
+            }
+        ]
     },
     "problemtype": {
         "problemtype_data": [
@@ -39,73 +47,78 @@
                         "value": "insecure temporary file vulnerability"
                     }
                 ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-379 Creation of Temporary File in Directory with Incorrect Permissions"
+                    }
+                ]
             }
         ]
     },
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
                 "name": "https://lists.apache.org/thread.html/rc3c8ef9724b5b1e171529b47f4b35cb7920edfb6e917fa21eb6c64ea%40%3Cdev.ant.apache.org%3E",
+                "refsource": "MISC",
                 "url": "https://lists.apache.org/thread.html/rc3c8ef9724b5b1e171529b47f4b35cb7920edfb6e917fa21eb6c64ea%40%3Cdev.ant.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-dev] 20201006 [jira] [Commented] (RAT-274) Update to at least Ant 1.10.8/1.9.15 in order to fix CVE-2020-11979",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/r1dc8518dc99c42ecca5ff82d0d2de64cd5d3a4fa691eb9ee0304781e@%3Cdev.creadur.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-dev] 20201006 [jira] [Assigned] (RAT-274) Update to at least Ant 1.10.8/1.9.15 in order to fix CVE-2020-11979",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/r4ca33fad3fb39d130cda287d5a60727d9e706e6f2cf2339b95729490@%3Cdev.creadur.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-dev] 20201006 [jira] [Updated] (RAT-274) Update to at least Ant 1.10.8/1.9.15 in order to fix CVE-2020-11979",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/r107ea1b1a7a214bc72fe1a04207546ccef542146ae22952e1013b5cc@%3Cdev.creadur.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-dev] 20201006 [jira] [Updated] (RAT-274) Update to at least Ant 1.10.8/1.9.15 in order to fix CVE-2020-11979 / raise compiler level to JDK8",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/r2306b67f20c24942b872b0a41fbdc9330e8467388158bcd19c1094e0@%3Cdev.creadur.apache.org%3E"
             },
             {
-                "refsource": "MLIST",
                 "name": "[creadur-dev] 20201006 [jira] [Resolved] (RAT-274) Update to at least Ant 1.10.8/1.9.15 in order to fix CVE-2020-11979 / raise compiler level to JDK8",
+                "refsource": "MLIST",
                 "url": "https://lists.apache.org/thread.html/r5e1cdd79f019162f76414708b2092acad0a6703d666d72d717319305@%3Cdev.creadur.apache.org%3E"
             },
             {
-                "refsource": "FEDORA",
                 "name": "FEDORA-2020-2640aa4e19",
+                "refsource": "FEDORA",
                 "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/U3NRQQ7ECII4ZNGW7GBC225LVYMPQEKB/"
             },
             {
-                "refsource": "FEDORA",
                 "name": "FEDORA-2020-92b1d001b3",
+                "refsource": "FEDORA",
                 "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/AALW42FWNQ35F7KB3JVRC6NBVV7AAYYI/"
             },
             {
-                "refsource": "FEDORA",
                 "name": "FEDORA-2020-3ce0f55bc5",
+                "refsource": "FEDORA",
                 "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DYBRN5C2RW7JRY75IB7Q7ZVKZCHWAQWS/"
             },
             {
-                "refsource": "GENTOO",
                 "name": "GLSA-202011-18",
+                "refsource": "GENTOO",
                 "url": "https://security.gentoo.org/glsa/202011-18"
             },
             {
-                "url": "https://www.oracle.com/security-alerts/cpujan2021.html",
+                "name": "https://www.oracle.com/security-alerts/cpujan2021.html",
                 "refsource": "MISC",
-                "name": "https://www.oracle.com/security-alerts/cpujan2021.html"
-            }
-        ]
-    },
-    "description": {
-        "description_data": [
+                "url": "https://www.oracle.com/security-alerts/cpujan2021.html"
+            },
             {
-                "lang": "eng",
-                "value": "As mitigation for CVE-2020-1945 Apache Ant 1.10.8 changed the permissions of temporary files it created so that only the current user was allowed to access them. Unfortunately the fixcrlf task deleted the temporary file and created a new one without said protection, effectively nullifying the effort. This would still allow an attacker to inject modified source files into the build process."
+                "name": "https://github.com/gradle/gradle/security/advisories/GHSA-j45w-qrgf-25vm",
+                "refsource": "MISC",
+                "url": "https://github.com/gradle/gradle/security/advisories/GHSA-j45w-qrgf-25vm"
             }
         ]
     }


### PR DESCRIPTION
❗ This is a new kind of update from GitHub CNA ❗ 

In this update GitHub CNA is adding a reference and adding a CWE to a CVE that was submitted by a different CNA (Apache Foundation).  If we should not be doing this, then please close this PR and simply let us know.

This is being done at the request of a maintainer whom would like their GitHub advisory referenced from the CVE.

The changes in here are:
- Add reference to https://github.com/gradle/gradle/security/advisories/GHSA-j45w-qrgf-25vm.  This is referenced because the insecure Ant dependency that is is CVE-2020-11979 was present in Gradle, but was upgraded and this advisory was made.
- Add CWE-379 
