### PR TITLE
Update affected version info for CVE-2020-28852

### DIFF
--- a/2020/28xxx/CVE-2020-28852.json
+++ b/2020/28xxx/CVE-2020-28852.json
@@ -11,11 +11,12 @@
                     "product": {
                         "product_data": [
                             {
-                                "product_name": "n/a",
+                                "product_name": "golang.org/x/text",
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "n/a"
+                                            "version_affected": "<",
+                                            "version_value": "v0.3.5"
                                         }
                                     ]
                                 }
@@ -34,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In x/text in Go 1.15.4, a \"slice bounds out of range\" panic occurs in language.ParseAcceptLanguage while processing a BCP 47 tag. (x/text/language is supposed to be able to parse an HTTP Accept-Language header.)"
+                "value": "In x/text in Go before v0.3.5, a \"slice bounds out of range\" panic occurs in language.ParseAcceptLanguage while processing a BCP 47 tag. (x/text/language is supposed to be able to parse an HTTP Accept-Language header.)"
             }
         ]
     },


### PR DESCRIPTION
Source: https://github.com/golang/go/issues/42536#issuecomment-756807274