### PR TITLE
Fix the description for CVE-2021-23841

### DIFF
--- a/2021/23xxx/CVE-2021-23841.json
+++ b/2021/23xxx/CVE-2021-23841.json
@@ -4,7 +4,7 @@
         "DATE_PUBLIC": "2021-02-16",
         "ID": "CVE-2021-23841",
         "STATE": "PUBLIC",
-        "TITLE": "Integer overflow in CipherUpdate"
+        "TITLE": "Null pointer deref in X509_issuer_and_serial_hash()"
     },
     "affects": {
         "vendor": {
@@ -35,7 +35,7 @@
     "credit": [
         {
             "lang": "eng",
-            "value": "Paul Kehrer"
+            "value": "Tavis Ormandy (Google)"
         }
     ],
     "data_format": "MITRE",
@@ -45,15 +45,15 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x)."
+                "value": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x)."
             }
         ]
     },
     "impact": [
         {
             "lang": "eng",
-            "url": "https://www.openssl.org/policies/secpolicy.html#Low",
-            "value": "Low"
+            "url": "https://www.openssl.org/policies/secpolicy.html#Moderate",
+            "value": "Moderate"
         }
     ],
     "problemtype": {
@@ -62,7 +62,7 @@
                 "description": [
                     {
                         "lang": "eng",
-                        "value": "Overflow"
+                        "value": "NULL pointer dereference"
                     }
                 ]
             }
@@ -76,14 +76,14 @@
                 "url": "https://www.openssl.org/news/secadv/20210216.txt"
             },
             {
-                "name": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1",
+                "name": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=122a19ab48091c657f7cb1fb3af9fc07bd557bbf",
                 "refsource": "CONFIRM",
-                "url": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1"
+                "url": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=122a19ab48091c657f7cb1fb3af9fc07bd557bbf"
             },
             {
-                "name": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2",
+                "name": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807",
                 "refsource": "CONFIRM",
-                "url": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2"
+                "url": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807"
             }
         ]
     }


### PR DESCRIPTION
The descirption for CVE-2021-23841 inadvertently had the description for
a different CVE against it. This commit corrects things to have the
right description.