### PR TITLE
Update CVE-2020-27221

### DIFF
--- a/2020/27xxx/CVE-2020-27221.json
+++ b/2020/27xxx/CVE-2020-27221.json
@@ -17,9 +17,9 @@
                             {
                                 "product_name": "Eclipse OpenJ9",
                                 "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "All versions up to 0.23"
+                                    "version_data": [                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "0.23"
                                         }
                                     ]
                                 }
@@ -34,7 +34,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In Eclipse OpenJ9 up to version 0.23, there is potential for a stack-based buffer overflow when the virtual machine or JNI natives are converting from UTF-8 characters to platform encoding."
+                "value": "In Eclipse OpenJ9 up to and including version 0.23, there is potential for a stack-based buffer overflow when the virtual machine or JNI natives are converting from UTF-8 characters to platform encoding."
             }
         ]
     },


### PR DESCRIPTION
Signed-off-by: Wayne Beaton <wayne.beaton@eclipse-foundation.org>