### PR TITLE
Add CVE-2021-21352 for GHSA-43c9-rx4h-4gqq

### DIFF
--- a/2021/21xxx/CVE-2021-21352.json
+++ b/2021/21xxx/CVE-2021-21352.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-21352",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Predictable tokens used for password resets"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "timetracker",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.19.24.5415"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "anuko"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Anuko Time Tracker is an open source, web-based time tracking application written in PHP. In TimeTracker before version 1.19.24.5415 tokens used in password reset feature in Time Tracker are based on system time and, therefore, are predictable. This opens a window for brute force attacks to guess user tokens and, once successful, change user passwords, including that of a system administrator. This vulnerability is pathced in version 1.19.24.5415 (started to use more secure tokens) with an additional improvement in 1.19.24.5416 (limited an available window for brute force token guessing)."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.8,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-330: Use of Insufficiently Random Values"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/anuko/timetracker/security/advisories/GHSA-43c9-rx4h-4gqq",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/anuko/timetracker/security/advisories/GHSA-43c9-rx4h-4gqq"
+            },
+            {
+                "name": "https://github.com/anuko/timetracker/commit/40f3d9345adc20e6f28eb9f59e2489aff87fecf5",
+                "refsource": "MISC",
+                "url": "https://github.com/anuko/timetracker/commit/40f3d9345adc20e6f28eb9f59e2489aff87fecf5"
+            },
+            {
+                "name": "https://www.anuko.com/time-tracker/index.htm",
+                "refsource": "MISC",
+                "url": "https://www.anuko.com/time-tracker/index.htm"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-43c9-rx4h-4gqq",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-21352 for GHSA-43c9-rx4h-4gqq