### PR TITLE
Canonical CNA: add info for CVE-2021-3444/linux kernel

### DIFF
--- a/2021/3xxx/CVE-2021-3444.json
+++ b/2021/3xxx/CVE-2021-3444.json
@@ -1,18 +1,118 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2021-03-23T00:00:00.000Z",
         "ID": "CVE-2021-3444",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Linux kernel bpf verifier incorrect mod32 truncation"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "kernel",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "trunk",
+                                            "version_value": "5.12-rc1"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.11",
+                                            "version_value": "5.11.2"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.10",
+                                            "version_value": "5.10.19"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.4",
+                                            "version_value": "5.4.101"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Linux"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "De4dCr0w of 360 Alpha Lab"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "The bpf verifier in the Linux kernel did not properly handle mod32 destination register truncation when the source register was known to be 0. A local attacker with the ability to load bpf programs could use this gain out-of-bounds reads in kernel memory leading to information disclosure (kernel memory), and possibly out-of-bounds writes that could potentially lead to code execution. This issue was addressed in the upstream kernel in commit 9b00f1b78809 (\"bpf: Fix truncation handling for mod32 dst reg wrt zero\") and in Linux stable kernels 5.11.2, 5.10.19, and 5.4.101. "
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-681: Incorrect Conversion between Numeric Types"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9b00f1b78809"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://www.openwall.com/lists/oss-security/2021/03/23/2"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Apply or update to a kernel that contains the commit 9b00f1b78809 (\"bpf: Fix truncation handling for mod32 dst reg wrt zero\")."
+        }
+    ],
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
Signed-off-by: Steve Beattie <steve.beattie@canonical.com>