### PR TITLE
Add CVE-2020-26279 for GHSA-27pv-q55r-222g

### DIFF
--- a/2020/26xxx/CVE-2020-26279.json
+++ b/2020/26xxx/CVE-2020-26279.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-26279",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Path traversal"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "go-ipfs",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.8.0-rc1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ipfs"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "go-ipfs is an open-source golang implementation of IPFS which is a global, versioned, peer-to-peer filesystem.  In go-ipfs before version 0.8.0-rc1, it is possible for path traversal to occur with DAGs containing relative paths during retrieval. This can cause files to be overwritten, or written to incorrect output directories. The issue can only occur when a get is done on an affected DAG.  This is fixed in version 0.8.0-rc1. "
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.7,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-22 Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/ipfs/go-ipfs/security/advisories/GHSA-27pv-q55r-222g",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/ipfs/go-ipfs/security/advisories/GHSA-27pv-q55r-222g"
+            },
+            {
+                "name": "https://github.com/ipfs/go-ipfs/commit/b7ddba7fe47dee5b1760b8ffe897908417e577b2",
+                "refsource": "MISC",
+                "url": "https://github.com/ipfs/go-ipfs/commit/b7ddba7fe47dee5b1760b8ffe897908417e577b2"
+            },
+            {
+                "name": "https://github.com/whyrusleeping/tar-utils/commit/20a61371de5b51380bbdb0c7935b30b0625ac227",
+                "refsource": "MISC",
+                "url": "https://github.com/whyrusleeping/tar-utils/commit/20a61371de5b51380bbdb0c7935b30b0625ac227"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-27pv-q55r-222g",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-26279 for GHSA-27pv-q55r-222g