### PR TITLE
CVE-2021-28166

### DIFF
--- a/2021/28xxx/CVE-2021-28166.json
+++ b/2021/28xxx/CVE-2021-28166.json
@@ -4,14 +4,70 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2021-28166",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security@eclipse.org",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "The Eclipse Foundation",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Eclipse Mosquitto",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "2.0"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "2.0.9"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Eclipse Mosquitto version 2.0.0 to 2.0.9, if an authenticated client that had connected with MQTT v5 sent a crafted CONNACK message to the broker, a NULL pointer dereference would occur."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "baseScore": 6.0,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H/E:F/RL:O/RC:C",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-476: NULL Pointer Dereference"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=572608",
+                "refsource": "CONFIRM",
+                "url": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=572608"
             }
         ]
     }


### PR DESCRIPTION
Signed-off-by: Wayne Beaton <wayne.beaton@eclipse-foundation.org>