### PR TITLE
Updates CVE-2021-24125 with latest data

### DIFF
--- a/2021/24xxx/CVE-2021-24125.json
+++ b/2021/24xxx/CVE-2021-24125.json
@@ -3,7 +3,7 @@
         "ASSIGNER": "contact@wpscan.com",
         "ID": "CVE-2021-24125",
         "STATE": "PUBLIC",
-        "TITLE": "Contact Form Submissions <= 1.6.4 - Authenticated SQL Injection"
+        "TITLE": "Contact Form Submissions < 1.7.1 - Authenticated SQL Injection"
     },
     "affects": {
         "vendor": {
@@ -16,9 +16,9 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_affected": "<=",
-                                            "version_name": "1.6.4",
-                                            "version_value": "1.6.4"
+                                            "version_affected": "<",
+                                            "version_name": "1.7.1",
+                                            "version_value": "1.7.1"
                                         }
                                     ]
                                 }
@@ -43,7 +43,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Unvalidated input in the Contact Form Submissions WordPress plugin, versions 1.6.4 and before, could lead to SQL injection in the wpcf7_contact_form GET parameter when submitting a filter request as a high privilege user (admin+)"
+                "value": "Unvalidated input in the Contact Form Submissions WordPress plugin before 1.7.1, could lead to SQL injection in the wpcf7_contact_form GET parameter when submitting a filter request as a high privilege user (admin+)"
             }
         ]
     },
@@ -65,9 +65,9 @@
     "references": {
         "reference_data": [
             {
-                "refsource": "MISC",
-                "url": "https://wpscan.com/vulnerability/8591b3c9-b041-4ff5-b8d9-6f9f81041178",
-                "name": "https://wpscan.com/vulnerability/8591b3c9-b041-4ff5-b8d9-6f9f81041178"
+                "name": "https://wpscan.com/vulnerability/8591b3c9-b041-4ff5-b8d9-6f9f81041178",
+                "refsource": "CONFIRM",
+                "url": "https://wpscan.com/vulnerability/8591b3c9-b041-4ff5-b8d9-6f9f81041178"
             }
         ]
     },


### PR DESCRIPTION
The issue has been fixed, CVE data updated to reflect that.

One question: Why the references are duplicated in the CVE output ? https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-24125

There are two https://wpscan.com/vulnerability/8591b3c9-b041-4ff5-b8d9-6f9f81041178, one as MISC and one as URL