### PR TITLE
Update CVE-2021-21431 reference

### DIFF
--- a/2021/21xxx/CVE-2021-21431.json
+++ b/2021/21xxx/CVE-2021-21431.json
@@ -88,9 +88,9 @@
                 "url": "https://github.com/MirahezeBots/sopel-channelmgnt/security/advisories/GHSA-23c7-6444-399m"
             },
             {
-                "name": "https://github.com/MirahezeBots/sopel-channelmgnt/commit/643388365f28c5cc682254ab913c401f0e53260a",
+                "name": "https://github.com/MirahezeBots/sopel-channelmgnt/commit/7c96d400358221e59135f0a0be0744f3fad73856",
                 "refsource": "MISC",
-                "url": "https://github.com/MirahezeBots/sopel-channelmgnt/commit/643388365f28c5cc682254ab913c401f0e53260a"
+                "url": "https://github.com/MirahezeBots/sopel-channelmgnt/commit/7c96d400358221e59135f0a0be0744f3fad73856"
             }
         ]
     },


### PR DESCRIPTION
Update CVE-2021-21431 reference.  We got a request from the maintainer to link to a more direct fix commit rather than the one we had previously linked to