### PR TITLE
Canonical CNA - CVE-2021-3492 and CVE-2021-3493 submissions

### DIFF
--- a/2021/3xxx/CVE-2021-3492.json
+++ b/2021/3xxx/CVE-2021-3492.json
@@ -1,18 +1,118 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2021-04-15T00:00:00.000Z",
         "ID": "CVE-2021-3492",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Ubuntu linux kernel shiftfs file system double free vulnerability"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Linux kernel",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.8 kernel",
+                                            "version_value": "5.8.0-50.56"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.4 kernel",
+                                            "version_value": "5.4.0-72.80 "
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Ubuntu"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Vincent Dehors of Synactiv Digital Security"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Shiftfs, an out-of-tree stacking file system included in Ubuntu Linux kernels, did not properly handle faults occurring during copy_from_user() correctly. These could lead to either a double-free situation or memory not being freed at all. An attacker could use this to cause a denial of service (kernel memory exhaustion) or gain privileges via executing arbitrary code. AKA ZDI-CAN-13562."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-415: Double Free"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-401: Missing Release of Memory after Effective Lifetime"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://www.openwall.com/lists/oss-security/2021/04/16/2"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/commit/?id=8fee52ab9da87d82bc6de9ebb3480fff9b4d53e6"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/commit/?id=25c891a949bf918b59cbc6e4932015ba4c35c333"
+            },
+            {
+                "refsource": "UBUNTU",
+                "url": "https://ubuntu.com/security/notices/USN-4917-1"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }

--- a/2021/3xxx/CVE-2021-3493.json
+++ b/2021/3xxx/CVE-2021-3493.json
@@ -1,18 +1,127 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security@ubuntu.com",
+        "DATE_PUBLIC": "2021-04-15T00:00:00.000Z",
         "ID": "CVE-2021-3493",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "linux kernel",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.8 kernel",
+                                            "version_value": "5.8.0-50.56 "
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "5.4 kernel",
+                                            "version_value": " 5.4.0-72.80 "
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "4.15 kernel",
+                                            "version_value": "4.15.0-142.146 "
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "4.4 kernel",
+                                            "version_value": " 4.4.0-209.241"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Ubuntu"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "An independent security researcher reporting to the SSD Secure Disclosure program"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "The overlayfs implementation in the linux kernel did not properly validate with respect to user namespaces the setting of file capabilities on files in an underlying file system. Due to the combination of unprivileged user namespaces along with a patch carried in the Ubuntu kernel to allow unprivileged overlay mounts, an attacker could use this to gain elevated privileges."
             }
         ]
-    }
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-270: Privilege Context Switching Error"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "UBUNTU",
+                "url": "https://ubuntu.com/security/notices/USN-4917-1"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=7c03e2cda4a584cadc398e8f6641ca9988a39d52"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://www.openwall.com/lists/oss-security/2021/04/16/1"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Apply https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=7c03e2cda4a584cadc398e8f6641ca9988a39d52"
+        }
+    ],
+    "source": {
+        "discovery": "EXTERNAL"
+    },
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "Disable unprivileged user namespaces."
+        }
+    ]
 }


### PR DESCRIPTION
CVE-2021-3492 - Ubuntu shiftfs linux kernel double free code execution
CVE-2021-3493 - Ubuntu overlayfs linux kernel fs caps privilege escalation