### PR TITLE
Add CVE-2021-29483 for GHSA-jmc9-rv2f-g8vv

### DIFF
--- a/2021/29xxx/CVE-2021-29483.json
+++ b/2021/29xxx/CVE-2021-29483.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-29483",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "wikiconfig API leaked private config variables set through ManageWiki"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "ManageWiki",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< befb83c66f5b643e174897ea41a8a46679b26304"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "miraheze"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "ManageWiki is an extension to the MediaWiki project. The 'wikiconfig' API leaked the value of private configuration variables set through the ManageWiki variable to all users. This has been patched by https://github.com/miraheze/ManageWiki/compare/99f3b2c8af18...befb83c66f5b.patch. If you are unable to patch set `$wgAPIListModules['wikiconfig'] = 'ApiQueryDisabled';` or remove private config as a workaround."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9.4,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "{\"CWE-200\":\"Exposure of Sensitive Information to an Unauthorized Actor\"}"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/miraheze/ManageWiki/security/advisories/GHSA-jmc9-rv2f-g8vv",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/miraheze/ManageWiki/security/advisories/GHSA-jmc9-rv2f-g8vv"
+            },
+            {
+                "name": "https://github.com/miraheze/ManageWiki/commit/befb83c66f5b643e174897ea41a8a46679b26304",
+                "refsource": "MISC",
+                "url": "https://github.com/miraheze/ManageWiki/commit/befb83c66f5b643e174897ea41a8a46679b26304"
+            },
+            {
+                "name": "https://phabricator.miraheze.org/T7213",
+                "refsource": "MISC",
+                "url": "https://phabricator.miraheze.org/T7213"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-jmc9-rv2f-g8vv",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-29483 for GHSA-jmc9-rv2f-g8vv