### PR TITLE
Add CVE-2021-29499 for GHSA-4gh8-x3vv-phhg

### DIFF
--- a/2021/29xxx/CVE-2021-29499.json
+++ b/2021/29xxx/CVE-2021-29499.json
@@ -1,18 +1,83 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-29499",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Predictable SIF UUID Identifiers"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "sif",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "<= 1.2.2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "sylabs"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "SIF is an open source implementation of the Singularity Container Image Format. The `siftool new` command and func siftool.New() produce predictable UUID identifiers due to insecure randomness in the version of the `github.com/satori/go.uuid` module used as a dependency. A patch is available in version >= v1.2.3 of the module. Users are encouraged to upgrade. As a workaround, users passing CreateInfo struct should ensure the `ID` field is generated using a version of `github.com/satori/go.uuid` that is not vulnerable to this issue."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-330 Use of Insufficiently Random Values"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/sylabs/sif/security/advisories/GHSA-4gh8-x3vv-phhg",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/sylabs/sif/security/advisories/GHSA-4gh8-x3vv-phhg"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-4gh8-x3vv-phhg",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-29499 for GHSA-4gh8-x3vv-phhg