### PR TITLE
Add CVE-2021-29595 for GHSA-vf94-36g5-69v8

### DIFF
--- a/2021/29xxx/CVE-2021-29595.json
+++ b/2021/29xxx/CVE-2021-29595.json
@@ -1,18 +1,97 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-29595",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Division by zero in TFLite's implementation of `DepthToSpace`"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "tensorflow",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 2.1.4"
+                                        },
+                                        {
+                                            "version_value": ">= 2.2.0, < 2.2.3"
+                                        },
+                                        {
+                                            "version_value": ">= 2.3.0, < 2.3.3"
+                                        },
+                                        {
+                                            "version_value": ">= 2.4.0, < 2.4.2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "tensorflow"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "TensorFlow is an end-to-end open source platform for machine learning. The implementation of the `DepthToSpace` TFLite operator is vulnerable to a division by zero error(https://github.com/tensorflow/tensorflow/blob/0d45ea1ca641b21b73bcf9c00e0179cda284e7e7/tensorflow/lite/kernels/depth_to_space.cc#L63-L69). An attacker can craft a model such that `params->block_size` is 0. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "LOW",
+            "baseScore": 2.5,
+            "baseSeverity": "LOW",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-369: Divide By Zero"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vf94-36g5-69v8",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vf94-36g5-69v8"
+            },
+            {
+                "name": "https://github.com/tensorflow/tensorflow/commit/106d8f4fb89335a2c52d7c895b7a7485465ca8d9",
+                "refsource": "MISC",
+                "url": "https://github.com/tensorflow/tensorflow/commit/106d8f4fb89335a2c52d7c895b7a7485465ca8d9"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-vf94-36g5-69v8",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-29595 for GHSA-vf94-36g5-69v8