### PR TITLE
CVE-2021-28170

### DIFF
--- a/2021/28xxx/CVE-2021-28170.json
+++ b/2021/28xxx/CVE-2021-28170.json
@@ -4,14 +4,68 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2021-28170",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security@eclipse.org",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "The Eclipse Foundation",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jakarta Expression Language Implementation",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "3.0.3"
+                                        },
+                                        {
+                                            "version_affected": "?>",
+                                            "version_value": "3.0.3"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In the Jakarta Expression Language implementation 3.0.3 and earlier, a bug in the ELParserTokenManager enables invalid EL expressions to be evaluated as if they were valid."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-20: Improper Input Validation"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/eclipse-ee4j/el-ri/issues/155",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/eclipse-ee4j/el-ri/issues/155"
+            },
+            {
+                "name": "https://securitylab.github.com/advisories/GHSL-2020-021-jakarta-el/",
+                "refsource": "CONFIRM",
+                "url": "https://securitylab.github.com/advisories/GHSL-2020-021-jakarta-el/"
             }
         ]
     }


### PR DESCRIPTION
Signed-off-by: Wayne Beaton <wayne.beaton@eclipse-foundation.org>