### PR TITLE
Add CVE-2021-32654 for GHSA-jf9h-v24c-22g5

### DIFF
--- a/2021/32xxx/CVE-2021-32654.json
+++ b/2021/32xxx/CVE-2021-32654.json
@@ -1,18 +1,94 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-32654",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Attacker can obtain write access to any federated share/public link"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "security-advisories",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 19.0.11"
+                                        },
+                                        {
+                                            "version_value": ">= 20.0.0, < 20.0.10"
+                                        },
+                                        {
+                                            "version_value": ">= 21.0.0, < 21.0.2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "nextcloud"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Nextcloud Server is a Nextcloud package that handles data storage. In versions prior to 19.0.11, 20.0.10, and 21.0.2, an attacker is able to receive write/read privileges on any Federated File Share. Since public links can be added as federated file share, this can also be exploited on any public link. Users can upgrade to patched versions (19.0.11, 20.0.10 or 21.0.2) or, as a workaround, disable federated file sharing."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-639: Authorization Bypass Through User-Controlled Key"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/nextcloud/security-advisories/security/advisories/GHSA-jf9h-v24c-22g5",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/nextcloud/security-advisories/security/advisories/GHSA-jf9h-v24c-22g5"
+            },
+            {
+                "name": "https://hackerone.com/reports/1170024",
+                "refsource": "MISC",
+                "url": "https://hackerone.com/reports/1170024"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-jf9h-v24c-22g5",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-32654 for GHSA-jf9h-v24c-22g5