### PR TITLE
Add CVE-2021-31618 and note that after release of the CVE it was foun…

### DIFF
--- a/2021/31xxx/CVE-2021-31618.json
+++ b/2021/31xxx/CVE-2021-31618.json
@@ -2,7 +2,7 @@
     "CVE_data_meta": {
         "ASSIGNER": "security@apache.org",
         "ID": "CVE-2021-31618",
-        "STATE": "DRAFT",
+        "STATE": "PUBLIC",
         "TITLE": "NULL pointer dereference on specially crafted HTTP/2 request"
     },
     "affects": {

--- a/2021/31xxx/CVE-2021-31618.json
+++ b/2021/31xxx/CVE-2021-31618.json
@@ -1,18 +1,107 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security@apache.org",
         "ID": "CVE-2021-31618",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "DRAFT",
+        "TITLE": "NULL pointer dereference on specially crafted HTTP/2 request"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Apache HTTP Server",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "=",
+                                            "version_value": "2.4.47"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Apache Software Foundation"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Apache HTTP server would like to thank  LI ZHI XIN from NSFocus for reporting this."
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Apache HTTP Server protocol handler for the HTTP/2 protocol checks received request headers against the size limitations as configured for the server and used for the HTTP/1 protocol as well. On violation of these restrictions and HTTP response is sent to the client with a status code indicating why the request was rejected.\n\nThis rejection response was not fully initialised in the HTTP/2 protocol handler if the offending header was the very first one received or appeared in a a footer. This led to a NULL pointer dereference on initialised memory, crashing reliably the child process. Since such a triggering HTTP/2 request is easy to craft and submit, this can be exploited to DoS the server.\n\nThis issue affected  mod_http2 1.15.17 and Apache HTTP Server version 2.4.47 only. Apache HTTP Server 2.4.47 was never released."
             }
         ]
-    }
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": [
+        {
+            "other": "important"
+        }
+    ],
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-476 NULL Pointer Dereference"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "http://httpd.apache.org/security/vulnerabilities_24.html"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://seclists.org/oss-sec/2021/q2/206"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "UNKNOWN"
+    },
+    "timeline": [
+        {
+            "lang": "eng",
+            "time": "2021-04-22",
+            "value": "reported"
+        },
+        {
+            "lang": "eng",
+            "time": "--",
+            "value": "public"
+        },
+        {
+            "lang": "eng",
+            "time": "--",
+            "value": "2.4.48 released"
+        }
+    ],
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "On unpatched servers, the `h2` protocol can be disabled by removing it from the `Protocols` configuration. If the `h2` protocol is not enabled, the server is not affected by this vulnerability."
+        }
+    ]
 }

--- a/2021/31xxx/CVE-2021-31618.json
+++ b/2021/31xxx/CVE-2021-31618.json
@@ -81,23 +81,6 @@
     "source": {
         "discovery": "UNKNOWN"
     },
-    "timeline": [
-        {
-            "lang": "eng",
-            "time": "2021-04-22",
-            "value": "reported"
-        },
-        {
-            "lang": "eng",
-            "time": "--",
-            "value": "public"
-        },
-        {
-            "lang": "eng",
-            "time": "--",
-            "value": "2.4.48 released"
-        }
-    ],
     "work_around": [
         {
             "lang": "eng",


### PR DESCRIPTION
…d to only affect

2.4.47 (unreleased) but also the upstream mod_http2 project therefore not rejecting the CVE