### PR TITLE
Add CVE-2021-32568 for 1-pypi-tfx

### DIFF
--- a/2021/32xxx/CVE-2021-32568.json
+++ b/2021/32xxx/CVE-2021-32568.json
@@ -1,18 +1,92 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "jamie@418sec.com",
         "ID": "CVE-2021-32568",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Code Injection in tensorflow/tfx"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "tensorflow/tfx",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "1.0.0-rc1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Google"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Tensorflow Extended is vulnerable to YAML deserialization attacks caused via unsafe loading."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "PHYSICAL",
+            "availabilityImpact": "LOW",
+            "baseScore": 3.8,
+            "baseSeverity": "LOW",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:P/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-94: Improper Control of Generation of Code"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://huntr.dev/bounties/1-pypi-tfx",
+                "refsource": "CONFIRM",
+                "url": "https://huntr.dev/bounties/1-pypi-tfx"
+            },
+            {
+                "name": "https://github.com/tensorflow/tfx/commit/5741af596671fad5c0d74638961b30ecb6a8024c",
+                "refsource": "MISC",
+                "url": "https://github.com/tensorflow/tfx/commit/5741af596671fad5c0d74638961b30ecb6a8024c"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "1-pypi-tfx",
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
Add CVE-2021-32568 for [1-pypi-tfx](https://huntr.dev/bounties/1-pypi-tfx)