### PR TITLE
Initial Avaya June 2021 CVE Publication

### DIFF
--- a/2021/25xxx/CVE-2021-25649.json
+++ b/2021/25xxx/CVE-2021-25649.json
@@ -2,7 +2,7 @@
    "CVE_data_meta": {
       "ASSIGNER": "securityalerts@avaya.com",
       "ID": "CVE-2021-25649",
-      "STATE": "READY",
+      "STATE": "PUBLIC",
       "TITLE": "Avaya Utility Services Sensitive Information Disclosure Vulnerability"
    },
    "affects": {

--- a/2021/25xxx/CVE-2021-25649.json
+++ b/2021/25xxx/CVE-2021-25649.json
@@ -1,18 +1,87 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-25649",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta": {
+      "ASSIGNER": "securityalerts@avaya.com",
+      "ID": "CVE-2021-25649",
+      "STATE": "READY",
+      "TITLE": "Avaya Utility Services Sensitive Information Disclosure Vulnerability"
+   },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Avaya Aura Utility Services",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<=",
+                                 "version_name": "7.0.0.0",
+                                 "version_value": "7.1.3.8"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Avaya"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
+         {
+            "lang": "eng",
+            "value": "** UNSUPPORTED WHEN ASSIGNED **  An information disclosure vulnerability was discovered in the directory and file management of Avaya Aura Utility Services. This vulnerability may potentially allow any local user to access system functionality and configuration information that should only be available to a privileged user. Affects all 7.x versions of Avaya Aura Utility Services."
+         }
+      ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "NONE",
+         "baseScore": 4.9,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "HIGH",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N",
+         "version": "3.1"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "CWE-200\nCWE-378"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "CONFIRM",
+            "url": "https://support.avaya.com/css/P8/documents/101072728"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "N/A",
+      "defect": [
+         "PSST-1147"
+      ],
+      "discovery": "EXTERNAL"
+   }
 }

--- a/2021/25xxx/CVE-2021-25650.json
+++ b/2021/25xxx/CVE-2021-25650.json
@@ -1,18 +1,87 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-25650",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta": {
+      "ASSIGNER": "securityalerts@avaya.com",
+      "ID": "CVE-2021-25650",
+      "STATE": "READY",
+      "TITLE": "Avaya Aura Utility Services Privilege Escalation Vulnerability"
+   },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Avaya Aura Utility Services",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<=",
+                                 "version_name": "7.0.0.0",
+                                 "version_value": "7.1.3.8"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Avaya"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
+         {
+            "lang": "eng",
+            "value": "** UNSUPPORTED WHEN ASSIGNED ** A privilege escalation vulnerability was discovered in Avaya Aura Utility Services that may potentially allow a local user to execute specially crafted scripts as a privileged user. Affects all 7.x versions of Avaya Aura Utility Services."
+         }
+      ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "HIGH",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "NONE",
+         "baseScore": 7.7,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "HIGH",
+         "scope": "CHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:C/C:H/I:H/A:N",
+         "version": "3.1"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "CWE-250"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "CONFIRM",
+            "url": "https://support.avaya.com/css/P8/documents/101072728"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "N/A",
+      "defect": [
+         "PSST-1147"
+      ],
+      "discovery": "EXTERNAL"
+   }
 }

--- a/2021/25xxx/CVE-2021-25650.json
+++ b/2021/25xxx/CVE-2021-25650.json
@@ -2,7 +2,7 @@
    "CVE_data_meta": {
       "ASSIGNER": "securityalerts@avaya.com",
       "ID": "CVE-2021-25650",
-      "STATE": "READY",
+      "STATE": "PUBLIC",
       "TITLE": "Avaya Aura Utility Services Privilege Escalation Vulnerability"
    },
    "affects": {

--- a/2021/25xxx/CVE-2021-25651.json
+++ b/2021/25xxx/CVE-2021-25651.json
@@ -1,18 +1,87 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-25651",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta": {
+      "ASSIGNER": "securityalerts@avaya.com",
+      "ID": "CVE-2021-25651",
+      "STATE": "READY",
+      "TITLE": "Avaya Aura Utility Services Privilege Escalation Vulnerability"
+   },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Avaya Aura Utility Services",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<=",
+                                 "version_name": "7.0.0.0",
+                                 "version_value": "7.1.3.8"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Avaya"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
+         {
+            "lang": "eng",
+            "value": "** UNSUPPORTED WHEN ASSIGNED ** A privilege escalation vulnerability was discovered in Avaya Aura Utility Services that may potentially allow a local user to escalate privileges. Affects all 7.x versions of Avaya Aura Utility Services."
+         }
+      ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "HIGH",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 8,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "HIGH",
+         "scope": "CHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:C/C:H/I:H/A:H",
+         "version": "3.1"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "CWE-250"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "CONFIRM",
+            "url": "https://support.avaya.com/css/P8/documents/101072728"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "N/A",
+      "defect": [
+         "PSST-1147"
+      ],
+      "discovery": "EXTERNAL"
+   }
 }

--- a/2021/25xxx/CVE-2021-25651.json
+++ b/2021/25xxx/CVE-2021-25651.json
@@ -2,7 +2,7 @@
    "CVE_data_meta": {
       "ASSIGNER": "securityalerts@avaya.com",
       "ID": "CVE-2021-25651",
-      "STATE": "READY",
+      "STATE": "PUBLIC",
       "TITLE": "Avaya Aura Utility Services Privilege Escalation Vulnerability"
    },
    "affects": {

--- a/2021/25xxx/CVE-2021-25652.json
+++ b/2021/25xxx/CVE-2021-25652.json
@@ -2,7 +2,7 @@ Z{
    "CVE_data_meta": {
       "ASSIGNER": "securityalerts@avaya.com",
       "ID": "CVE-2021-25652",
-      "STATE": "READY",
+      "STATE": "PUBLIC",
       "TITLE": "Avaya Aura Appliance Virtualization Platform Utilities Sensitive Information Disclosure Vulnerability"
    },
    "affects": {

--- a/2021/25xxx/CVE-2021-25652.json
+++ b/2021/25xxx/CVE-2021-25652.json
@@ -1,4 +1,4 @@
-Z{
+{
    "CVE_data_meta": {
       "ASSIGNER": "securityalerts@avaya.com",
       "ID": "CVE-2021-25652",

--- a/2021/25xxx/CVE-2021-25652.json
+++ b/2021/25xxx/CVE-2021-25652.json
@@ -1,18 +1,87 @@
-{
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-25652",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+Z{
+   "CVE_data_meta": {
+      "ASSIGNER": "securityalerts@avaya.com",
+      "ID": "CVE-2021-25652",
+      "STATE": "READY",
+      "TITLE": "Avaya Aura Appliance Virtualization Platform Utilities Sensitive Information Disclosure Vulnerability"
+   },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Avaya Aura Appliance Virtualization Platform Utilities",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<=",
+                                 "version_name": "8.0.0.0",
+                                 "version_value": "8.1.3.1"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Avaya"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
+         {
+            "lang": "eng",
+            "value": "An information disclosure vulnerability was discovered in the directory and file management of Avaya Aura Appliance Virtualization Platform Utilities (AVPU). This vulnerability may potentially allow any local user to access system functionality and configuration information that should only be available to a privileged user. Affects versions 8.0.0.0 through 8.1.3.1 of AVPU."
+         }
+      ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "NONE",
+         "baseScore": 4.9,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "HIGH",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N",
+         "version": "3.1"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "CWE-200\nCWE-378"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "CONFIRM",
+            "url": "https://support.avaya.com/css/P8/documents/101076479"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "ASA-2021-087",
+      "defect": [
+         "PSST-1147"
+      ],
+      "discovery": "EXTERNAL"
+   }
 }

--- a/2021/25xxx/CVE-2021-25653.json
+++ b/2021/25xxx/CVE-2021-25653.json
@@ -2,7 +2,7 @@
    "CVE_data_meta": {
       "ASSIGNER": "securityalerts@avaya.com",
       "ID": "CVE-2021-25653",
-      "STATE": "READY",
+      "STATE": "PUBLIC",
       "TITLE": "Avaya Aura Appliance Virtualization Platform Utilities Privilege Escalation Vulnerability"
    },
    "affects": {

--- a/2021/25xxx/CVE-2021-25653.json
+++ b/2021/25xxx/CVE-2021-25653.json
@@ -1,18 +1,87 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-25653",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta": {
+      "ASSIGNER": "securityalerts@avaya.com",
+      "ID": "CVE-2021-25653",
+      "STATE": "READY",
+      "TITLE": "Avaya Aura Appliance Virtualization Platform Utilities Privilege Escalation Vulnerability"
+   },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Avaya Aura Appliance Virtualization Platform Utilities",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<=",
+                                 "version_name": "8.0.0.0",
+                                 "version_value": "8.1.3.1"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Avaya"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
+         {
+            "lang": "eng",
+            "value": "A privilege escalation vulnerability was discovered in Avaya Aura Appliance Virtualization Platform Utilities (AVPU) that may potentially allow a local user to escalate privileges. Affects 8.0.0.0 through 8.1.3.1 versions of AVPU."
+         }
+      ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "HIGH",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 8,
+         "baseSeverity": "HIGH",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "HIGH",
+         "scope": "CHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:C/C:H/I:H/A:H",
+         "version": "3.1"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "CWE-250"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "CONFIRM",
+            "url": "https://support.avaya.com/css/P8/documents/101076479"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "ASA-2021-087",
+      "defect": [
+         "PSST-1147"
+      ],
+      "discovery": "EXTERNAL"
+   }
 }

--- a/2021/25xxx/CVE-2021-25655.json
+++ b/2021/25xxx/CVE-2021-25655.json
@@ -1,18 +1,92 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-25655",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta": {
+      "ASSIGNER": "securityalerts@avaya.com",
+      "ID": "CVE-2021-25655",
+      "STATE": "READY",
+      "TITLE": "URL redirection to untrusted site possible in Avaya Aura Experience Portal"
+   },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Avaya Experience Portal",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": ">=",
+                                 "version_name": "7.0",
+                                 "version_value": "7.2.3"
+                              },
+                              {
+                                 "affected": "=",
+                                 "version_name": "8.0",
+                                 "version_value": "8.0"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Avaya"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
+         {
+            "lang": "eng",
+            "value": "A vulnerability in the system Service Menu component of Avaya Aura Experience Portal may allow URL Redirection to any untrusted site through a crafted attack. Affected versions include 7.0 through 7.2.3 (without hotfix) and 8.0.0 (without hotfix)."
+         }
+      ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "LOCAL",
+         "availabilityImpact": "LOW",
+         "baseScore": 4.4,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "LOW",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "LOW",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:L",
+         "version": "3.1"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "CWE-601: URL Redirection to Untrusted Site ('Open Redirect')"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "CONFIRM",
+            "url": "https://downloads.avaya.com/css/P8/documents/101076234"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "ASA-2021-069",
+      "defect": [
+         "PSST-1161"
+      ],
+      "discovery": "EXTERNAL"
+   }
 }

--- a/2021/25xxx/CVE-2021-25655.json
+++ b/2021/25xxx/CVE-2021-25655.json
@@ -2,7 +2,7 @@
    "CVE_data_meta": {
       "ASSIGNER": "securityalerts@avaya.com",
       "ID": "CVE-2021-25655",
-      "STATE": "READY",
+      "STATE": "PUBLIC",
       "TITLE": "URL redirection to untrusted site possible in Avaya Aura Experience Portal"
    },
    "affects": {

--- a/2021/25xxx/CVE-2021-25656.json
+++ b/2021/25xxx/CVE-2021-25656.json
@@ -1,18 +1,92 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-25656",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta": {
+      "ASSIGNER": "securityalerts@avaya.com",
+      "ID": "CVE-2021-25656",
+      "STATE": "READY",
+      "TITLE": "Avaya Aura Experience Portal XSS vulnerabilities"
+   },
+   "affects": {
+      "vendor": {
+         "vendor_data": [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Product",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": ">=",
+                                 "version_name": "7.0",
+                                 "version_value": "7.2.3"
+                              },
+                              {
+                                 "affected": "=",
+                                 "version_name": "8.0",
+                                 "version_value": "8.0"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "Avaya"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
+         {
+            "lang": "eng",
+            "value": "Stored XSS injection vulnerabilities were discovered in the Avaya Aura Experience Portal Web management which could allow an authenticated user to potentially disclose sensitive information. Affected versions include 7.0 through 7.2.3 (without hotfix) and 8.0.0 (without hotfix)."
+         }
+      ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "LOCAL",
+         "availabilityImpact": "LOW",
+         "baseScore": 5.3,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "LOW",
+         "integrityImpact": "LOW",
+         "privilegesRequired": "LOW",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+         "version": "3.1"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')."
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "refsource": "CONFIRM",
+            "url": "https://downloads.avaya.com/css/P8/documents/101076234"
+         }
+      ]
+   },
+   "source": {
+      "advisory": "ASA-2021-069",
+      "defect": [
+         "PSST-1161"
+      ],
+      "discovery": "EXTERNAL"
+   }
 }

--- a/2021/25xxx/CVE-2021-25656.json
+++ b/2021/25xxx/CVE-2021-25656.json
@@ -2,7 +2,7 @@
    "CVE_data_meta": {
       "ASSIGNER": "securityalerts@avaya.com",
       "ID": "CVE-2021-25656",
-      "STATE": "READY",
+      "STATE": "PUBLIC",
       "TITLE": "Avaya Aura Experience Portal XSS vulnerabilities"
    },
    "affects": {


### PR DESCRIPTION
Bulk Avaya June 2021 CVE publication for the following CVEs:
CVE-2021-25649
CVE-2021-25650
CVE-2021-25651
CVE-2021-25652
CVE-2021-25653
CVE-2021-25655
CVE-2021-25656