### PR TITLE
XSA-374 CVE-2021-28691

### DIFF
--- a/2021/28xxx/CVE-2021-28691.json
+++ b/2021/28xxx/CVE-2021-28691.json
@@ -1,18 +1,116 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28691",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28691"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Linux",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "5.5.0"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "5.12.2"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Linux"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Systems using Linux version 5.5 or newer are vulnerable."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Michael Brown of iPXE and diagnosed by\nOlivier Benjamin, Michael Kurth and Martin Mazein of AWS."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Guest triggered use-after-free in Linux xen-netback\n\nA malicious or buggy network PV frontend can force Linux netback to\ndisable the interface and terminate the receive kernel thread\nassociated with queue 0 in response to the frontend sending a\nmalformed packet.\n\nSuch kernel thread termination will lead to a use-after-free in Linux\nnetback when the backend is destroyed, as the kernel thread associated\nwith queue 0 will have already exited and thus the call to\nkthread_stop will be performed against a stale pointer."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "A malicious or buggy frontend driver can trigger a dom0 crash.\nPrivilege escalation and information leaks cannot be ruled out."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-374.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "On x86 running only HVM guests with emulated network cards will avoid the\nissue.  There's however no option in the upstream toolstack to offer only\nemulated network cards to guests."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-374 CVE-2021-28691

CVE data entry for:
  CVE-2021-28691

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.
