### PR TITLE
XSA-373 CVE-2021-28692

### DIFF
--- a/2021/28xxx/CVE-2021-28692.json
+++ b/2021/28xxx/CVE-2021-28692.json
@@ -1,18 +1,157 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28692",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28692"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.13.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.15.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.12.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.11.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from at least 3.2 onwards are vulnerable.  Earlier\nversions have not been inspected.\n\nOnly x86 systems with in-use IOMMU hardware are vulnerable.  x86 systems\nwithout any IOMMUs in use are not vulnerable.  On Arm systems IOMMU /\nSMMU use is not security supported.\n\nOnly x86 guests which have physical devices passed through to them can\nleverage the vulnerability."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Igor Druzhinin and Andrew Cooper of Citrix,\nand further issues were uncovered by by Jan Beulich of SUSE while trying\nto fix the first issue."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "inappropriate x86 IOMMU timeout detection / handling\n\nIOMMUs process commands issued to them in parallel with the operation\nof the CPU(s) issuing such commands.  In the current implementation in\nXen, asynchronous notification of the completion of such commands is\nnot used.  Instead, the issuing CPU spin-waits for the completion of\nthe most recently issued command(s).  Some of these waiting loops try\nto apply a timeout to fail overly-slow commands.  The course of action\nupon a perceived timeout actually being detected is inappropriate:\n - on Intel hardware guests which did not originally cause the timeout\n   may be marked as crashed,\n - on AMD hardware higher layer callers would not be notified of the\n   issue, making them continue as if the IOMMU operation succeeded."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "A malicious guest may be able to elevate its privileges to that of the\nhost, cause host or guest Denial of Service (DoS), or cause information\nleaks."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-373.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not passing through physical devices to untrusted guests will avoid\nthe vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-373 CVE-2021-28692

CVE data entry for:
  CVE-2021-28692

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
