### PR TITLE
Add CVE-2021-22867

### DIFF
--- a/2021/22xxx/CVE-2021-22867.json
+++ b/2021/22xxx/CVE-2021-22867.json
@@ -1,18 +1,91 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-22867",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "product-cna@github.com",
+    "ID": "CVE-2021-22867",
+    "STATE": "PUBLIC",
+    "TITLE": "Unsafe configuration options in GitHub Pages leading to path traversal on GitHub Enterprise Server"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "GitHub Enterprise Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_name": "2.22",
+                      "version_value": "2.22.17"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.0",
+                      "version_value": "3.0.11"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.1",
+                      "version_value": "3.1.3"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "GitHub"
+        }
+      ]
     }
+  },
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "yvvdwf"
+    }
+  ],
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "A path traversal vulnerability was identified in GitHub Enterprise Server that could be exploited when building a GitHub Pages site. User-controlled configuration options used by GitHub Pages were not sufficiently restricted and made it possible to read files on the GitHub Enterprise Server instance. To exploit this vulnerability, an attacker would need permission to create and build a GitHub Pages site on the GitHub Enterprise Server instance. This vulnerability affected all versions of GitHub Enterprise Server prior to 3.1.3 and was fixed in 3.1.3, 3.0.11, and 2.22.17. This vulnerability was reported via the GitHub Bug Bounty program."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-77: Command Injection - Generic"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@2.22/admin/release-notes#2.22.17"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.0/admin/release-notes#3.0.11"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.1/admin/release-notes#3.1.3"
+      }
+    ]
+  },
+  "source": {
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
This PR adds CVE-2021-22867, which was patched and made public in the batch of GitHub Enterprise Server releases that went out today, 7/14/2021.