### PR TITLE
Update CVE-2021-32722 to note the new fix version

### DIFF
--- a/2021/32xxx/CVE-2021-32722.json
+++ b/2021/32xxx/CVE-2021-32722.json
@@ -16,7 +16,7 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "All"
+                                            "version_value": "< 48be7adb70568e20e961ea1cb70904454a671b1d"
                                         }
                                     ]
                                 }
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "GlobalNewFiles is a mediawiki extension. All existing versions of GlobalNewFiles are affected by an uncontrolled resource consumption vulnerability. A large amount of page moves within a short space of time could overwhelm Database servers due to improper handling of load balancing and a lack of an appropriate index. No patches are currently available. As a workaround, one may avoid use of the extension unless additional rate limit at the MediaWiki level or via PoolCounter / MySQL is enabled."
+                "value": "GlobalNewFiles is a mediawiki extension. Versions prior to 48be7adb70568e20e961ea1cb70904454a671b1d are affected by an uncontrolled resource consumption vulnerability. A large amount of page moves within a short space of time could overwhelm Database servers due to improper handling of load balancing and a lack of an appropriate index. As a workaround, one may avoid use of the extension unless additional rate limit at the MediaWiki level or via PoolCounter / MySQL is enabled. A patch is available in version 48be7adb70568e20e961ea1cb70904454a671b1d."
             }
         ]
     },
@@ -78,6 +78,16 @@
                 "name": "https://phabricator.miraheze.org/T7532",
                 "refsource": "MISC",
                 "url": "https://phabricator.miraheze.org/T7532"
+            },
+            {
+                "name": "https://github.com/miraheze/GlobalNewFiles/commit/48be7adb70568e20e961ea1cb70904454a671b1d",
+                "refsource": "MISC",
+                "url": "https://github.com/miraheze/GlobalNewFiles/commit/48be7adb70568e20e961ea1cb70904454a671b1d"
+            },
+            {
+                "name": "https://github.com/miraheze/GlobalNewFiles/pull/17",
+                "refsource": "MISC",
+                "url": "https://github.com/miraheze/GlobalNewFiles/pull/17"
             }
         ]
     },


### PR DESCRIPTION
Update CVE-2021-32722 to note the new fix version.  The maintainer of this affected software updated their advisory to note a fix version is now available: https://github.com/miraheze/GlobalNewFiles/security/advisories/GHSA-cwv5-c938-5h5h.  This updates the corresponding CVE with that fix version information.