### PR TITLE
Adding reference to NSO advisory

### DIFF
--- a/2021/1xxx/CVE-2021-1572.json
+++ b/2021/1xxx/CVE-2021-1572.json
@@ -71,6 +71,11 @@
                 "name": "20210804 ConfD CLI Secure Shell Server Privilege Escalation Vulnerability",
                 "refsource": "CISCO",
                 "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-confd-priv-esc-LsGtCRx4"
+            },
+             {
+                "name": "20210804 Cisco Network Services Orchestrator CLI Secure Shell Server Privilege Escalation Vulnerability",
+                "refsource": "CISCO",
+                "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-nso-priv-esc-XXqRtTfT"
             }
         ]
     },


### PR DESCRIPTION
Adding the reference to the advisory titled "Cisco Network Services Orchestrator CLI Secure Shell Server Privilege Escalation Vulnerability" at:  https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-nso-priv-esc-XXqRtTfT