### PR TITLE
Add CVE-2021-37696 for GHSA-ffhm-9c8j-wx9h

### DIFF
--- a/2021/37xxx/CVE-2021-37696.json
+++ b/2021/37xxx/CVE-2021-37696.json
@@ -1,18 +1,88 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-37696",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Sensitive information leak in MassDM of tmerc-cogs"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "tmerc-cogs",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 92325be650a6c17940cc5"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "tmercswims"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "tmerc-cogs are a collection of open source plugins for the Red Discord bot. A vulnerability has been found in the code that allows any user to access sensitive information by crafting a specific MassDM message. Issue is patched in commit 92325be650a6c17940cc52611797533ed95dbbe1. All users are advised to update to the current commit. As a workaround users may unload the MassDM cog or globally disable the `[p]massdm` command.\n"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-306: Missing Authentication for Critical Function"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/tmercswims/tmerc-cogs/security/advisories/GHSA-ffhm-9c8j-wx9h",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/tmercswims/tmerc-cogs/security/advisories/GHSA-ffhm-9c8j-wx9h"
+            },
+            {
+                "name": "https://github.com/tmercswims/tmerc-cogs/commit/92325be650a6c17940cc5",
+                "refsource": "MISC",
+                "url": "https://github.com/tmercswims/tmerc-cogs/commit/92325be650a6c17940cc5"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-ffhm-9c8j-wx9h",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-37696 for GHSA-ffhm-9c8j-wx9h