### PR TITLE
XSA-378 CVE-2021-28694 CVE-2021-28695 CVE-2021-28696

### DIFF
--- a/2021/28xxx/CVE-2021-28694.json
+++ b/2021/28xxx/CVE-2021-28694.json
@@ -1,18 +1,157 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28694",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28694"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.11.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.12.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.15.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.13.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The vulnerability is only exploitable by guests granted access to\nphysical devices (ie, via PCI passthrough).\n\nAll versions of Xen are affected.\n\nOnly x86 systems with IOMMUs and with firmware specifying memory regions\nto be identity mapped are affected.  Other x86 systems are not affected.\n\nWhether a particular system whose ACPI tables declare such memory\nregion(s) is actually affected cannot be known without knowing when\nand/or how these regions are used.  For example, if these regions were\nused only during system boot, there would not be any vulnerability.\nThe necessary knowledge can only be obtained from, collectively, the\nhardware and firmware manufacturers.\n\nOn Arm hardware IOMMU use is not security supported.  Accordingly, we\nhave not undertaken an analysis of these issues for Arm systems."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "IOMMU page mapping issues on x86\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nBoth AMD and Intel allow ACPI tables to specify regions of memory\nwhich should be left untranslated, which typically means these\naddresses should pass the translation phase unaltered.  While these\nare typically device specific ACPI properties, they can also be\nspecified to apply to a range of devices, or even all devices.\n\nOn all systems with such regions Xen failed to prevent guests from\nundoing/replacing such mappings (CVE-2021-28694).\n\nOn AMD systems, where a discontinuous range is specified by firmware,\nthe supposedly-excluded middle range will also be identity-mapped\n(CVE-2021-28695).\n\nFurther, on AMD systems, upon de-assigment of a physical device from a\nguest, the identity mappings would be left in place, allowing a guest\ncontinued access to ranges of memory which it shouldn't have access to\nanymore (CVE-2021-28696)."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The precise impact is system specific, but can - on affected systems -\nbe any or all of privilege escalation, denial of service, or information\nleaks."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-378.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not permitting untrusted guests access to phsyical devices will avoid\nthe vulnerability.\n\nLikewise, limiting untrusted guest access to physical devices whose\nfirmware-provided ACPI tables declare identity mappings, will avoid\nthe vulnerability.  (Provided that there are no identity mapped\nregions which are specified by the ACPI tables to apply globally.)\n\nNote that a system is still vulnerable if a guest was trusted, while\nit had such a device assigned, and then has the device removed in\nanticipation of the guest becoming untrusted (because of, for example,\nthe insertion of an untrusted kernel module),"
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2021/28xxx/CVE-2021-28695.json
+++ b/2021/28xxx/CVE-2021-28695.json
@@ -1,18 +1,157 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28695",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28695"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.11.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.12.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.15.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.13.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The vulnerability is only exploitable by guests granted access to\nphysical devices (ie, via PCI passthrough).\n\nAll versions of Xen are affected.\n\nOnly x86 systems with IOMMUs and with firmware specifying memory regions\nto be identity mapped are affected.  Other x86 systems are not affected.\n\nWhether a particular system whose ACPI tables declare such memory\nregion(s) is actually affected cannot be known without knowing when\nand/or how these regions are used.  For example, if these regions were\nused only during system boot, there would not be any vulnerability.\nThe necessary knowledge can only be obtained from, collectively, the\nhardware and firmware manufacturers.\n\nOn Arm hardware IOMMU use is not security supported.  Accordingly, we\nhave not undertaken an analysis of these issues for Arm systems."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "IOMMU page mapping issues on x86\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nBoth AMD and Intel allow ACPI tables to specify regions of memory\nwhich should be left untranslated, which typically means these\naddresses should pass the translation phase unaltered.  While these\nare typically device specific ACPI properties, they can also be\nspecified to apply to a range of devices, or even all devices.\n\nOn all systems with such regions Xen failed to prevent guests from\nundoing/replacing such mappings (CVE-2021-28694).\n\nOn AMD systems, where a discontinuous range is specified by firmware,\nthe supposedly-excluded middle range will also be identity-mapped\n(CVE-2021-28695).\n\nFurther, on AMD systems, upon de-assigment of a physical device from a\nguest, the identity mappings would be left in place, allowing a guest\ncontinued access to ranges of memory which it shouldn't have access to\nanymore (CVE-2021-28696)."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The precise impact is system specific, but can - on affected systems -\nbe any or all of privilege escalation, denial of service, or information\nleaks."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-378.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not permitting untrusted guests access to phsyical devices will avoid\nthe vulnerability.\n\nLikewise, limiting untrusted guest access to physical devices whose\nfirmware-provided ACPI tables declare identity mappings, will avoid\nthe vulnerability.  (Provided that there are no identity mapped\nregions which are specified by the ACPI tables to apply globally.)\n\nNote that a system is still vulnerable if a guest was trusted, while\nit had such a device assigned, and then has the device removed in\nanticipation of the guest becoming untrusted (because of, for example,\nthe insertion of an untrusted kernel module),"
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2021/28xxx/CVE-2021-28696.json
+++ b/2021/28xxx/CVE-2021-28696.json
@@ -1,18 +1,157 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28696",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28696"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.11.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.12.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.15.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.13.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The vulnerability is only exploitable by guests granted access to\nphysical devices (ie, via PCI passthrough).\n\nAll versions of Xen are affected.\n\nOnly x86 systems with IOMMUs and with firmware specifying memory regions\nto be identity mapped are affected.  Other x86 systems are not affected.\n\nWhether a particular system whose ACPI tables declare such memory\nregion(s) is actually affected cannot be known without knowing when\nand/or how these regions are used.  For example, if these regions were\nused only during system boot, there would not be any vulnerability.\nThe necessary knowledge can only be obtained from, collectively, the\nhardware and firmware manufacturers.\n\nOn Arm hardware IOMMU use is not security supported.  Accordingly, we\nhave not undertaken an analysis of these issues for Arm systems."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "IOMMU page mapping issues on x86\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nBoth AMD and Intel allow ACPI tables to specify regions of memory\nwhich should be left untranslated, which typically means these\naddresses should pass the translation phase unaltered.  While these\nare typically device specific ACPI properties, they can also be\nspecified to apply to a range of devices, or even all devices.\n\nOn all systems with such regions Xen failed to prevent guests from\nundoing/replacing such mappings (CVE-2021-28694).\n\nOn AMD systems, where a discontinuous range is specified by firmware,\nthe supposedly-excluded middle range will also be identity-mapped\n(CVE-2021-28695).\n\nFurther, on AMD systems, upon de-assigment of a physical device from a\nguest, the identity mappings would be left in place, allowing a guest\ncontinued access to ranges of memory which it shouldn't have access to\nanymore (CVE-2021-28696)."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The precise impact is system specific, but can - on affected systems -\nbe any or all of privilege escalation, denial of service, or information\nleaks."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-378.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not permitting untrusted guests access to phsyical devices will avoid\nthe vulnerability.\n\nLikewise, limiting untrusted guest access to physical devices whose\nfirmware-provided ACPI tables declare identity mappings, will avoid\nthe vulnerability.  (Provided that there are no identity mapped\nregions which are specified by the ACPI tables to apply globally.)\n\nNote that a system is still vulnerable if a guest was trusted, while\nit had such a device assigned, and then has the device removed in\nanticipation of the guest becoming untrusted (because of, for example,\nthe insertion of an untrusted kernel module),"
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-378 CVE-2021-28694 CVE-2021-28695 CVE-2021-28696

CVE data entry for:
  CVE-2021-28694

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2021-28695

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2021-28696

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
