### PR TITLE
XSA-379 CVE-2021-28697

### DIFF
--- a/2021/28xxx/CVE-2021-28697.json
+++ b/2021/28xxx/CVE-2021-28697.json
@@ -1,18 +1,155 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28697",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28697"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.13.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.11.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "4.12.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.15.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from 4.0 onwards are affected.  Xen versions 3.4 and\nolder are not affected.\n\nOnly x86 HVM and PVH guests permitted to use grant table version 2\ninterfaces can leverage this vulnerability.  x86 PV guests cannot\nleverage this vulnerability.  On Arm, grant table v2 use is explicitly\nunsupported."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "grant table v2 status pages may remain accessible after de-allocation\n\nGuest get permitted access to certain Xen-owned pages of memory.  The\nmajority of such pages remain allocated / associated with a guest for\nits entire lifetime.  Grant table v2 status pages, however, get\nde-allocated when a guest switched (back) from v2 to v1.  The freeing\nof such pages requires that the hypervisor know where in the guest\nthese pages were mapped.  The hypervisor tracks only one use within\nguest space, but racing requests from the guest to insert mappings of\nthese pages may result in any of them to become mapped in multiple\nlocations.  Upon switching back from v2 to v1, the guest would then\nretain access to a page that was freed and perhaps re-used for other\npurposes."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "A malicious guest may be able to elevate its privileges to that of the\nhost, cause host or guest Denial of Service (DoS), or cause information\nleaks."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-379.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Running only PV guests will avoid this vulnerability.\n\nSuppressing use of grant table v2 interfaces for HVM or PVH guests will\nalso avoid this vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-379 CVE-2021-28697

CVE data entry for:
  CVE-2021-28697

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
