### PR TITLE
XSA-380 CVE-2021-28698

### DIFF
--- a/2021/28xxx/CVE-2021-28698.json
+++ b/2021/28xxx/CVE-2021-28698.json
@@ -1,18 +1,156 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28698",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28698"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.15.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.13.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.11.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.12.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from at least 3.2 onwards are vulnerable in principle.\n\nSystems running with default settings are generally believed to not be\nvulnerable."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Andrew Cooper of Citrix."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "long running loops in grant table handling\n\nIn order to properly monitor resource use, Xen maintains information on\nthe grant mappings a domain may create to map grants offered by other\ndomains.  In the process of carrying out certain actions, Xen would\niterate over all such entries, including ones which aren't in use\nanymore and some which may have been created but never used.  If the\nnumber of entries for a given domain is large enough, this iterating of\nthe entire table may tie up a CPU for too long, starving other domains\nor causing issues in the hypervisor itself.\n\nNote that a domain may map its own grants, i.e. there is no need for\nmultiple domains to be involved here.  A pair of \"cooperating\" guests\nmay, however, cause the effects to be more severe."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Malicious or buggy guest kernels may be able to mount a Denial of\nService (DoS) attack affecting the entire system."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-380.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The problem can be avoided by reducing the number of grant mappings Xen\nwould allow guests to establish.  For example, setting\n\"gnttab_max_maptrack_frames=256\" on the Xen command line (available\nfrom Xen 4.5 onwards) or \"max_maptrack_frames=256\" in the xl domain\nconfigurations (available from Xen 4.10 onwards) may be low enough for\nall hardware Xen is able to run on.  Note that except for driver\ndomains, guests don't normally have a need to establish grant mappings,\ni.e. they may be okay to run with \"max_maptrack_frames=0\" in their xl\ndomain configurations.\n\n- From Xen 4.14 onwards it is also possible to alter the system wide upper\nbound of the number of grant mappings Xen would allow guests to\nestablish by writing to the /params/gnttab_max_maptrack_frames\nhypervisor file system node.  Note however that changing the value this\nway will only affect guests yet to be created on the respective host."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-380 CVE-2021-28698

CVE data entry for:
  CVE-2021-28698

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
