### PR TITLE
XSA-382 CVE-2021-28699

### DIFF
--- a/2021/28xxx/CVE-2021-28699.json
+++ b/2021/28xxx/CVE-2021-28699.json
@@ -1,18 +1,116 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28699",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28699"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.11.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from 4.10 onwards are affected.  Xen versions 4.9 and\nolder are not affected.\n\nOnly 32-bit x86 guests permitted to use grant table version 2 interfaces\ncan leverage this vulnerability.  64-bit x86 guests cannot leverage this\nvulnerability, but note that HVM and PVH guests are free to alter their\nbitness as they see fit.  On Arm, grant table v2 use is explicitly\nunsupported.\n\nOnly guests permitted to have 8177 or more grant table frames can\nleverage this vulnerability."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "inadequate grant-v2 status frames array bounds check\n\nThe v2 grant table interface separates grant attributes from grant\nstatus.  That is, when operating in this mode, a guest has two tables.\nAs a result, guests also need to be able to retrieve the addresses that\nthe new status tracking table can be accessed through.\n\nFor 32-bit guests on x86, translation of requests has to occur because\nthe interface structure layouts commonly differ between 32- and 64-bit.\n\nThe translation of the request to obtain the frame numbers of the\ngrant status table involves translating the resulting array of frame\nnumbers.  Since the space used to carry out the translation is limited,\nthe translation layer tells the core function the capacity of the array\nwithin translation space.  Unfortunately the core function then only\nenforces array bounds to be below 8 times the specified value, and would\nwrite past the available space if enough frame numbers needed storing."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Malicious or buggy guest kernels may be able to mount a Denial of\nService (DoS) attack affecting the entire system.  Privilege escalation\nand information leaks cannot be ruled out."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-382.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The problem can be avoided by not increasing too much the number of\ngrants Xen would allow guests to establish.  The limit is controlled by\nthe \"gnttab_max_frames\" Xen command line option and the\n\"max_grant_frames\" xl domain configuration setting.\n\n- From Xen 4.14 onwards it is also possible to alter the system wide upper\nbound of the number of grants Xen would allow guests to establish by\nwriting to the /params/gnttab_max_frames hypervisor file system node.\nNote however that changing the value this way will only affect guests\nyet to be created on the respective host.\n\nSuppressing use of grant table v2 interfaces for 32-bit x86 guests will\nalso avoid this vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-382 CVE-2021-28699

CVE data entry for:
  CVE-2021-28699

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
