### PR TITLE
Modify CVE-2021-39186 for GHSA-57p5-hqjq-h7vg

### DIFF
--- a/2021/39xxx/CVE-2021-39186.json
+++ b/2021/39xxx/CVE-2021-39186.json
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "GlobalNewFiles is a package in Miraheze, a wiki hosting service. Prior to commit number cee254e1b158cdb0ddbea716b1d3edc31fa4fb5d, the username column of the GlobalNewFiles special page is vulnerable to a stored XSS. Commit number cee254e1b158cdb0ddbea716b1d3edc31fa4fb5d contains a patch. As a workaround, one may disallow <,> (or other characters required to insert html/js) from being used in account names so an XSS is not possible."
+                "value": "GlobalNewFiles is a MediaWiki extension maintained by Miraheze. Prior to commit number cee254e1b158cdb0ddbea716b1d3edc31fa4fb5d, the username column of the GlobalNewFiles special page is vulnerable to a stored XSS. Commit number cee254e1b158cdb0ddbea716b1d3edc31fa4fb5d contains a patch. As a workaround, one may disallow <,> (or other characters required to insert html/js) from being used in account names so an XSS is not possible."
             }
         ]
     },


### PR DESCRIPTION
Modify CVE-2021-39186 for GHSA-57p5-hqjq-h7vg. Added new opening line to description (`GlobalNewFiles is a MediaWiki extension maintained by Miraheze.`)