### PR TITLE
updated to note exploitation does not require authentication

### DIFF
--- a/2021/26xxx/CVE-2021-26084.json
+++ b/2021/26xxx/CVE-2021-26084.json
@@ -95,7 +95,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In affected versions of Confluence Server and Data Center, an OGNL injection vulnerability exists that would allow an authenticated user, and in some instances an unauthenticated user, to execute arbitrary code on a Confluence Server or Data Center instance. The vulnerable endpoints can be accessed by a non-administrator user or unauthenticated user if \u2018Allow people to sign up to create their account\u2019 is enabled. To check whether this is enabled go to COG > User Management > User Signup Options. The affected versions are before version 6.13.23, from version 6.14.0 before 7.4.11, from version 7.5.0 before 7.11.6, and from version 7.12.0 before 7.12.5."
+                "value": "In affected versions of Confluence Server and Data Center, an OGNL injection vulnerability exists that would allow an unauthenticated attacker to execute arbitrary code on a Confluence Server or Data Center instance. The affected versions are before version 6.13.23, from version 6.14.0 before 7.4.11, from version 7.5.0 before 7.11.6, and from version 7.12.0 before 7.12.5."
             }
         ]
     },


### PR DESCRIPTION
corrected the description of CVE-2021-26084. exploitation does **not** require authentication