### PR TITLE
Add CVE-2021-39199 for GHSA-9q5w-79cv-947m

### DIFF
--- a/2021/39xxx/CVE-2021-39199.json
+++ b/2021/39xxx/CVE-2021-39199.json
@@ -1,18 +1,101 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-39199",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Cross site scripting via unsafe defaults in remark-html"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "remark-html",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 14.0.0, < 14.0.1"
+                                        },
+                                        {
+                                            "version_value": "< 13.0.2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "remarkjs"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "remark-html is an open source nodejs library which compiles Markdown to HTML. In affected versions the documentation of remark-html has mentioned that it was safe by default. In practice the default was never safe and had to be opted into. That is, user input was not sanitized. This means arbitrary HTML can be passed through leading to potential XSS attacks. The problem has been patched in 13.0.2 and 14.0.1: `remark-html` is now safe by default, and the implementation matches the documentation. On older affected versions, pass `sanitize: true` if you cannot update."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 10.0,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/remarkjs/remark-html/security/advisories/GHSA-9q5w-79cv-947m",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/remarkjs/remark-html/security/advisories/GHSA-9q5w-79cv-947m"
+            },
+            {
+                "name": "https://github.com/remarkjs/remark-html/commit/b75c9dde582ad87ba498e369c033dc8a350478c1",
+                "refsource": "MISC",
+                "url": "https://github.com/remarkjs/remark-html/commit/b75c9dde582ad87ba498e369c033dc8a350478c1"
+            },
+            {
+                "name": "https://github.com/remarkjs/remark-html/releases/tag/14.0.1",
+                "refsource": "MISC",
+                "url": "https://github.com/remarkjs/remark-html/releases/tag/14.0.1"
+            },
+            {
+                "name": "https://www.npmjs.com/package/remark-html",
+                "refsource": "MISC",
+                "url": "https://www.npmjs.com/package/remark-html"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-9q5w-79cv-947m",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-39199 for GHSA-9q5w-79cv-947m