### PR TITLE
Add CVE-2021-39194 for GHSA-fmm9-3gv8-58f4

### DIFF
--- a/2021/39xxx/CVE-2021-39194.json
+++ b/2021/39xxx/CVE-2021-39194.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-39194",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Denial of service while parsing polymorphic input with tagged polymorphism style in kaml"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "kaml",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.35.2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "charleskorn"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "kaml is an open source implementation of the YAML format with support for kotlinx.serialization. In affected versions attackers that could provide arbitrary YAML input to an application that uses kaml could cause the application to endlessly loop while parsing the input. This could result in resource starvation and denial of service. This only affects applications that use polymorphic serialization with the default tagged polymorphism style. Applications using the property polymorphism style are not affected. YAML input for a polymorphic type that provided a tag but no value for the object would trigger the issue. Version 0.35.3 or later contain the fix for this issue."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 4.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-835: Loop with Unreachable Exit Condition ('Infinite Loop')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/charleskorn/kaml/security/advisories/GHSA-fmm9-3gv8-58f4",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/charleskorn/kaml/security/advisories/GHSA-fmm9-3gv8-58f4"
+            },
+            {
+                "name": "https://github.com/charleskorn/kaml/issues/179",
+                "refsource": "MISC",
+                "url": "https://github.com/charleskorn/kaml/issues/179"
+            },
+            {
+                "name": "https://github.com/charleskorn/kaml/commit/e18785d043fc6324c81e968aae9764b4b060bc6a",
+                "refsource": "MISC",
+                "url": "https://github.com/charleskorn/kaml/commit/e18785d043fc6324c81e968aae9764b4b060bc6a"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-fmm9-3gv8-58f4",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-39194 for GHSA-fmm9-3gv8-58f4