### PR TITLE
XSA-384 CVE-2021-28701

### DIFF
--- a/2021/28xxx/CVE-2021-28701.json
+++ b/2021/28xxx/CVE-2021-28701.json
@@ -1,18 +1,145 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28701",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28701"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.15.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.11.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.12.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from 4.0 onwards are affected.  Xen versions 3.4 and\nolder are not affected.\n\nOnly x86 HVM and PVH guests permitted to use grant table version 2\ninterfaces can leverage this vulnerability.  x86 PV guests cannot\nleverage this vulnerability.  On Arm, grant table v2 use is explicitly\nunsupported."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Julien Grall of Amazon."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Another race in XENMAPSPACE_grant_table handling\n\nGuests are permitted access to certain Xen-owned pages of memory.  The\nmajority of such pages remain allocated / associated with a guest for\nits entire lifetime.  Grant table v2 status pages, however, are\nde-allocated when a guest switches (back) from v2 to v1.  Freeing\nsuch pages requires that the hypervisor enforce that no parallel request\ncan result in the addition of a mapping of such a page to a guest.  That\nenforcement was missing, allowing guests to retain access to pages\nthat were freed and perhaps re-used for other purposes.\n\nUnfortunately, when XSA-379 was being prepared, this similar issue was\nnot noticed."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "A malicious guest may be able to elevate its privileges to that of the\nhost, cause host or guest Denial of Service (DoS), or cause information\nleaks."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-384.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Running only PV guests will avoid this vulnerability.\n\nSuppressing use of grant table v2 interfaces for HVM or PVH guests will\nalso avoid this vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-384 CVE-2021-28701

CVE data entry for:
  CVE-2021-28701

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
