### PR TITLE
Remove the incorrect references to ASF projects from this Microsoft CVE

### DIFF
--- a/2020/0xxx/CVE-2020-0822.json
+++ b/2020/0xxx/CVE-2020-0822.json
@@ -245,46 +245,6 @@
                 "url": "https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-0822",
                 "refsource": "MISC",
                 "name": "https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-0822"
-            },
-            {
-                "refsource": "MLIST",
-                "name": "[axis-java-dev] 20210228 axis2 1.7.9 is exposed to CVE-2020-8022 via tomcat dependency",
-                "url": "https://lists.apache.org/thread.html/r5be80ba868a11a1f64e4922399f171b8619bca4bc2039f79cf913928@%3Cjava-dev.axis.apache.org%3E"
-            },
-            {
-                "refsource": "MLIST",
-                "name": "[axis-java-dev] 20210307 Re: axis2 1.7.9 is exposed to CVE-2020-8022 via tomcat dependency",
-                "url": "https://lists.apache.org/thread.html/r393d4f431683e99c839b4aed68f720b8583bca6c35cd84adccaa02be@%3Cjava-dev.axis.apache.org%3E"
-            },
-            {
-                "refsource": "MLIST",
-                "name": "[axis-java-user] 20210419 Re: Axis2 1.8.0 Release timelines",
-                "url": "https://lists.apache.org/thread.html/r492afeeeb1bfe484f2f4a1f5d296eee49b13eb0c579ac460e3d7d957@%3Cjava-user.axis.apache.org%3E"
-            },
-            {
-                "refsource": "MLIST",
-                "name": "[axis-java-user] 20210419 RE: Axis2 1.8.0 Release timelines",
-                "url": "https://lists.apache.org/thread.html/r31d9c450e6d84e82e85c2dd1a7586f56ae4ed6776e5b8765c30fe2ac@%3Cjava-user.axis.apache.org%3E"
-            },
-            {
-                "refsource": "MLIST",
-                "name": "[axis-java-dev] 20210525 [jira] [Created] (AXIS2-6002) AXIS 2 1.7.9 jars with vulnerability CVE-2020-0822",
-                "url": "https://lists.apache.org/thread.html/r02687681920bb91816b735cc48847eef77c473a749678d855fbb565d@%3Cjava-dev.axis.apache.org%3E"
-            },
-            {
-                "refsource": "MLIST",
-                "name": "[axis-java-dev] 20210525 [jira] [Closed] (AXIS2-6002) AXIS 2 1.7.9 jars with vulnerability CVE-2020-0822",
-                "url": "https://lists.apache.org/thread.html/r258f18d563859c0ef9584fd7341426bd14f5042bdf7e7bc396d91272@%3Cjava-dev.axis.apache.org%3E"
-            },
-            {
-                "refsource": "MLIST",
-                "name": "[tomcat-dev] 20210823 [Bug 65517] New: upgrade to axis2-adb 1.8.0 to address CVE-2020-0822",
-                "url": "https://lists.apache.org/thread.html/rf3058e80123e804b74face024752c1ded5213e63011de139f25977bc@%3Cdev.tomcat.apache.org%3E"
-            },
-            {
-                "refsource": "MLIST",
-                "name": "[tomcat-dev] 20210823 [Bug 65517] upgrade to axis2-adb 1.8.0 to address CVE-2020-0822",
-                "url": "https://lists.apache.org/thread.html/r6dbbfd80c4b335685e2a561f85013593e7b99934d4cdfc5fc129f4ce@%3Cdev.tomcat.apache.org%3E"
             }
         ]
     }


### PR DESCRIPTION
they were caused by someone on a mailing list making a typo between
CVE-2020-8022 and CVE-2020-0822 and are not relevent. This mistake led
to NVD including ASF Tomcat and Axis as affects CPE's.