### PR TITLE
Add CVE-2021-41082 for GHSA-vm3x-w6jm-j9vv

### DIFF
--- a/2021/41xxx/CVE-2021-41082.json
+++ b/2021/41xxx/CVE-2021-41082.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-41082",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Private message title and participating users leaked in discourse"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "discourse",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= tests-passed = ddb4583, < tests-passed = 27bad28"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "discourse"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Discourse is a platform for community discussion. In affected versions any private message that includes a group had its title and participating user exposed to users that do not have access to the private messages. However, access control for the private messages was not compromised as users were not able to view the posts in the leaked private message despite seeing it in their inbox. The problematic commit was reverted around 32 minutes after it was made. Users are encouraged to upgrade to the latest commit if they are running Discourse against the `tests-passed` branch. \n\n"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/discourse/discourse/security/advisories/GHSA-vm3x-w6jm-j9vv",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/discourse/discourse/security/advisories/GHSA-vm3x-w6jm-j9vv"
+            },
+            {
+                "name": "https://github.com/discourse/discourse/commit/27bad28c530c89acab35a56b945b6a3924280f4b",
+                "refsource": "MISC",
+                "url": "https://github.com/discourse/discourse/commit/27bad28c530c89acab35a56b945b6a3924280f4b"
+            },
+            {
+                "name": "https://github.com/discourse/discourse/commit/ddb458343dc39a7a8c99467dcd809b444514fe2c",
+                "refsource": "MISC",
+                "url": "https://github.com/discourse/discourse/commit/ddb458343dc39a7a8c99467dcd809b444514fe2c"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-vm3x-w6jm-j9vv",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-41082 for GHSA-vm3x-w6jm-j9vv