### PR TITLE
Add CVE-2021-41095 for GHSA-qvqx-2h7w-m479

### DIFF
--- a/2021/41xxx/CVE-2021-41095.json
+++ b/2021/41xxx/CVE-2021-41095.json
@@ -1,18 +1,91 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-41095",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "XSS via blocked watched word in error message"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "discourse",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "<= 2.7.7"
+                                        },
+                                        {
+                                            "version_value": ">= 2.8.0.beta1, <= 2.8.0.beta6"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "discourse"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Discourse is an open source discussion platform. There is a cross-site scripting (XSS) vulnerability in versions 2.7.7 and earlier of the `stable` branch, versions 2.8.0.beta6 and earlier of the `beta` branch, and versions 2.8.0.beta6 and earlier of the `tests-passed` branch. Rendering of some error messages that contain user input can be susceptible to XSS attacks. This vulnerability only affects sites which have blocked watched words that contain HTML tags, modified or disabled Discourse's default Content Security Policy. This issue is patched in the latest `stable`, `beta` and `tests-passed` versions of Discourse. As a workaround, avoid modifying or disabling Discourse’s default Content Security Policy, and blocking watched words containing HTML tags."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.2,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/discourse/discourse/security/advisories/GHSA-qvqx-2h7w-m479",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/discourse/discourse/security/advisories/GHSA-qvqx-2h7w-m479"
+            },
+            {
+                "name": "https://github.com/discourse/discourse/pull/14434/commits/40b776b9d39c41d9273d01eecf8fe03aa39fcb59",
+                "refsource": "MISC",
+                "url": "https://github.com/discourse/discourse/pull/14434/commits/40b776b9d39c41d9273d01eecf8fe03aa39fcb59"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-qvqx-2h7w-m479",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-41095 for GHSA-qvqx-2h7w-m479