### PR TITLE
Add CVE-2021-32626 for GHSA-p486-xggp-782c

### DIFF
--- a/2021/32xxx/CVE-2021-32626.json
+++ b/2021/32xxx/CVE-2021-32626.json
@@ -1,18 +1,102 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-32626",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Lua scripts can overflow the heap-based Lua stack in Redis"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "redis",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 6.2.0, < 6.2.6"
+                                        },
+                                        {
+                                            "version_value": ">= 6.0.0, < 6.0.16"
+                                        },
+                                        {
+                                            "version_value": ">= 2.6.0, < 5.0.14"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "redis"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Redis is an open source, in-memory database that persists on disk. In affected versions specially crafted Lua scripts executing in Redis can cause the heap-based Lua stack to be overflowed, due to incomplete checks for this condition. This can result with heap corruption and potentially remote code execution. This problem exists in all versions of Redis with Lua scripting support, starting from 2.6. The problem is fixed in versions 6.2.6, 6.0.16 and 5.0.14. For users unable to update an additional workaround to mitigate the problem without patching the redis-server executable is to prevent users from executing Lua scripts. This can be done using ACL to restrict EVAL and EVALSHA commands.\n"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-122: Heap-based Buffer Overflow"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-787: Out-of-bounds Write"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/redis/redis/security/advisories/GHSA-p486-xggp-782c",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/redis/redis/security/advisories/GHSA-p486-xggp-782c"
+            },
+            {
+                "name": "https://github.com/redis/redis/commit/666ed7facf4524bf6d19b11b20faa2cf93fdf591",
+                "refsource": "MISC",
+                "url": "https://github.com/redis/redis/commit/666ed7facf4524bf6d19b11b20faa2cf93fdf591"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-p486-xggp-782c",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-32626 for GHSA-p486-xggp-782c