### PR TITLE
Add CVE-2021-32627 for GHSA-f434-69fm-g45v

### DIFF
--- a/2021/32xxx/CVE-2021-32627.json
+++ b/2021/32xxx/CVE-2021-32627.json
@@ -1,18 +1,102 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-32627",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Integer overflow issue with Streams in Redis"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "redis",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 5.0.0, < 5.0.14"
+                                        },
+                                        {
+                                            "version_value": ">= 6.0.0, < 6.0.16"
+                                        },
+                                        {
+                                            "version_value": ">= 6.2.0, < 6.2.6"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "redis"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Redis is an open source, in-memory database that persists on disk. In affected versions an integer overflow bug in Redis can be exploited to corrupt the heap and potentially result with remote code execution. The vulnerability involves changing the default proto-max-bulk-len and client-query-buffer-limit configuration parameters to very large values and constructing specially crafted very large stream elements. The problem is fixed in Redis 6.2.6, 6.0.16 and 5.0.14. For users unable to upgrade an additional workaround to mitigate the problem without patching the redis-server executable is to prevent users from modifying the proto-max-bulk-len configuration parameter. This can be done using ACL to restrict unprivileged users from using the CONFIG SET command."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-190: Integer Overflow or Wraparound"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-680: Integer Overflow to Buffer Overflow"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/redis/redis/security/advisories/GHSA-f434-69fm-g45v",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/redis/redis/security/advisories/GHSA-f434-69fm-g45v"
+            },
+            {
+                "name": "https://github.com/redis/redis/commit/f6a40570fa63d5afdd596c78083d754081d80ae3",
+                "refsource": "MISC",
+                "url": "https://github.com/redis/redis/commit/f6a40570fa63d5afdd596c78083d754081d80ae3"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-f434-69fm-g45v",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-32627 for GHSA-f434-69fm-g45v