### PR TITLE
XSA-386 CVE-2021-28702

### DIFF
--- a/2021/28xxx/CVE-2021-28702.json
+++ b/2021/28xxx/CVE-2021-28702.json
@@ -1,18 +1,104 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28702",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28702"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.12.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All versions of Xen from at least 4.4 onwards are vulnerable.\n\nOnly Intel x86 systems are affected.  AMD x86 systems, and Arm\nsystems, are all unaffected.\n\nOnly systems using PCI passthrough are affected.  (And then, only if\nthe assigned devices have RMRRs, but whether a device advertises RMRRs\nis not easy to discern.)"
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "PCI devices with RMRRs not deassigned correctly\n\nCertain PCI devices in a system might be assigned Reserved Memory\nRegions (specified via Reserved Memory Region Reporting, \"RMRR\").\nThese are typically used for platform tasks such as legacy USB\nemulation.\n\nIf such a device is passed through to a guest, then on guest shutdown\nthe device is not properly deassigned.  The IOMMU configuration for\nthese devices which are not properly deassigned ends up pointing to a\nfreed data structure, including the IO Pagetables.\n\nSubsequent DMA or interrupts from the device will have unpredictable\nbehaviour, ranging from IOMMU faults to memory corruption."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Administrators of guests which have been assigned RMRR-using PCI\ndevices can cause denial of service and other problems, possibly\nincluding escalation of privilege."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-386.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no mitigation (other than not passing through PCI devices\nwith RMRRs to guests)."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-386 CVE-2021-28702

CVE data entry for:
  CVE-2021-28702

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
