### PR TITLE
Add CVE-2021-39184 for GHSA-mpjm-v997-c4h4

### DIFF
--- a/2021/39xxx/CVE-2021-39184.json
+++ b/2021/39xxx/CVE-2021-39184.json
@@ -1,18 +1,94 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-39184",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Sandboxed renderers can obtain thumbnails of arbitrary files through the nativeImage API"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "electron",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 11.5.0"
+                                        },
+                                        {
+                                            "version_value": ">= 12.0.0, < 12.1.0"
+                                        },
+                                        {
+                                            "version_value": ">= 13.0.0, < 13.3.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "electron"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Electron is a framework for writing cross-platform desktop applications using JavaScript, HTML and CSS. A vulnerability in versions prior to 11.5.0, 12.1.0, and 13.3.0 allows a sandboxed renderer to request a \"thumbnail\" image of an arbitrary file on the user's system. The thumbnail can potentially include significant parts of the original file, including textual data in many cases. Versions 15.0.0-alpha.10, 14.0.0, 13.3.0, 12.1.0, and 11.5.0 all contain a fix for the vulnerability. Two workarounds aside from upgrading are available. One may make the vulnerability significantly more difficult for an attacker to exploit by enabling `contextIsolation` in one's app. One may also disable the functionality of the `createThumbnailFromPath` API if one does not need it."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.8,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-668: Exposure of Resource to Wrong Sphere"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/electron/electron/security/advisories/GHSA-mpjm-v997-c4h4",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/electron/electron/security/advisories/GHSA-mpjm-v997-c4h4"
+            },
+            {
+                "name": "https://github.com/electron/electron/pull/30728",
+                "refsource": "MISC",
+                "url": "https://github.com/electron/electron/pull/30728"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-mpjm-v997-c4h4",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-39184 for GHSA-mpjm-v997-c4h4