### PR TITLE
Add CVE-2021-41137 for GHSA-v64v-g97p-577c

### DIFF
--- a/2021/41xxx/CVE-2021-41137.json
+++ b/2021/41xxx/CVE-2021-41137.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-41137",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Bypassing policy restrictions on regular users "
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "minio",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "= RELEASE.2021-10-10T16-53-30Z"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "minio"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Minio is a Kubernetes native application for cloud storage. All users on release `RELEASE.2021-10-10T16-53-30Z` are affected by a vulnerability that involves bypassing policy restrictions on regular users. Normally, checkKeyValid() should return owner true for rootCreds. In the affected version, policy restriction did not work properly for users who did not have service (svc) or security token service (STS) accounts. This issue is fixed in `RELEASE.2021-10-13T00-23-17Z`. A downgrade back to release `RELEASE.2021-10-08T23-58-24Z` is available as a workaround."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-285: Improper Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/minio/minio/security/advisories/GHSA-v64v-g97p-577c",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/minio/minio/security/advisories/GHSA-v64v-g97p-577c"
+            },
+            {
+                "name": "https://github.com/minio/minio/pull/13388",
+                "refsource": "MISC",
+                "url": "https://github.com/minio/minio/pull/13388"
+            },
+            {
+                "name": "https://github.com/minio/minio/pull/13422",
+                "refsource": "MISC",
+                "url": "https://github.com/minio/minio/pull/13422"
+            },
+            {
+                "name": "https://github.com/minio/minio/commit/415bbc74aacd53a120e54a663e941b1809982dbd",
+                "refsource": "MISC",
+                "url": "https://github.com/minio/minio/commit/415bbc74aacd53a120e54a663e941b1809982dbd"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-v64v-g97p-577c",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-41137 for GHSA-v64v-g97p-577c