### PR TITLE
Add CVE-2021-41150 for GHSA-r56q-vv3c-6g9c

### DIFF
--- a/2021/41xxx/CVE-2021-41150.json
+++ b/2021/41xxx/CVE-2021-41150.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-41150",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Improper sanitization of delegated role names in tough"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "tough",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.12.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "awslabs"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Tough provides a set of Rust libraries and tools for using and generating the update framework (TUF) repositories. The tough library, prior to 0.12.0, does not properly sanitize delegated role names when caching a repository, or when loading a repository from the filesystem. When the repository is cached or loaded, files ending with the .json extension could be overwritten with role metadata anywhere on the system. A fix is available in version 0.12.0. No workarounds to this issue are known."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 8.2,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/awslabs/tough/security/advisories/GHSA-r56q-vv3c-6g9c",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/awslabs/tough/security/advisories/GHSA-r56q-vv3c-6g9c"
+            },
+            {
+                "name": "https://github.com/theupdateframework/python-tuf/security/advisories/GHSA-wjw6-2cqr-j4qr ",
+                "refsource": "MISC",
+                "url": "https://github.com/theupdateframework/python-tuf/security/advisories/GHSA-wjw6-2cqr-j4qr "
+            },
+            {
+                "name": "https://github.com/awslabs/tough/commit/1809b9bd1106d78a51fbea3071aa97a3530bac9a",
+                "refsource": "MISC",
+                "url": "https://github.com/awslabs/tough/commit/1809b9bd1106d78a51fbea3071aa97a3530bac9a"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-r56q-vv3c-6g9c",
+        "discovery": "UNKNOWN"
     }
 }

--- a/2021/41xxx/CVE-2021-41150.json
+++ b/2021/41xxx/CVE-2021-41150.json
@@ -75,9 +75,9 @@
                 "url": "https://github.com/awslabs/tough/security/advisories/GHSA-r56q-vv3c-6g9c"
             },
             {
-                "name": "https://github.com/theupdateframework/python-tuf/security/advisories/GHSA-wjw6-2cqr-j4qr ",
+                "name": "https://github.com/theupdateframework/python-tuf/security/advisories/GHSA-wjw6-2cqr-j4qr",
                 "refsource": "MISC",
-                "url": "https://github.com/theupdateframework/python-tuf/security/advisories/GHSA-wjw6-2cqr-j4qr "
+                "url": "https://github.com/theupdateframework/python-tuf/security/advisories/GHSA-wjw6-2cqr-j4qr"
             },
             {
                 "name": "https://github.com/awslabs/tough/commit/1809b9bd1106d78a51fbea3071aa97a3530bac9a",


### PR DESCRIPTION
Add CVE-2021-41150 for GHSA-r56q-vv3c-6g9c