### PR TITLE
[ISC] document BIND9 CVE-2021-25219

### DIFF
--- a/2021/25xxx/CVE-2021-25219.json
+++ b/2021/25xxx/CVE-2021-25219.json
@@ -3,16 +3,122 @@
     "data_format": "MITRE",
     "data_version": "4.0",
     "CVE_data_meta": {
+        "DATE_PUBLIC": "2021-10-27T20:10:02.000Z",
         "ID": "CVE-2021-25219",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security-officer@isc.org",
+        "STATE": "PUBLIC",
+        "TITLE": "Lame cache can be abused to severely degrade resolver performance"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "BIND9",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_name": "Open Source Branches 9.3 through 9.11",
+                                            "version_value": "9.3.0 through versions before 9.11.36"
+                                        },
+                                        {
+                                            "version_name": "Open Source Branches 9.12 through 9.16",
+                                            "version_value": "9.12.0 through versions before 9.16.22"
+                                        },
+                                        {
+                                            "version_name": "Supported Preview Branches 9.9-S through 9.11-S",
+                                            "version_value": "9.9.3-S1 through versions before 9.11.36-S1"
+                                        },
+                                        {
+                                            "version_name": "Supported Preview Branch 9.16-S",
+                                            "version_value": "9.16.8-S1 through versions before 9.16.22-S1"
+                                        },
+                                        {
+                                            "version_name": "Development Branch 9.17",
+                                            "version_value": "9.17.0 through versions before 9.17.19"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ISC"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "ISC would like to thank Kishore Kumar Kothapalli of Infoblox for bringing this vulnerability to our attention."
+        }
+    ],
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In BIND 9.3.0 -> 9.11.35, 9.12.0 -> 9.16.21, and versions 9.9.3-S1 -> 9.11.35-S1 and 9.16.8-S1 -> 9.16.21-S1 of BIND Supported Preview Edition, as well as release versions 9.17.0 -> 9.17.18 of the BIND 9.17 development branch, exploitation of broken authoritative servers using a flaw in response processing can cause degradation in BIND resolver performance. The way the lame cache is currently designed makes it possible for its internal data structures to grow almost infinitely, which may cause significant delays in client query processing."
             }
         ]
-    }
+    },
+    "exploit": [
+        {
+            "lang": "eng",
+            "value": "We are not aware of any active exploits."
+        }
+    ],
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Authoritative-only BIND 9 servers are NOT vulnerable to this flaw. The purpose of a resolver's lame cache is to ensure that if an authoritative server responds to a resolver's query in a specific broken way, subsequent client queries for the same <QNAME, QTYPE> tuple do not trigger further queries to the same server for a configurable amount of time. The lame cache is enabled by setting the \"lame-ttl\" option in named.conf to a value greater than 0. That option is set to \"lame-ttl 600;\" in the default configuration, which means the lame cache is enabled by default. A successful attack exploiting this flaw causes a named resolver to spend most of its CPU time on managing and checking the lame cache. This results in client queries being responded to with large delays, and increased likelihood of DNS timeouts on client hosts. Affects BIND 9.3.0 -> 9.11.35, 9.12.0 -> 9.16.21, and versions 9.9.3-S1 -> 9.11.35-S1 and 9.16.8-S1 -> 9.16.21-S1 of BIND Supported Preview Edition, as well as release versions 9.17.0 -> 9.17.18 of the BIND 9.17 development branch."
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://kb.isc.org/v1/docs/cve-2021-25219",
+                "refsource": "CONFIRM",
+                "url": "https://kb.isc.org/v1/docs/cve-2021-25219"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Upgrade to the patched release most closely related to your current version of BIND: BIND 9.11.36, BIND 9.16.22, BIND 9.17.19, or for BIND Supported Preview Edition (a special feature preview branch of BIND provided to eligible ISC support customers): BIND 9.11.36-S1, BIND 9.16.22-S1."
+        }
+    ],
+    "source": {
+        "discovery": "EXTERNAL"
+    },
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "Setting \"lame-ttl 0;\" disables the lame cache and prevents the performance issue. Our research and testing indicate that in the current Internet there is almost no downside to disabling the lame cache."
+        }
+    ]
 }


### PR DESCRIPTION
One BIND 9 vulnerability was publicly disclosed today:

https://lists.isc.org/pipermail/bind-announce/2021-October/001201.html