### PR TITLE
Add CVE-2021-41189 for GHSA-cf2j-vf36-c6w8

### DIFF
--- a/2021/41xxx/CVE-2021-41189.json
+++ b/2021/41xxx/CVE-2021-41189.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-41189",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Communities and collections administrators can escalate their privilege up to system administrator"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "DSpace",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 7.0, < 7.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "DSpace"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "DSpace is an open source turnkey repository application. In version 7.0, any community or collection administrator can escalate their permission up to become system administrator. This vulnerability only exists in 7.0 and does not impact 6.x or below. This issue is patched in version 7.1. As a workaround, users of 7.0 may temporarily disable the ability for community or collection administrators to manage permissions or workflows settings."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.2,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-863: Incorrect Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/DSpace/DSpace/security/advisories/GHSA-cf2j-vf36-c6w8",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/DSpace/DSpace/security/advisories/GHSA-cf2j-vf36-c6w8"
+            },
+            {
+                "name": "https://github.com/DSpace/DSpace/issues/7928",
+                "refsource": "MISC",
+                "url": "https://github.com/DSpace/DSpace/issues/7928"
+            },
+            {
+                "name": "https://github.com/DSpace/DSpace/commit/277b499a5cd3a4f5eb2370513a1b7e4ec2a6e041",
+                "refsource": "MISC",
+                "url": "https://github.com/DSpace/DSpace/commit/277b499a5cd3a4f5eb2370513a1b7e4ec2a6e041"
+            },
+            {
+                "name": "https://github.com/DSpace/DSpace/commit/c3bea16ab911606e15ae96c97a1575e1ffb14f8a",
+                "refsource": "MISC",
+                "url": "https://github.com/DSpace/DSpace/commit/c3bea16ab911606e15ae96c97a1575e1ffb14f8a"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-cf2j-vf36-c6w8",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-41189 for GHSA-cf2j-vf36-c6w8