### PR TITLE
Reject three unused Chrome CVEs.

### DIFF
--- a/2019/5xxx/CVE-2019-5863.json
+++ b/2019/5xxx/CVE-2019-5863.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5863",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5863",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2021/30xxx/CVE-2021-30631.json
+++ b/2021/30xxx/CVE-2021-30631.json
@@ -5,13 +5,13 @@
     "CVE_data_meta": {
         "ID": "CVE-2021-30631",
         "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2021/37xxx/CVE-2021-37960.json
+++ b/2021/37xxx/CVE-2021-37960.json
@@ -5,13 +5,13 @@
     "CVE_data_meta": {
         "ID": "CVE-2021-37960",
         "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "REJECT"
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }


### PR DESCRIPTION
In each case we believed it was a security vulnerability, but
investigation showed it wasn't.