### PR TITLE
Reject another CVE.

### DIFF
--- a/2019/13xxx/CVE-2019-13776.json
+++ b/2019/13xxx/CVE-2019-13776.json
@@ -1,0 +1,18 @@
+{
+    "data_type": "CVE",
+    "data_format": "MITRE",
+    "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-13776",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: some publications have used this number when they meant to use CVE-2019-13376."
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This is unused by the Chrome CNA, but is on the RBP URL list as it
has been referenced at
https://lists.debian.org/debian-lts-announce/2019/10/msg00006.html
It appears to be a plain old typo in that e-mail, and it seems like
the similarly-numbered CVE-2019-13376 matches the description.