### PR TITLE
Populate an old Chrome CVE.

### DIFF
--- a/2017/5xxx/CVE-2017-5123.json
+++ b/2017/5xxx/CVE-2017-5123.json
@@ -1,17 +1,66 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2017-5123",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2017-5123",
+        "ASSIGNER": "chrome-cve-admin@google.com",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "n/a",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "n/a"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "n/a"
+                }
+            ]
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Insufficient data validation"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "https://crbug.com/772848",
+                "refsource": "MISC",
+                "name": "https://crbug.com/772848"
+            },
+            {
+                "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=96ca579a1ecc943b75beba58bebb0356f6cc4b51",
+                "refsource": "MISC",
+                "name": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=96ca579a1ecc943b75beba58bebb0356f6cc4b51"
+            }
+        ]
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Insufficient data validation in waitid allowed an user to escape sandboxes on Linux."
             }
         ]
     }


### PR DESCRIPTION
This was allocated by Chrome, possibly erroneously, on the basis
that Linux was an open source component of ChromeOS and is therefore
in our CNA scope.

However this bug never affected a released version of ChromeOS.

As this is now publicly referenced in various places, it probably
makes most sense just to populate it.