### PR TITLE
Add CVE-2021-41197 for GHSA-prcg-wp5q-rv7p

### DIFF
--- a/2021/41xxx/CVE-2021-41197.json
+++ b/2021/41xxx/CVE-2021-41197.json
@@ -1,18 +1,114 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-41197",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Crashes due to overflow and `CHECK`-fail in ops with large tensor shapes"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "tensorflow",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 2.6.0, < 2.6.1"
+                                        },
+                                        {
+                                            "version_value": ">= 2.5.0, < 2.5.2"
+                                        },
+                                        {
+                                            "version_value": "< 2.4.4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "tensorflow"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "TensorFlow is an open source platform for machine learning. In affected versions TensorFlow allows tensor to have a large number of dimensions and each dimension can be as large as desired. However, the total number of elements in a tensor must fit within an `int64_t`. If an overflow occurs, `MultiplyWithoutOverflow` would return a negative result. In the majority of TensorFlow codebase this then results in a `CHECK`-failure. Newer constructs exist which return a `Status` instead of crashing the binary. This is similar to CVE-2021-29584. The fix will be included in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected and still in supported range."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-190: Integer Overflow or Wraparound"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/tensorflow/tensorflow/security/advisories/GHSA-prcg-wp5q-rv7p",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/tensorflow/tensorflow/security/advisories/GHSA-prcg-wp5q-rv7p"
+            },
+            {
+                "name": "https://github.com/tensorflow/tensorflow/issues/46890",
+                "refsource": "MISC",
+                "url": "https://github.com/tensorflow/tensorflow/issues/46890"
+            },
+            {
+                "name": "https://github.com/tensorflow/tensorflow/issues/51908",
+                "refsource": "MISC",
+                "url": "https://github.com/tensorflow/tensorflow/issues/51908"
+            },
+            {
+                "name": "https://github.com/tensorflow/tensorflow/commit/7c1692bd417eb4f9b33ead749a41166d6080af85",
+                "refsource": "MISC",
+                "url": "https://github.com/tensorflow/tensorflow/commit/7c1692bd417eb4f9b33ead749a41166d6080af85"
+            },
+            {
+                "name": "https://github.com/tensorflow/tensorflow/commit/a871989d7b6c18cdebf2fb4f0e5c5b62fbc19edf",
+                "refsource": "MISC",
+                "url": "https://github.com/tensorflow/tensorflow/commit/a871989d7b6c18cdebf2fb4f0e5c5b62fbc19edf"
+            },
+            {
+                "name": "https://github.com/tensorflow/tensorflow/commit/d81b1351da3e8c884ff836b64458d94e4a157c15",
+                "refsource": "MISC",
+                "url": "https://github.com/tensorflow/tensorflow/commit/d81b1351da3e8c884ff836b64458d94e4a157c15"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-prcg-wp5q-rv7p",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-41197 for GHSA-prcg-wp5q-rv7p