### PR TITLE
Add CVE-2021-41253 for GHSA-q42v-hv86-3m4g

### DIFF
--- a/2021/41xxx/CVE-2021-41253.json
+++ b/2021/41xxx/CVE-2021-41253.json
@@ -1,18 +1,106 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-41253",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Possible heap buffer overflow when using zycore string functions in formatter hooks"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "zydis",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 3.2.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "zyantific"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Zydis is an x86/x86-64 disassembler library. Users of Zydis versions v3.2.0 and older that use the string functions provided in `zycore` in order to append untrusted user data to the formatter buffer within their custom formatter hooks can run into heap buffer overflows. Older versions of Zydis failed to properly initialize the string object within the formatter buffer, forgetting to initialize a few fields, leaving their value to chance. This could then in turn cause zycore functions like `ZyanStringAppend` to make incorrect calculations for the new target size, resulting in heap memory corruption. This does not affect the regular uncustomized Zydis formatter, because Zydis internally doesn't use the string functions in zycore that act upon these fields. However, because the zycore string functions are the intended way to work with the formatter buffer for users of the library that wish to extend the formatter, we still consider this to be a vulnerability in Zydis. This bug is patched starting in version 3.2.1. As a workaround, users may refrain from using zycore string functions in their formatter hooks until updating to a patched version."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.9,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-122: Heap-based Buffer Overflow"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-457: Use of Uninitialized Variable"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/zyantific/zydis/security/advisories/GHSA-q42v-hv86-3m4g",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/zyantific/zydis/security/advisories/GHSA-q42v-hv86-3m4g"
+            },
+            {
+                "name": "https://github.com/zyantific/zydis/commit/55dd08c210722aed81b38132f5fd4a04ec1943b5",
+                "refsource": "MISC",
+                "url": "https://github.com/zyantific/zydis/commit/55dd08c210722aed81b38132f5fd4a04ec1943b5"
+            },
+            {
+                "name": "https://huntr.dev/bounties/96b0a482-7041-45b1-9327-c6a4a8f32d3a",
+                "refsource": "MISC",
+                "url": "https://huntr.dev/bounties/96b0a482-7041-45b1-9327-c6a4a8f32d3a"
+            },
+            {
+                "name": "https://huntr.dev/bounties/d2536d7d-36ce-4723-928c-98d1ee039784",
+                "refsource": "MISC",
+                "url": "https://huntr.dev/bounties/d2536d7d-36ce-4723-928c-98d1ee039784"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-q42v-hv86-3m4g",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-41253 for GHSA-q42v-hv86-3m4g