### PR TITLE
Add CVE-2021-25974, CVE-2021-25975

### DIFF
--- a/2021/25xxx/CVE-2021-25974.json
+++ b/2021/25xxx/CVE-2021-25974.json
@@ -1,18 +1,100 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "vulnerabilitylab@whitesourcesoftware.com",
         "ID": "CVE-2021-25974",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Publify - Stored Cross-Site Scripting (XSS) in Editor"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "publify_core",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v8.0"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "v9.2.4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "publify_core"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Publify, versions v8.0 to v9.2.4 are vulnerable to stored XSS. A user with a “publisher” role is able to inject and execute arbitrary JavaScript code while creating a page/article."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79 Cross-site Scripting (XSS)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://github.com/publify/publify/commit/fefd5f76302adcc425b2b6e7e7d23587cfc0083e"
+            },
+            {
+                "refsource": "MISC",
+                "url": "https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-25974"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update to v9.2.5"
+        }
+    ],
+    "source": {
+        "advisory": "https://www.whitesourcesoftware.com/vulnerability-database/",
+        "discovery": "UNKNOWN"
     }
 }

--- a/2021/25xxx/CVE-2021-25975.json
+++ b/2021/25xxx/CVE-2021-25975.json
@@ -1,18 +1,100 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "vulnerabilitylab@whitesourcesoftware.com",
         "ID": "CVE-2021-25975",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Publify - Stored Cross-Site Scripting (XSS) due to Unrestricted File Upload"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "publify_core",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v8.0"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "v9.2.4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "publify_core"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In publify, versions v8.0 to v9.2.4 are vulnerable to stored XSS as a result of an unrestricted file upload. This issue allows a user with “publisher” role to inject malicious JavaScript via the uploaded html file."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79 Cross-site Scripting (XSS)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://github.com/publify/publify/commit/d99c0870d3dbbfde7febdc6cad33199b84770101"
+            },
+            {
+                "refsource": "MISC",
+                "url": "https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-25974"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update to v9.2.5"
+        }
+    ],
+    "source": {
+        "advisory": "https://www.whitesourcesoftware.com/vulnerability-database/",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
CVE-2021-25974 - Publify - Stored Cross-Site Scripting (XSS) in Editor
CVE-2021-25975 - Publify - Stored Cross-Site Scripting (XSS) due to Unrestricted File Upload
Committed by: Hagai Wechsler