### PR TITLE
2021/41xxx/CVE-2021-41038.json

### DIFF
--- a/2021/41xxx/CVE-2021-41038.json
+++ b/2021/41xxx/CVE-2021-41038.json
@@ -4,14 +4,64 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2021-41038",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security@eclipse.org",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "The Eclipse Foundation",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "@theia/plugin-ext",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "1.18.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In versions of the @theia/plugin-ext component of Eclipse Theia prior to 1.18.0, Webview contents can be hijacked via postMessage()."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-940: Improper Verification of Source of a Communication Channel"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=575924",
+                "refsource": "CONFIRM",
+                "url": "https://bugs.eclipse.org/bugs/show_bug.cgi?id=575924"
+            },
+            {
+                "name": "https://github.com/eclipse-theia/theia/pull/10125",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/eclipse-theia/theia/pull/10125"
             }
         ]
     }


### PR DESCRIPTION
Signed-off-by: Wayne Beaton <wayne.beaton@eclipse-foundation.org>