### PR TITLE
Add CVE-2021-25980

### DIFF
--- a/2021/25xxx/CVE-2021-25980.json
+++ b/2021/25xxx/CVE-2021-25980.json
@@ -1,18 +1,122 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "vulnerabilitylab@whitesourcesoftware.com",
         "ID": "CVE-2021-25980",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Talkyard - Host-Header Injection Leads to Account Takeover"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "talkyard",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_name": "v0",
+                                            "version_value": "v0.04.01"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "v0",
+                                            "version_value": "v0.6.74-WIP-63220cb"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_name": "v0.2020",
+                                            "version_value": "v0.2020.22-WIP-b2e97fe0e"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "v0.2021",
+                                            "version_value": "v0.2021.02-WIP-879ef3fe1"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_name": "tyse-v0.2021",
+                                            "version_value": "tyse-v0.2021.02-879ef3fe1-regular"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "tyse-v0.2021",
+                                            "version_value": "tyse-v0.2021.28-af66b6905-regular"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "debiki"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Talkyard, versions v0.04.01 through v0.6.74-WIP-63220cb, v0.2020.22-WIP-b2e97fe0e through v0.2021.02-WIP-879ef3fe1 and tyse-v0.2021.02-879ef3fe1-regular through tyse-v0.2021.28-af66b6905-regular, are vulnerable to Host Header Injection. By luring a victim application-user to click on a link, an unauthenticated attacker can use the “forgot password” functionality to reset the victim’s password and successfully take over their account."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-74 Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://github.com/debiki/talkyard/commit/4067e191a909ed06f250d09a40e43aa5edbb0289"
+            },
+            {
+                "refsource": "MISC",
+                "url": "https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-25980"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update to tyse-v0.2021.29-8cb7f73fe-regular or later"
+        }
+    ],
+    "source": {
+        "advisory": "https://www.whitesourcesoftware.com/vulnerability-database/",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Talkyard - Host-Header Injection Leads to Account Takeover
Committed by: Hagai Wechsler