### PR TITLE
Add CVE-2021-41263 for GHSA-844m-cpr9-jcmh

### DIFF
--- a/2021/41xxx/CVE-2021-41263.json
+++ b/2021/41xxx/CVE-2021-41263.json
@@ -1,18 +1,96 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-41263",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Secure/signed cookies share secrets between sites in rails_multisite"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "rails_multisite",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 4.0.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "discourse"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "rails_multisite provides multi-db support for Rails applications. In affected versions this vulnerability impacts any Rails applications using `rails_multisite` alongside Rails' signed/encrypted cookies. Depending on how the application makes use of these cookies, it may be possible for an attacker to re-use cookies on different 'sites' within a multi-site Rails application. The issue has been patched in v4 of the `rails_multisite` gem. Note that this upgrade will invalidate all previous signed/encrypted cookies. The impact of this invalidation will vary based on the application architecture."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.3,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-565: Reliance on Cookies without Validation and Integrity Checking"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/discourse/rails_multisite/security/advisories/GHSA-844m-cpr9-jcmh",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/discourse/rails_multisite/security/advisories/GHSA-844m-cpr9-jcmh"
+            },
+            {
+                "name": "https://github.com/discourse/rails_multisite/commit/c6785cdb5c9277dd2c5ac8d55180dd1ece440ed0",
+                "refsource": "MISC",
+                "url": "https://github.com/discourse/rails_multisite/commit/c6785cdb5c9277dd2c5ac8d55180dd1ece440ed0"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-844m-cpr9-jcmh",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-41263 for GHSA-844m-cpr9-jcmh