### PR TITLE
blacksmith CVE-2021-42114

### DIFF
--- a/2021/42xxx/CVE-2021-42114.json
+++ b/2021/42xxx/CVE-2021-42114.json
@@ -1,18 +1,202 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "AKA": "Blacksmith",
+        "ASSIGNER": "vulnerability@ncsc.ch",
+        "DATE_PUBLIC": "2021-11-15T16:00:00.000Z",
         "ID": "CVE-2021-42114",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Scalable Rowhammering In the Frequency Domain to Bypass TRR Mitigations On Modern DDR4/LPDDR4X Devices"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Micron ddr4_sdram",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Micron"
+                },
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Samsung ddr4_sdram",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Samsung"
+                },
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "SK Hynix ddr4_sdram",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "SK Hynix"
+                },
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Micron lpddr4",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Micron"
+                },
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Samsung lpddr4",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Samsung"
+                },
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "SK Hynix lpddr4",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "SK Hynix"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Kaveh Razavi, Patrick Jattke, Stijn Gunter; Eidgenössische Technische Hochschule (ETH) Zürich"
+        },
+        {
+            "lang": "eng",
+            "value": "Victor van der Veen; Qualcomm Technologies Inc."
+        },
+        {
+            "lang": "eng",
+            "value": "Pietro Frigo; VU Amsterdam"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Modern DRAM devices (PC-DDR4, LPDDR4X) are affected by a vulnerability in their internal Target Row Refresh (TRR) mitigation against Rowhammer attacks. Novel non-uniform Rowhammer access patterns, consisting of aggressors with different frequencies, phases, and amplitudes allow triggering bit flips on affected memory modules using our Blacksmith fuzzer. The patterns generated by Blacksmith were able to trigger bitflips on all 40 PC-DDR4 DRAM devices in our test pool, which cover the three major DRAM manufacturers: Samsung, SK Hynix, and Micron. This means that, even when chips advertised as Rowhammer-free are used, attackers may still be able to exploit Rowhammer. For example, this enables privilege-escalation attacks against the kernel or binaries such as the sudo binary, and also triggering bit flips in RSA-2048 keys (e.g., SSH keys) to gain cross-tenant virtual-machine access. We can confirm that DRAM devices acquired in July 2020 with DRAM chips from all three major DRAM vendors (Samsung, SK Hynix, Micron) are affected by this vulnerability. For more details, please refer to our publication."
             }
         ]
-    }
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-20: Improper Input Validation"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://comsec.ethz.ch/wp-content/files/blacksmith_sec22.pdf",
+                "refsource": "CONFIRM",
+                "url": "https://comsec.ethz.ch/wp-content/files/blacksmith_sec22.pdf"
+            },
+            {
+                "name": "https://comsec.ethz.ch/research/dram/blacksmith/",
+                "refsource": "MISC",
+                "url": "https://comsec.ethz.ch/research/dram/blacksmith/"
+            },
+            {
+                "name": "https://github.com/comsec-group/blacksmith",
+                "refsource": "MISC",
+                "url": "https://github.com/comsec-group/blacksmith"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
+    },
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "Using ECC DRAM substantially increases the difficulty of carrying out Rowhammer attacks on systems, although previous work [1] showed that it does not provide complete protection.\n\n[1] L. Cojocar, K. Razavi, C. Giuffrida, and H. Bos, “Exploiting Correcting Codes: On the Effectiveness of ECC Memory Against Rowhammer Attacks,” San Francisco, CA, USA, May 2019, pp. 55–71. DOI: 10.1109/SP.2019.00089. "
+        }
+    ]
 }


### PR DESCRIPTION
Added CVE for blacksmith https://comsec.ethz.ch/research/dram/blacksmith/
