### PR TITLE
Add CVE-2021-25965

### DIFF
--- a/2021/25xxx/CVE-2021-25965.json
+++ b/2021/25xxx/CVE-2021-25965.json
@@ -1,18 +1,106 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "vulnerabilitylab@whitesourcesoftware.com",
         "ID": "CVE-2021-25965",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Calibre-web - Admin Account Takeover via Cross-Site Request Forgery (CSRF)"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "calibreweb",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "0.6.0"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "0.6.13"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "calibreweb"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "WhiteSource Vulnerability Research Team (WVR)"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Calibre-web, versions 0.6.0 to 0.6.13 are vulnerable to Cross-Site Request Forgery (CSRF). By luring an authenticated user to click on a link, an attacker can create a new user role with admin privileges and attacker-controlled credentials, allowing them to take over the application."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-352 Cross-Site Request Forgery (CSRF)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://github.com/janeczku/calibre-web/commit/50919d47212066c75f03ee7a5332ecf2d584b98e"
+            },
+            {
+                "refsource": "MISC",
+                "url": "https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-25965"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update to 0.6.14"
+        }
+    ],
+    "source": {
+        "advisory": "https://www.whitesourcesoftware.com/vulnerability-database/",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Calibre-web - Admin Account Takeover via Cross-Site Request Forgery (CSRF)
Committed by: Hagai Wechsler