### PR TITLE
CVE-2021-25743: ANSI escape characters in kubectl output are not bein…

### DIFF
--- a/2021/25xxx/CVE-2021-25743.json
+++ b/2021/25xxx/CVE-2021-25743.json
@@ -1,18 +1,112 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security@kubernetes.io",
+        "DATE_PUBLIC": "2021-05-02T12:06:00.000Z",
         "ID": "CVE-2021-25743",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "ANSI escape characters in kubectl output are not being filtered"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Kubernetes",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "1.22.4"
+                                        },
+                                        {
+                                            "version_affected": "?>",
+                                            "version_value": "1.22.4"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "1.21.7"
+                                        },
+                                        {
+                                            "version_affected": "?>",
+                                            "version_value": "1.21.7"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "1.20.13"
+                                        },
+                                        {
+                                            "version_affected": "?>",
+                                            "version_value": "1.20.13"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Kubernetes"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Eviatar Gerzi"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "kubectl does not neutralize escape, meta or control sequences contained in the raw data it outputs to a terminal. This includes but is not limited to the output of kubectl logs, kubectl attach, or the unstructured string fields in objects such as Events."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 3,
+            "baseSeverity": "LOW",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:N/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-150: Improper Neutralization of Escape, Meta, or Control Sequences"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://github.com/kubernetes/kubernetes/issues/101695"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
Populate CVE-2021-25743: ANSI escape characters in kubectl output are not being filtered