### PR TITLE
XSA-390 CVE-2021-28710

### DIFF
--- a/2021/28xxx/CVE-2021-28710.json
+++ b/2021/28xxx/CVE-2021-28710.json
@@ -1,18 +1,116 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28710",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28710"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.15.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Xen version 4.15 is vulnerable.  Xen versions 4.14 and earlier are not\nvulnerable.\n\nOnly x86 Intel systems with IOMMU(s) in use are affected.  Arm\nsystems, non-Intel x86 systems, and x86 systems without IOMMU are not\naffected.\n\nOnly HVM guests with passed-through PCI devices and configured to share\nIOMMU and EPT page tables are able to leverage the vulnerability on\naffected hardware.  Note that page table sharing is the default\nconfiguration on capable hardware.\n\nSystems are only affected if the IOMMU used for a passed through\ndevice requires the use of page tables less than 4 levels deep.  We\nare informed that this is the case for some at least Ivybridge and\nearlier \"client\" chips; additionally it might be possible for such a\nsituation to arise when Xen is running nested under another\nhypervisor, if an (emulated) Intel IOMMU is made available to Xen."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "certain VT-d IOMMUs may not work in shared page table mode\n\nFor efficiency reasons, address translation control structures (page\ntables) may (and, on suitable hardware, by default will) be shared\nbetween CPUs, for second-level translation (EPT), and IOMMUs.  These\npage tables are presently set up to always be 4 levels deep.  However,\nan IOMMU may require the use of just 3 page table levels.  In such a\nconfiguration the lop level table needs to be stripped before\ninserting the root table's address into the hardware pagetable base\nregister.  When sharing page tables, Xen erroneously skipped this\nstripping.  Consequently, the guest is able to write to leaf page\ntable entries."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "A malicious guest may be able to escalate its privileges to that of\nthe host."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-390.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Suppressing the use of shared page tables avoids the vulnerability.\nThis can be achieved globally by passing \"iommu=no-sharept\" on the\nhypervisor command line.  This can also be achieved on a per-guest basis\nvia the \"passthrough=sync_pt\" xl guest configuration file option."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-390 CVE-2021-28710

CVE data entry for:
  CVE-2021-28710

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
