### PR TITLE
XSA-385 CVE-2021-28706

### DIFF
--- a/2021/28xxx/CVE-2021-28706.json
+++ b/2021/28xxx/CVE-2021-28706.json
@@ -1,18 +1,146 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28706",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28706"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.12.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.14.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "4.15.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.13.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from at least 3.2 onwards are affected.\n\nOn x86, only Xen builds with the BIGMEM configuration option enabled are\naffected.  (This option is off by default.)\n\nOnly hosts with more than 16 TiB of memory are affected."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Julien Grall of Amazon."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "guests may exceed their designated memory limit\n\nWhen a guest is permitted to have close to 16TiB of memory, it may be\nable to issue hypercalls to increase its memory allocation beyond the\nadministrator established limit.  This is a result of a calculation\ndone with 32-bit precision, which may overflow.  It would then only\nbe the overflowed (and hence small) number which gets compared against\nthe established upper bound."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "A guest may be able too allocate unbounded amounts of memory to itself.\nThis may result in a Denial of Service (DoS) affecting the entire host."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-385.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Setting the maximum amount of memory a guest may allocate to strictly\nless than 1023 GiB will avoid the vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-385 CVE-2021-28706

CVE data entry for:
  CVE-2021-28706

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
