### PR TITLE
XSA-387 CVE-2021-28703

### DIFF
--- a/2021/28xxx/CVE-2021-28703.json
+++ b/2021/28xxx/CVE-2021-28703.json
@@ -15,6 +15,48 @@
          }
       }
    },
+
+"affects": {
+    "vendor": {
+        "vendor_data": [
+            {
+                "product": {
+                    "product_data": [
+                        {
+                            "product_name": "Xen",
+                            "version": {
+                                "version_data": [
+                                    {
+                                        "version_affected": "!",
+                                        "version_name": "Branch 4.13.4",
+                                        "version_value": "4.13.4"
+                                    },
+                                    {
+                                        "version_affected": "!",
+                                        "version_name": "Branch 4.14.x",
+                                        "version_value": "4.14.x"
+                                    },
+                                    {
+                                        "version_affected": "!",
+                                        "version_name": "Branch 4.15.x",
+                                        "version_value": "4.15.x"
+                                    },
+                                    {
+                                        "version_affected": "<=",
+                                        "version_name": "Branch 4.13",
+                                        "version_value": "4.13"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "vendor_name": "Xen Project"
+            }
+        ]
+    }
+},
+
    "credit" : {
       "credit_data" : {
          "description" : {

--- a/2021/28xxx/CVE-2021-28703.json
+++ b/2021/28xxx/CVE-2021-28703.json
@@ -1,18 +1,84 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28703",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
-    }
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28703"
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen branches up to and including 4.13 are vulnerable,\nbut only if the patches for XSA-378 have not been applied.\n\nXen versions 4.13.4, 4.14.x and 4.15.x are not affected.\n\nOnly x86 HMV and PVH guests permitted to use grant table version 2\ninterfaces can leverage this vulnerability.  x86 PV guests cannot\nleverage this vulnerability.  On Arm, grant table v2 use is explicitly\nunsupported."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Patryk Balicki and Julien Grall of Amazon."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "grant table v2 status pages may remain accessible after de-allocation (take two)\n\nGuest get permitted access to certain Xen-owned pages of memory.  The\nmajority of such pages remain allocated / associated with a guest for\nits entire lifetime.  Grant table v2 status pages, however, get\nde-allocated when a guest switched (back) from v2 to v1.  The freeing\nof such pages requires that the hypervisor know where in the guest\nthese pages were mapped.  The hypervisor tracks only one use within\nguest space, but racing requests from the guest to insert mappings of\nthese pages may result in any of them to become mapped in multiple\nlocations.  Upon switching back from v2 to v1, the guest would then\nretain access to a page that was freed and perhaps re-used for other\npurposes.\n\nThis bug was fortuitously fixed by code cleanup in Xen 4.14, and\nbackported to security-supported Xen branches as a prerequisite of the\nfix for XSA-378."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "A malicious guest may be able to elevate its privileges to that of the\nhost, cause host or guest Denial of Service (DoS), or cause information\nleaks."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-387.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Running only PV guests will avoid this vulnerability.\n\nSuppressing use of grant table v2 interfaces for HVM or PVH guests will\nalso avoid this vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-387 CVE-2021-28703

CVE data entry for:
  CVE-2021-28703

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
