### PR TITLE
XSA-388 CVE-2021-28704 CVE-2021-28707 CVE-2021-28708

### DIFF
--- a/2021/28xxx/CVE-2021-28704.json
+++ b/2021/28xxx/CVE-2021-28704.json
@@ -1,18 +1,136 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28704",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28704"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.12.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.15.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from 4.7 onwards are affected.  Xen versions 4.6 and\nolder are not affected.\n\nOnly x86 HVM and PVH guests started in populate-on-demand mode can\nleverage the vulnerability.  Populate-on-demand mode is activated\nwhen the guest's xl configuration file specifies a \"maxmem\" value which\nis larger than the \"memory\" value."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "PoD operations on misaligned GFNs\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nx86 HVM and PVH guests may be started in populate-on-demand (PoD) mode,\nto provide a way for them to later easily have more memory assigned.\n\nGuests are permitted to control certain P2M aspects of individual\npages via hypercalls.  These hypercalls may act on ranges of pages\nspecified via page orders (resulting in a power-of-2 number of pages).\nThe implementation of some of these hypercalls for PoD does not\nenforce the base page frame number to be suitably aligned for the\nspecified order, yet some code involved in PoD handling actually makes\nsuch an assumption.\n\nThese operations are XENMEM_decrease_reservation (CVE-2021-28704) and\nXENMEM_populate_physmap (CVE-2021-28707), the latter usable only by\ndomains controlling the guest, i.e. a de-privileged qemu or a stub\ndomain.  (Patch 1, combining the fix to both these two issues.)\n\nIn addition handling of XENMEM_decrease_reservation can also trigger a\nhost crash when the specified page order is neither 4k nor 2M nor 1G\n(CVE-2021-28708, patch 2)."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Malicious or buggy guest kernels may be able to mount a Denial of\nService (DoS) attack affecting the entire system.  Privilege escalation\nand information leaks cannot be ruled out."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-388.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not starting x86 HVM or PVH guests in populate-on-demand mode will avoid\nthe vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2021/28xxx/CVE-2021-28707.json
+++ b/2021/28xxx/CVE-2021-28707.json
@@ -1,18 +1,136 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28707",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28707"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.12.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.15.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from 4.7 onwards are affected.  Xen versions 4.6 and\nolder are not affected.\n\nOnly x86 HVM and PVH guests started in populate-on-demand mode can\nleverage the vulnerability.  Populate-on-demand mode is activated\nwhen the guest's xl configuration file specifies a \"maxmem\" value which\nis larger than the \"memory\" value."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "PoD operations on misaligned GFNs\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nx86 HVM and PVH guests may be started in populate-on-demand (PoD) mode,\nto provide a way for them to later easily have more memory assigned.\n\nGuests are permitted to control certain P2M aspects of individual\npages via hypercalls.  These hypercalls may act on ranges of pages\nspecified via page orders (resulting in a power-of-2 number of pages).\nThe implementation of some of these hypercalls for PoD does not\nenforce the base page frame number to be suitably aligned for the\nspecified order, yet some code involved in PoD handling actually makes\nsuch an assumption.\n\nThese operations are XENMEM_decrease_reservation (CVE-2021-28704) and\nXENMEM_populate_physmap (CVE-2021-28707), the latter usable only by\ndomains controlling the guest, i.e. a de-privileged qemu or a stub\ndomain.  (Patch 1, combining the fix to both these two issues.)\n\nIn addition handling of XENMEM_decrease_reservation can also trigger a\nhost crash when the specified page order is neither 4k nor 2M nor 1G\n(CVE-2021-28708, patch 2)."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Malicious or buggy guest kernels may be able to mount a Denial of\nService (DoS) attack affecting the entire system.  Privilege escalation\nand information leaks cannot be ruled out."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-388.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not starting x86 HVM or PVH guests in populate-on-demand mode will avoid\nthe vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2021/28xxx/CVE-2021-28708.json
+++ b/2021/28xxx/CVE-2021-28708.json
@@ -1,18 +1,136 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28708",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28708"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?<",
+                                 "version_value" : "4.12"
+                              },
+                              {
+                                 "version_affected" : ">=",
+                                 "version_value" : "4.12.x"
+                              },
+                              {
+                                 "version_affected" : "!>",
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.15.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from 4.7 onwards are affected.  Xen versions 4.6 and\nolder are not affected.\n\nOnly x86 HVM and PVH guests started in populate-on-demand mode can\nleverage the vulnerability.  Populate-on-demand mode is activated\nwhen the guest's xl configuration file specifies a \"maxmem\" value which\nis larger than the \"memory\" value."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "PoD operations on misaligned GFNs\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nx86 HVM and PVH guests may be started in populate-on-demand (PoD) mode,\nto provide a way for them to later easily have more memory assigned.\n\nGuests are permitted to control certain P2M aspects of individual\npages via hypercalls.  These hypercalls may act on ranges of pages\nspecified via page orders (resulting in a power-of-2 number of pages).\nThe implementation of some of these hypercalls for PoD does not\nenforce the base page frame number to be suitably aligned for the\nspecified order, yet some code involved in PoD handling actually makes\nsuch an assumption.\n\nThese operations are XENMEM_decrease_reservation (CVE-2021-28704) and\nXENMEM_populate_physmap (CVE-2021-28707), the latter usable only by\ndomains controlling the guest, i.e. a de-privileged qemu or a stub\ndomain.  (Patch 1, combining the fix to both these two issues.)\n\nIn addition handling of XENMEM_decrease_reservation can also trigger a\nhost crash when the specified page order is neither 4k nor 2M nor 1G\n(CVE-2021-28708, patch 2)."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Malicious or buggy guest kernels may be able to mount a Denial of\nService (DoS) attack affecting the entire system.  Privilege escalation\nand information leaks cannot be ruled out."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-388.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not starting x86 HVM or PVH guests in populate-on-demand mode will avoid\nthe vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-388 CVE-2021-28704 CVE-2021-28707 CVE-2021-28708

CVE data entry for:
  CVE-2021-28704

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2021-28707

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2021-28708

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
