### PR TITLE
XSA-389 CVE-2021-28705 CVE-2021-28709

### DIFF
--- a/2021/28xxx/CVE-2021-28705.json
+++ b/2021/28xxx/CVE-2021-28705.json
@@ -1,18 +1,147 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28705",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28705"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.12.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.15.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.13.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from 3.4 onwards are affected.  Xen versions 3.3 and\nolder are believed to not be affected.\n\nOnly x86 HVM and PVH guests started in populate-on-demand mode are\nbelieved to be able to leverage the vulnerability.  Populate-on-demand\nmode is activated when the guest's xl configuration file specifies a\n\"maxmem\" value which is larger than the \"memory\" value."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "issues with partially successful P2M updates on x86\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nx86 HVM and PVH guests may be started in populate-on-demand (PoD) mode,\nto provide a way for them to later easily have more memory assigned.\n\nGuests are permitted to control certain P2M aspects of individual\npages via hypercalls.  These hypercalls may act on ranges of pages\nspecified via page orders (resulting in a power-of-2 number of pages).\nIn some cases the hypervisor carries out the requests by splitting\nthem into smaller chunks.  Error handling in certain PoD cases has\nbeen insufficient in that in particular partial success of some\noperations was not properly accounted for.\n\nThere are two code paths affected - page removal (CVE-2021-28705) and\ninsertion of new pages (CVE-2021-28709).  (We provide one patch which\ncombines the fix to both issues.)"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Malicious or buggy guest kernels may be able to mount a Denial of\nService (DoS) attack affecting the entire system.  Privilege escalation\nand information leaks cannot be ruled out."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-389.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not starting x86 HVM or PVH guests in populate-on-demand mode is\nbelieved to allow avoiding the vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2021/28xxx/CVE-2021-28709.json
+++ b/2021/28xxx/CVE-2021-28709.json
@@ -1,18 +1,147 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28709",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28709"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.14.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.12.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.15.x"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "xen-unstable"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_value" : "4.13.x"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from 3.4 onwards are affected.  Xen versions 3.3 and\nolder are believed to not be affected.\n\nOnly x86 HVM and PVH guests started in populate-on-demand mode are\nbelieved to be able to leverage the vulnerability.  Populate-on-demand\nmode is activated when the guest's xl configuration file specifies a\n\"maxmem\" value which is larger than the \"memory\" value."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "issues with partially successful P2M updates on x86\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nx86 HVM and PVH guests may be started in populate-on-demand (PoD) mode,\nto provide a way for them to later easily have more memory assigned.\n\nGuests are permitted to control certain P2M aspects of individual\npages via hypercalls.  These hypercalls may act on ranges of pages\nspecified via page orders (resulting in a power-of-2 number of pages).\nIn some cases the hypervisor carries out the requests by splitting\nthem into smaller chunks.  Error handling in certain PoD cases has\nbeen insufficient in that in particular partial success of some\noperations was not properly accounted for.\n\nThere are two code paths affected - page removal (CVE-2021-28705) and\ninsertion of new pages (CVE-2021-28709).  (We provide one patch which\ncombines the fix to both issues.)"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Malicious or buggy guest kernels may be able to mount a Denial of\nService (DoS) attack affecting the entire system.  Privilege escalation\nand information leaks cannot be ruled out."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-389.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not starting x86 HVM or PVH guests in populate-on-demand mode is\nbelieved to allow avoiding the vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-389 CVE-2021-28705 CVE-2021-28709

CVE data entry for:
  CVE-2021-28705

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2021-28709

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
