### PR TITLE
Update CVE-2021-25969

### DIFF
--- a/2021/25xxx/CVE-2021-25969.json
+++ b/2021/25xxx/CVE-2021-25969.json
@@ -40,7 +40,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In “Camaleon CMS” application, versions 0.0.1 to 2.6.0 are vulnerable to stored XSS, that allows unprivileged application users to store malicious scripts in the comments section of the post. These scripts are executed in a victim’s browser when they open the page containing the malicious comment."
+                "value": "In “Camaleon CMS” application, versions 0.0.1 to 2.6.0 are vulnerable to stored XSS, that allows an unauthenticated user to store malicious scripts in the comments section of the post. These scripts are executed in a victim’s browser when they open the page containing the malicious comment."
             }
         ]
     },


### PR DESCRIPTION
After coordinating with NVD about the Privileges Required metric, it was agreed that the public description should reflect that the attacker is unauthenticated, so NVD could properly modify their score.
Committed by: Hagai Wechsler