### PR TITLE
Add CVE-2021-43794 for GHSA-249g-pc77-65hp

### DIFF
--- a/2021/43xxx/CVE-2021-43794.json
+++ b/2021/43xxx/CVE-2021-43794.json
@@ -1,18 +1,94 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-43794",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Anonymous user cache poisoning via development-mode header in Discourse"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "discourse",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "stable < 2.7.11"
+                                        },
+                                        {
+                                            "version_value": "beta < 2.8.0.beta9"
+                                        },
+                                        {
+                                            "version_value": "tests-passed < 2.8.0.beta9"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "discourse"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Discourse is an open source discussion platform. In affected versions an attacker can poison the cache for anonymous (i.e. not logged in) users, such that the users are shown a JSON blob instead of the HTML page. This can lead to a partial denial-of-service. This issue is patched in the latest stable, beta and tests-passed versions of Discourse."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-610: Externally Controlled Reference to a Resource in Another Sphere"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/discourse/discourse/security/advisories/GHSA-249g-pc77-65hp",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/discourse/discourse/security/advisories/GHSA-249g-pc77-65hp"
+            },
+            {
+                "name": "https://github.com/discourse/discourse/commit/2da0001965c6d8632d723c46ea5df9f22a1a23f1",
+                "refsource": "MISC",
+                "url": "https://github.com/discourse/discourse/commit/2da0001965c6d8632d723c46ea5df9f22a1a23f1"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-249g-pc77-65hp",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-43794 for GHSA-249g-pc77-65hp