### PR TITLE
CVE-2021-22568 - No destination checking in Dart publish can lead to …

### DIFF
--- a/2021/22xxx/CVE-2021-22568.json
+++ b/2021/22xxx/CVE-2021-22568.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-22568",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
-    }
+  "CVE_data_meta": {
+      "ASSIGNER": "security@google.com",
+      "ID": "CVE-2021-22568",
+      "STATE": "PUBLIC",
+      "TITLE": "Dart - Publishing to third-party package repositories may expose pub.dev credentials"
+  },
+  "affects": {
+      "vendor": {
+          "vendor_data": [
+              {
+                  "product": {
+                      "product_data": [
+                          {
+                              "product_name": "Dart SDK",
+                              "version": {
+                                  "version_data": [
+                                      {
+                                          "version_affected": "<",
+                                          "version_value": "2.15.0"
+                                      }
+                                  ]
+                              }
+                          }
+                      ]
+                  },
+                  "vendor_name": "Google LLC"
+              }
+          ]
+      }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+      "description_data": [
+          {
+              "lang": "eng",
+              "value": "When using the dart pub publish command to publish a package to a third-party package server, the request would be authenticated with an oauth2 access_token that is valid for publishing on pub.dev. Using these obtained credentials, an attacker can impersonate the user on pub.dev. We recommend upgrading past https://github.com/dart-lang/sdk/commit/d787e78d21e12ec1ef712d229940b1172aafcdf8 or beyond version 2.15.0 "
+          }
+      ]
+  },
+  "generator": {
+      "engine": "Vulnogram 0.0.9"
+  },
+  "impact": {
+      "cvss": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "LOW",
+          "baseScore": 8.8,
+          "baseSeverity": "HIGH",
+          "confidentialityImpact": "LOW",
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "CHANGED",
+          "userInteraction": "REQUIRED",
+          "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:H/A:L",
+          "version": "3.1"
+      }
+  },
+  "problemtype": {
+      "problemtype_data": [
+          {
+              "description": [
+                  {
+                      "lang": "eng",
+                      "value": "CWE-255 Credentials Management"
+                  }
+              ]
+          }
+      ]
+  },
+  "references": {
+      "reference_data": [
+          {
+              "refsource": "CONFIRM",
+              "url": "https://github.com/dart-lang/sdk/commit/d787e78d21e12ec1ef712d229940b1172aafcdf8"
+          },
+          {
+              "refsource": "CONFIRM",
+              "url": "https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md"
+          },
+          {
+              "refsource": "CONFIRM",
+              "url": "https://github.com/dart-lang/sdk/security/advisories/GHSA-r32f-vhjp-qhj7"
+          }
+      ]
+  },
+  "source": {
+      "discovery": "UNKNOWN"
+  }
 }


### PR DESCRIPTION
…exposed credentials