### PR TITLE
Updates for CVE-2021-42138

### DIFF
--- a/2021/42xxx/CVE-2021-42138.json
+++ b/2021/42xxx/CVE-2021-42138.json
@@ -5,14 +5,95 @@
     "CVE_data_meta": {
         "ID": "CVE-2021-42138",
         "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Safenet Authentication Service",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "Windows Logon Agent",
+                                            "version_value": "3.4.4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Thales CPL"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "compass-security"
+        }
+    ],
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A user of a machine protected by SafeNet Agent for Windows Logon may leverage weak entropy to access the encrypted credentials of any or all the users on that machine."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.2,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "https://cwe.mitre.org/data/definitions/336.html"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://supportportal.gemalto.com/csm?sys_kb_id=a52bd13adbff7010f0e322080596194a&id=kb_article_view&sysparm_rank=1&sysparm_tsqueryId=b3bdd932db33b010f0e3220805961955"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://supportportal.gemalto.com/csm?sys_kb_id=e8397662dbb7fc10520c4705059619eb&id=kb_article_view&sysparm_rank=2&sysparm_tsqueryId=b3bdd932db33b010f0e3220805961955"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://cpl.thalesgroup.com/support/security-updates"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }

--- a/2021/42xxx/CVE-2021-42138.json
+++ b/2021/42xxx/CVE-2021-42138.json
@@ -4,7 +4,7 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2021-42138",
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "psirt@thalesgroup.com",
         "STATE": "PUBLIC"
     },
     "affects": {

--- a/2021/42xxx/CVE-2021-42808.json
+++ b/2021/42xxx/CVE-2021-42808.json
@@ -3,16 +3,94 @@
     "data_format": "MITRE",
     "data_version": "4.0",
     "CVE_data_meta": {
+	"ASSIGNER": "psirt@thalesgroup.com",
         "ID": "CVE-2021-42808",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "The Sentinel Protection Installer 7.7.0 creates files and directory with all privileges granting any user full permissions."
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Sentinel Protection Installer",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "platform": "Windows",
+                                            "version_affected": "<=",
+                                            "version_name": "7.7.0",
+                                            "version_value": "7.7.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Thales"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Intel Corp"
+        }
+    ],
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+		"value": "Improper Access Control in Thales Sentinel Protection Installer could allow a local user to escalate privileges."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-284 Improper Access Control"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://cpl.thalesgroup.com/fr/software-monetization/security-updates"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update Sentinel Protection Installer to version 7.7.1 or newer."
+        }
+    ],
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }

--- a/2021/42xxx/CVE-2021-42809.json
+++ b/2021/42xxx/CVE-2021-42809.json
@@ -3,16 +3,94 @@
     "data_format": "MITRE",
     "data_version": "4.0",
     "CVE_data_meta": {
+	"ASSIGNER": "psirt@thalesgroup.com",
         "ID": "CVE-2021-42809",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "The Sentinel Protection Installer 7.7.0 does not properly restrict loading Dynamic Link Library"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Sentinel Protection Installer",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "platform": "Windows",
+                                            "version_affected": "<=",
+                                            "version_name": "7.7.0",
+                                            "version_value": "7.7.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Thales"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Intel Corp"
+        }
+    ],
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+		"value": "Improper Access Control of Dynamically-Managed Code Resources (DLL) in Thales Sentinel Protection Installer could allow the execution of arbitrary code."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-913 Improper Control of Dynamically-Managed Code Resources"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://cpl.thalesgroup.com/fr/software-monetization/security-updates"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update Sentinel Protection Installer to version 7.7.1 or newer."
+        }
+    ],
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
CVE impacting Safenet Authentication Service updated and ready to be publicly released.
Agreed with reporter to push it.