### PR TITLE
Cna/certcc/CVE 2021 44228

### DIFF
--- a/2021/44xxx/CVE-2021-44228.json
+++ b/2021/44xxx/CVE-2021-44228.json
@@ -1,6 +1,7 @@
 {
     "CVE_data_meta": {
         "ASSIGNER": "security@apache.org",
+        "DATE_PUBLIC": "2021-11-29T05:00:00.000Z",
         "ID": "CVE-2021-44228",
         "STATE": "PUBLIC",
         "TITLE": "Apache Log4j2 JNDI features do not protect against attacker controlled LDAP and other JNDI related endpoints"
@@ -43,18 +44,29 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Apache Log4j2 <=2.14.1 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default. In previous releases (>2.10) this behavior can be mitigated by setting system property \"log4j2.formatMsgNoLookups\" to \u201ctrue\u201d or by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class). Java 8u121 (see https://www.oracle.com/java/technologies/javase/8u121-relnotes.html) protects against remote code execution by defaulting \"com.sun.jndi.rmi.object.trustURLCodebase\" and \"com.sun.jndi.cosnaming.object.trustURLCodebase\" to \"false\"."
+                "value": "Apache Log4j2 <=2.14.1 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default. In previous releases (>2.10) this behavior can be mitigated by setting system property \"log4j2.formatMsgNoLookups\" to “true” or by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class)."
             }
         ]
     },
     "generator": {
         "engine": "Vulnogram 0.0.9"
     },
-    "impact": [
-        {
-            "other": "critical"
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
         }
-    ],
+    },
     "problemtype": {
         "problemtype_data": [
             {
@@ -86,54 +98,59 @@
     "references": {
         "reference_data": [
             {
+                "name": "https://logging.apache.org/log4j/2.x/security.html",
                 "refsource": "MISC",
-                "url": "https://logging.apache.org/log4j/2.x/security.html",
-                "name": "https://logging.apache.org/log4j/2.x/security.html"
+                "url": "https://logging.apache.org/log4j/2.x/security.html"
             },
             {
-                "refsource": "MLIST",
                 "name": "[oss-security] 20211210 CVE-2021-44228: Apache Log4j2 JNDI features do not protect against attacker controlled LDAP and other JNDI related endpoints",
+                "refsource": "MLIST",
                 "url": "http://www.openwall.com/lists/oss-security/2021/12/10/1"
             },
             {
-                "refsource": "MLIST",
                 "name": "[oss-security] 20211210 Re: CVE-2021-44228: Apache Log4j2 JNDI features do not protect against attacker controlled LDAP and other JNDI related endpoints",
+                "refsource": "MLIST",
                 "url": "http://www.openwall.com/lists/oss-security/2021/12/10/2"
             },
             {
-                "refsource": "CISCO",
                 "name": "20211210 Vulnerability in Apache Log4j Library Affecting Cisco Products: December 2021",
+                "refsource": "CISCO",
                 "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd"
             },
             {
-                "refsource": "MLIST",
                 "name": "[oss-security] 20211210 Re: CVE-2021-44228: Apache Log4j2 JNDI features do not protect against attacker controlled LDAP and other JNDI related endpoints",
+                "refsource": "MLIST",
                 "url": "http://www.openwall.com/lists/oss-security/2021/12/10/3"
             },
             {
-                "refsource": "CONFIRM",
                 "name": "https://security.netapp.com/advisory/ntap-20211210-0007/",
+                "refsource": "CONFIRM",
                 "url": "https://security.netapp.com/advisory/ntap-20211210-0007/"
             },
             {
-                "refsource": "MISC",
                 "name": "http://packetstormsecurity.com/files/165225/Apache-Log4j2-2.14.1-Remote-Code-Execution.html",
+                "refsource": "MISC",
                 "url": "http://packetstormsecurity.com/files/165225/Apache-Log4j2-2.14.1-Remote-Code-Execution.html"
             },
             {
-                "refsource": "CONFIRM",
                 "name": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032",
+                "refsource": "CONFIRM",
                 "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032"
             },
             {
-                "refsource": "CONFIRM",
                 "name": "https://www.oracle.com/security-alerts/alert-cve-2021-44228.html",
+                "refsource": "CONFIRM",
                 "url": "https://www.oracle.com/security-alerts/alert-cve-2021-44228.html"
             },
             {
-                "refsource": "FEDORA",
                 "name": "FEDORA-2021-f0f501d01f",
+                "refsource": "FEDORA",
                 "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VU57UJDCFIASIO35GC55JMKSRXJMCDFM/"
+            },
+            {
+                "name": "https://issues.apache.org/jira/browse/LOG4J2-3198",
+                "refsource": "CONFIRM",
+                "url": "https://issues.apache.org/jira/browse/LOG4J2-3198"
             }
         ]
     },

--- a/2021/44xxx/CVE-2021-44228.json
+++ b/2021/44xxx/CVE-2021-44228.json
@@ -44,7 +44,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Apache Log4j2 <=2.14.1 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default. In previous releases (>2.10) this behavior can be mitigated by setting system property \"log4j2.formatMsgNoLookups\" to “true” or by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class)."
+                "value": "Apache Log4j2 <=2.15.0 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. Log4j versions prior to 2.15.0 enabled this behavior by default whereas Log4j 2.15.0 disabled this behavior by default. Log4j 2.16.0 completely removed the message lookups feature."
             }
         ]
     },

--- a/2021/44xxx/CVE-2021-44228.json
+++ b/2021/44xxx/CVE-2021-44228.json
@@ -99,7 +99,7 @@
         "reference_data": [
             {
                 "name": "https://logging.apache.org/log4j/2.x/security.html",
-                "refsource": "MISC",
+                "refsource": "CONFIRM",
                 "url": "https://logging.apache.org/log4j/2.x/security.html"
             },
             {


### PR DESCRIPTION
Remove mitigation details which are hard to maintain and do not contribute to essential identification of the vulnerability. Add a reference, change an Apache reference to CONFIRM.

CC @iamamoose