### PR TITLE
Add CVE-2021-43827 for GHSA-58vr-c56v-qr57

### DIFF
--- a/2021/43xxx/CVE-2021-43827.json
+++ b/2021/43xxx/CVE-2021-43827.json
@@ -1,18 +1,88 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-43827",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Inline footnotes wrapped in <a> tags can cause errors in discourse-footnotes"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "discourse-footnote",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "discourse"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "discourse-footnote is a library providing footnotes for posts in Discourse.\n### Impact\nWhen posting an inline footnote wrapped in `<a>` tags (e.g. `<a>^[footnote]</a>`, the resulting rendered HTML would include a nested `<a>`, which is stripped by Nokogiri because it is not valid. This then caused a javascript error on topic pages because we were looking for an `<a>` element inside the footnote reference span and getting its ID, and because it did not exist we got a null reference error in javascript. Users are advised to update to version 0.2. As a workaround editing offending posts from the rails console or the database console for self-hosters, or disabling the plugin in the admin panel can mitigate this issue."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 4.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-755: Improper Handling of Exceptional Conditions"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/discourse/discourse-footnote/security/advisories/GHSA-58vr-c56v-qr57",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/discourse/discourse-footnote/security/advisories/GHSA-58vr-c56v-qr57"
+            },
+            {
+                "name": "https://github.com/discourse/discourse-footnote/commit/796617e0131277011207541313522cd1946661ab",
+                "refsource": "MISC",
+                "url": "https://github.com/discourse/discourse-footnote/commit/796617e0131277011207541313522cd1946661ab"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-58vr-c56v-qr57",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-43827 for GHSA-58vr-c56v-qr57