### PR TITLE
Update log4j CVE-2021-44228

### DIFF
--- a/2021/44xxx/CVE-2021-44228.json
+++ b/2021/44xxx/CVE-2021-44228.json
@@ -5,31 +5,50 @@
         "STATE": "PUBLIC",
         "TITLE": "Apache Log4j2 JNDI features do not protect against attacker controlled LDAP and other JNDI related endpoints"
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Apache Log4j",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_affected": "<=",
-                                            "version_name": "Apache Log4j 2",
-                                            "version_value": "2.14.1"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "Apache Software Foundation",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Apache Log4j",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "Apache Log4j 2",
+                      "version_affected": ">=",
+                      "version_value": "2.0-beta9",
+                      "platform": ""
                     },
-                    "vendor_name": "Apache Software Foundation"
+                    {
+                      "version_name": "Apache Log4j 2",
+                      "version_affected": "<=",
+                      "version_value": "2.12.1",
+                      "platform": ""
+                    },
+                    {
+                      "version_name": "Apache Log4j 2",
+                      "version_affected": ">=",
+                      "version_value": "2.13.0",
+                      "platform": ""
+                    },
+                    {
+                      "version_name": "Apache Log4j 2",
+                      "version_affected": "<=",
+                      "version_value": "2.14.1",
+                      "platform": ""
+                    }
+                  ]
                 }
+              }
             ]
+          }
         }
-    },
+      ]
+    }
+  },    
     "credit": [
         {
             "lang": "eng",
@@ -43,7 +62,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Apache Log4j2 <=2.14.1 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default. In previous releases (>2.10) this behavior can be mitigated by setting system property \"log4j2.formatMsgNoLookups\" to \u201ctrue\u201d or it can be mitigated in prior releases (<2.10) by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class)."
+        "value": "Apache Log4j2 2.0-beta9 through 2.12.1 and 2.13.0 through 2.15.0 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default. From version 2.16.0, this functionality has been completely removed.\n\nNote that this vulnerability is specific to log4j-core and does not affect log4net, log4cxx, or other Apache Logging Services projects."
             }
         ]
     },


### PR DESCRIPTION
Update affects as 2.12.1 is now out and not vulnerable, this also helps fix things false positive matching for log4j 1.x

Update description to remove the workarounds, these are not required for CVE and change over time.