### PR TITLE
CVE-2021-45046: Change CVSS impact score

### DIFF
--- a/2021/45xxx/CVE-2021-45046.json
+++ b/2021/45xxx/CVE-2021-45046.json
@@ -46,7 +46,7 @@
     },
     "impact": [
         {
-            "other": "moderate (CVSS: 3.7 AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L)"
+            "other": "critical (CVSS: 9.0 AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H)"
         }
     ],
     "problemtype": {
@@ -114,6 +114,20 @@
                 "url": "https://www.debian.org/security/2021/dsa-5022"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackVector": "NETWORK",
+            "attackComplexity": "HIGH",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "CHANGED",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+        }
     },
     "source": {
         "discovery": "UNKNOWN"


### PR DESCRIPTION
The impact has changed in the official advisory, this patch adds the
impact entry in the JSON along with updating the impact.

Signed-off-by: Morten Linderud <morten@linderud.pw>