### PR TITLE
Add CVE-2021-43838 for GHSA-55xv-f85c-248q

### DIFF
--- a/2021/43xxx/CVE-2021-43838.json
+++ b/2021/43xxx/CVE-2021-43838.json
@@ -1,18 +1,88 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-43838",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Regular Expression Denial of Service (ReDoS) in jsx-slack"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "jsx-slack",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 4.5.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "yhatt"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "jsx-slack is a library for building JSON objects for Slack Block Kit surfaces from JSX. In versions prior to 4.5.1 users are vulnerable to a regular expression denial-of-service (ReDoS) attack. If attacker can put a lot of JSX elements into `<blockquote>` tag, an internal regular expression for escaping characters may consume an excessive amount of computing resources. jsx-slack v4.5.1 has patched to a regex for escaping blockquote characters. Users are advised to upgrade as soon as possible."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-400: Uncontrolled Resource Consumption"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/yhatt/jsx-slack/security/advisories/GHSA-55xv-f85c-248q",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/yhatt/jsx-slack/security/advisories/GHSA-55xv-f85c-248q"
+            },
+            {
+                "name": "https://github.com/yhatt/jsx-slack/commit/36e4a10405e4c7745333e245fcc5029c02c7065d",
+                "refsource": "MISC",
+                "url": "https://github.com/yhatt/jsx-slack/commit/36e4a10405e4c7745333e245fcc5029c02c7065d"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-55xv-f85c-248q",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-43838 for GHSA-55xv-f85c-248q