### PR TITLE
Oracle Security Alert - CVE-2021-44228 Rev 2

### DIFF
--- a/2021/45xxx/CVE-2021-45046.json
+++ b/2021/45xxx/CVE-2021-45046.json
@@ -112,7 +112,12 @@
                 "refsource": "DEBIAN",
                 "name": "DSA-5022",
                 "url": "https://www.debian.org/security/2021/dsa-5022"
-            }
+            },
+            {
+                "refsource": "CONFIRM",
+                "name": "https://www.oracle.com/security-alerts/alert-cve-2021-44228.html",
+                "url": "https://www.oracle.com/security-alerts/alert-cve-2021-44228.html"
+            }			
         ]
     },
     "source": {


### PR DESCRIPTION
 Committer: BSITU <BSITU@BSITU-7320.us.oracle.com>

 On branch cna/Oracle/AlertCVE-2021-44228v2
 Changes to be committed:
	modified:   2021/45xxx/CVE-2021-45046.json