### PR TITLE
XSA-391 CVE-2021-28711 CVE-2021-28712 CVE-2021-28713

### DIFF
--- a/2021/28xxx/CVE-2021-28711.json
+++ b/2021/28xxx/CVE-2021-28711.json
@@ -1,18 +1,106 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28711",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28711"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Linux",
+                        "version" : {
+                           "version_data" : {
+                              "version_affected" : "?",
+                              "version_value" : "consult Xen advisory XSA-391"
+                           }
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Linux"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All guests being serviced by potentially malicious backends are vulnerable,\neven if those backends are running in a less privileged environment. The\nvulnerability is not affecting the host, but the guests."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jürgen Groß of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Rogue backends can cause DoS of guests via high frequency events\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nXen offers the ability to run PV backends in regular unprivileged\nguests, typically referred to as \"driver domains\". Running PV backends\nin driver domains has one primary security advantage: if a driver domain\ngets compromised, it doesn't have the privileges to take over the\nsystem.\n\nHowever, a malicious driver domain could try to attack other guests via\nsending events at a high frequency leading to a Denial of Service in the\nguest due to trying to service interrupts for elongated amounts of time.\n\nThere are three affected backends:\n * blkfront          patch 1, CVE-2021-28711\n * netfront          patch 2, CVE-2021-28712\n * hvc_xen (console) patch 3, CVE-2021-28713"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Potentially malicious PV backends can cause guest DoS due to unhardened\nfrontends in the guests, even though this ought to have been prevented by\ncontaining them within a driver domain."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-391.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no known mitigation available."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2021/28xxx/CVE-2021-28711.json
+++ b/2021/28xxx/CVE-2021-28711.json
@@ -12,10 +12,12 @@
                      {
                         "product_name" : "Linux",
                         "version" : {
-                           "version_data" : {
-                              "version_affected" : "?",
-                              "version_value" : "consult Xen advisory XSA-391"
-                           }
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-391"
+                              }
+                           ]
                         }
                      }
                   ]

--- a/2021/28xxx/CVE-2021-28712.json
+++ b/2021/28xxx/CVE-2021-28712.json
@@ -1,18 +1,106 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28712",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28712"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Linux",
+                        "version" : {
+                           "version_data" : {
+                              "version_affected" : "?",
+                              "version_value" : "consult Xen advisory XSA-391"
+                           }
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Linux"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All guests being serviced by potentially malicious backends are vulnerable,\neven if those backends are running in a less privileged environment. The\nvulnerability is not affecting the host, but the guests."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jürgen Groß of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Rogue backends can cause DoS of guests via high frequency events\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nXen offers the ability to run PV backends in regular unprivileged\nguests, typically referred to as \"driver domains\". Running PV backends\nin driver domains has one primary security advantage: if a driver domain\ngets compromised, it doesn't have the privileges to take over the\nsystem.\n\nHowever, a malicious driver domain could try to attack other guests via\nsending events at a high frequency leading to a Denial of Service in the\nguest due to trying to service interrupts for elongated amounts of time.\n\nThere are three affected backends:\n * blkfront          patch 1, CVE-2021-28711\n * netfront          patch 2, CVE-2021-28712\n * hvc_xen (console) patch 3, CVE-2021-28713"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Potentially malicious PV backends can cause guest DoS due to unhardened\nfrontends in the guests, even though this ought to have been prevented by\ncontaining them within a driver domain."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-391.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no known mitigation available."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2021/28xxx/CVE-2021-28712.json
+++ b/2021/28xxx/CVE-2021-28712.json
@@ -12,10 +12,12 @@
                      {
                         "product_name" : "Linux",
                         "version" : {
-                           "version_data" : {
-                              "version_affected" : "?",
-                              "version_value" : "consult Xen advisory XSA-391"
-                           }
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-391"
+                              }
+                           ]
                         }
                      }
                   ]

--- a/2021/28xxx/CVE-2021-28713.json
+++ b/2021/28xxx/CVE-2021-28713.json
@@ -1,18 +1,106 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28713",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28713"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Linux",
+                        "version" : {
+                           "version_data" : {
+                              "version_affected" : "?",
+                              "version_value" : "consult Xen advisory XSA-391"
+                           }
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Linux"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All guests being serviced by potentially malicious backends are vulnerable,\neven if those backends are running in a less privileged environment. The\nvulnerability is not affecting the host, but the guests."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jürgen Groß of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Rogue backends can cause DoS of guests via high frequency events\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nXen offers the ability to run PV backends in regular unprivileged\nguests, typically referred to as \"driver domains\". Running PV backends\nin driver domains has one primary security advantage: if a driver domain\ngets compromised, it doesn't have the privileges to take over the\nsystem.\n\nHowever, a malicious driver domain could try to attack other guests via\nsending events at a high frequency leading to a Denial of Service in the\nguest due to trying to service interrupts for elongated amounts of time.\n\nThere are three affected backends:\n * blkfront          patch 1, CVE-2021-28711\n * netfront          patch 2, CVE-2021-28712\n * hvc_xen (console) patch 3, CVE-2021-28713"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Potentially malicious PV backends can cause guest DoS due to unhardened\nfrontends in the guests, even though this ought to have been prevented by\ncontaining them within a driver domain."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-391.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no known mitigation available."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2021/28xxx/CVE-2021-28713.json
+++ b/2021/28xxx/CVE-2021-28713.json
@@ -12,10 +12,12 @@
                      {
                         "product_name" : "Linux",
                         "version" : {
-                           "version_data" : {
-                              "version_affected" : "?",
-                              "version_value" : "consult Xen advisory XSA-391"
-                           }
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-391"
+                              }
+                           ]
                         }
                      }
                   ]


### PR DESCRIPTION
XSA-391 CVE-2021-28711 CVE-2021-28712 CVE-2021-28713

CVE data entry for:
  CVE-2021-28711

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2021-28712

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2021-28713

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
