### PR TITLE
XSA-392 CVE-2021-28714 CVE-2021-28715

### DIFF
--- a/2021/28xxx/CVE-2021-28714.json
+++ b/2021/28xxx/CVE-2021-28714.json
@@ -12,10 +12,12 @@
                      {
                         "product_name" : "Linux",
                         "version" : {
-                           "version_data" : {
-                              "version_affected" : "?",
-                              "version_value" : "consult Xen advisory XSA-392"
-                           }
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-392"
+                              }
+                           ]
                         }
                      }
                   ]

--- a/2021/28xxx/CVE-2021-28714.json
+++ b/2021/28xxx/CVE-2021-28714.json
@@ -1,18 +1,106 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28714",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28714"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Linux",
+                        "version" : {
+                           "version_data" : {
+                              "version_affected" : "?",
+                              "version_value" : "consult Xen advisory XSA-392"
+                           }
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Linux"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All systems using the Linux kernel based network backend xen-netback\nare vulnerable."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by  Jürgen Groß of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Guest can force Linux netback driver to hog large amounts of kernel memory\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nIncoming data packets for a guest in the Linux kernel's netback driver\nare buffered until the guest is ready to process them. There are some\nmeasures taken for avoiding to pile up too much data, but those can\nbe bypassed by the guest:\n\nThere is a timeout how long the client side of an interface can stop\nconsuming new packets before it is assumed to have stalled, but this\ntimeout is rather long (60 seconds by default). Using a UDP connection\non a fast interface can easily accumulate gigabytes of data in that\ntime.  (CVE-2021-28715)\n\nThe timeout could even never trigger if the guest manages to have only\none free slot in its RX queue ring page and the next package would\nrequire more than one free slot, which may be the case when using GSO,\nXDP, or software hashing.  (CVE-2021-28714)"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The Linux kernel's xen-netback backend driver can be forced by guests\nto queue arbitrary amounts of network data, finally causing an out of\nmemory situation in the domain the backend is running in (usually dom0)."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-392.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Using another PV network backend (e.g. the qemu based \"qnic\" backend)\nwill mitigate the problem.\n\nUsing a dedicated network driver domain per guest will mitigate the\nproblem."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2021/28xxx/CVE-2021-28715.json
+++ b/2021/28xxx/CVE-2021-28715.json
@@ -12,10 +12,12 @@
                      {
                         "product_name" : "Linux",
                         "version" : {
-                           "version_data" : {
-                              "version_affected" : "?",
-                              "version_value" : "consult Xen advisory XSA-392"
-                           }
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-392"
+                              }
+                           ]
                         }
                      }
                   ]

--- a/2021/28xxx/CVE-2021-28715.json
+++ b/2021/28xxx/CVE-2021-28715.json
@@ -1,18 +1,106 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-28715",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2021-28715"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Linux",
+                        "version" : {
+                           "version_data" : {
+                              "version_affected" : "?",
+                              "version_value" : "consult Xen advisory XSA-392"
+                           }
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Linux"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All systems using the Linux kernel based network backend xen-netback\nare vulnerable."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by  Jürgen Groß of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Guest can force Linux netback driver to hog large amounts of kernel memory\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nIncoming data packets for a guest in the Linux kernel's netback driver\nare buffered until the guest is ready to process them. There are some\nmeasures taken for avoiding to pile up too much data, but those can\nbe bypassed by the guest:\n\nThere is a timeout how long the client side of an interface can stop\nconsuming new packets before it is assumed to have stalled, but this\ntimeout is rather long (60 seconds by default). Using a UDP connection\non a fast interface can easily accumulate gigabytes of data in that\ntime.  (CVE-2021-28715)\n\nThe timeout could even never trigger if the guest manages to have only\none free slot in its RX queue ring page and the next package would\nrequire more than one free slot, which may be the case when using GSO,\nXDP, or software hashing.  (CVE-2021-28714)"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The Linux kernel's xen-netback backend driver can be forced by guests\nto queue arbitrary amounts of network data, finally causing an out of\nmemory situation in the domain the backend is running in (usually dom0)."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-392.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Using another PV network backend (e.g. the qemu based \"qnic\" backend)\nwill mitigate the problem.\n\nUsing a dedicated network driver domain per guest will mitigate the\nproblem."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-392 CVE-2021-28714 CVE-2021-28715

CVE data entry for:
  CVE-2021-28714

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2021-28715

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
