### PR TITLE
Fix CVE-2020-12080 duplicate keys issue

### DIFF
--- a/2020/12xxx/CVE-2020-12080.json
+++ b/2020/12xxx/CVE-2020-12080.json
@@ -55,10 +55,14 @@
             {
                 "name": "https://community.flexera.com/t5/FlexNet-Publisher-Knowledge-Base/CVE-2020-12080-Remediated-in-FlexNet-Publisher/ta-p/143873",
                 "refsource": "CONFIRM",
-                "url": "https://community.flexera.com/t5/FlexNet-Publisher-Knowledge-Base/CVE-2020-12080-Remediated-in-FlexNet-Publisher/ta-p/143873",
+                "url": "https://community.flexera.com/t5/FlexNet-Publisher-Knowledge-Base/CVE-2020-12080-Remediated-in-FlexNet-Publisher/ta-p/143873"
+	    },
+	    {
 		"name": "https://community.flexera.com/t5/FlexNet-Publisher-News/FlexNet-Publisher-2020-R2-11-17-0-is-here/ba-p/144017/jump-to/first-unread-message",
 		"refsource": "CONFIRM",
-		"url": "https://community.flexera.com/t5/FlexNet-Publisher-News/FlexNet-Publisher-2020-R2-11-17-0-is-here/ba-p/144017/jump-to/first-unread-message",
+		"url": "https://community.flexera.com/t5/FlexNet-Publisher-News/FlexNet-Publisher-2020-R2-11-17-0-is-here/ba-p/144017/jump-to/first-unread-message"
+	    },
+	    {
 		"name": "https://www.tenable.com/security/research/tra-2020-28",
 		"refsource": "MISC",
 		"url": "https://www.tenable.com/security/research/tra-2020-28"


### PR DESCRIPTION
CVE-2020-12080 had all references as a single element in the array, leading to duplicate "name", "refsource", and "url" key:value pairs when deserialized.