### PR TITLE
Add CVE-2022-21685 for GHSA-cjg2-2fjg-fph4

### DIFF
--- a/2022/21xxx/CVE-2022-21685.json
+++ b/2022/21xxx/CVE-2022-21685.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-21685",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Integer underflow in Frontier"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "frontier",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 8a93fdc"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "paritytech"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Frontier is Substrate's Ethereum compatibility layer. Prior to commit number `8a93fdc6c9f4eb1d2f2a11b7ff1d12d70bf5a664`, a bug in Frontier's MODEXP precompile implementation can cause an integer underflow in certain conditions. This will cause a node crash for debug builds. For release builds (and production WebAssembly binaries), the impact is limited as it can only cause a normal EVM out-of-gas. Users who do not use MODEXP precompile in their runtime are not impacted. A patch is available in pull request #549."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-191: Integer Underflow (Wrap or Wraparound)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/paritytech/frontier/security/advisories/GHSA-cjg2-2fjg-fph4",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/paritytech/frontier/security/advisories/GHSA-cjg2-2fjg-fph4"
+            },
+            {
+                "name": "https://github.com/paritytech/frontier/pull/549",
+                "refsource": "MISC",
+                "url": "https://github.com/paritytech/frontier/pull/549"
+            },
+            {
+                "name": "https://github.com/paritytech/frontier/commit/8a93fdc6c9f4eb1d2f2a11b7ff1d12d70bf5a664",
+                "refsource": "MISC",
+                "url": "https://github.com/paritytech/frontier/commit/8a93fdc6c9f4eb1d2f2a11b7ff1d12d70bf5a664"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-cjg2-2fjg-fph4",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-21685 for GHSA-cjg2-2fjg-fph4