### PR TITLE
Add CVE-2022-21658 for GHSA-r9cc-f5pr-p3j2

### DIFF
--- a/2022/21xxx/CVE-2022-21658.json
+++ b/2022/21xxx/CVE-2022-21658.json
@@ -1,18 +1,116 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-21658",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Race condition in std::fs::remove_dir_all in rustlang"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "rust",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.58.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "rust-lang"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Rust is a multi-paradigm, general-purpose programming language designed for performance and safety, especially safe concurrency. \n The Rust Security Response WG was notified that the `std::fs::remove_dir_all` standard library function is vulnerable a race condition enabling symlink following (CWE-363). An attacker could use this security issue to trick a privileged program into deleting files and directories the attacker couldn't otherwise access or delete. Rust 1.0.0 through Rust 1.58.0 is affected by this vulnerability with 1.58.1 containing a patch. Note that the following build targets don't have usable APIs to properly mitigate the attack, and are thus still vulnerable even with a patched toolchain: macOS before version 10.10 (Yosemite) and REDOX. We recommend everyone to update to Rust 1.58.1 as soon as possible, especially people developing programs expected to run in privileged contexts (including system daemons and setuid binaries), as those have the highest risk of being affected by this. Note that adding checks in your codebase before calling remove_dir_all will not mitigate the vulnerability, as they would also be vulnerable to race conditions like remove_dir_all itself. The existing mitigation is working as intended outside of race conditions.\n"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.3,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-363: Race Condition Enabling Link Following"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-367: Time-of-check Time-of-use (TOCTOU) Race Condition"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/rust-lang/rust/security/advisories/GHSA-r9cc-f5pr-p3j2",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/rust-lang/rust/security/advisories/GHSA-r9cc-f5pr-p3j2"
+            },
+            {
+                "name": "https://github.com/rust-lang/rust/pull/93110",
+                "refsource": "MISC",
+                "url": "https://github.com/rust-lang/rust/pull/93110"
+            },
+            {
+                "name": "https://github.com/rust-lang/rust/pull/93110/commits/32ed6e599bb4722efefd78bbc9cd7ec4613cb946",
+                "refsource": "MISC",
+                "url": "https://github.com/rust-lang/rust/pull/93110/commits/32ed6e599bb4722efefd78bbc9cd7ec4613cb946"
+            },
+            {
+                "name": "https://github.com/rust-lang/rust/pull/93110/commits/406cc071d6cfdfdb678bf3d83d766851de95abaf",
+                "refsource": "MISC",
+                "url": "https://github.com/rust-lang/rust/pull/93110/commits/406cc071d6cfdfdb678bf3d83d766851de95abaf"
+            },
+            {
+                "name": "https://github.com/rust-lang/rust/pull/93110/commits/4f0ad1c92ca08da6e8dc17838070975762f59714",
+                "refsource": "MISC",
+                "url": "https://github.com/rust-lang/rust/pull/93110/commits/4f0ad1c92ca08da6e8dc17838070975762f59714"
+            },
+            {
+                "name": "https://blog.rust-lang.org/2022/01/20/cve-2022-21658.html",
+                "refsource": "MISC",
+                "url": "https://blog.rust-lang.org/2022/01/20/cve-2022-21658.html"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-r9cc-f5pr-p3j2",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-21658 for GHSA-r9cc-f5pr-p3j2