### PR TITLE
XSA-395 CVE-2022-23035

### DIFF
--- a/2022/23xxx/CVE-2022-23035.json
+++ b/2022/23xxx/CVE-2022-23035.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23035",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-23035"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-395"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Xen versions 4.6 and later are vulnerable.  Xen versions 4.5 and earlier\nare not vulnerable.\n\nOnly x86 HVM guests with one or more passed-through physical devices\nusing (together) multiple physical interupts can leverage the\nvulnerability.  x86 PV guests cannot leverage the vulnerability.  x86\nHVM guests without passed-through devices or with a passed-through\ndevice using just a single physical interrupt also cannot leverage the\nvulnerability.  Device pass-through is unsupported for x86 PVH guests\nand all Arm guests."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Julien Grall of Amazon."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Insufficient cleanup of passed-through device IRQs\n\nThe management of IRQs associated with physical devices exposed to x86\nHVM guests involves an iterative operation in particular when cleaning\nup after the guest's use of the device.  In the case where an interrupt\nis not quiescent yet at the time this cleanup gets invoked, the cleanup\nattempt may be scheduled to be retried.  When multiple interrupts are\ninvolved, this scheduling of a retry may get erroneously skipped.  At\nthe same time pointers may get cleared (resulting in a de-reference of\nNULL) and freed (resulting in a use-after-free), while other code would\ncontinue to assume them to be valid."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The precise impact is system specific, but would typically be a Denial\nof Service (DoS) affecting the entire host.  Privilege escalation and\ninformation leaks cannot be ruled out."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-395.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no mitigation (other than not passing through to x86 HVM guests\nPCI devices with, overall, more than a single physical interrupt)."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-395 CVE-2022-23035

CVE data entry for:
  CVE-2022-23035

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
