### PR TITLE
Add CVE-2021-22600 - Double Free in net/packet/af_packet.c leading to…

### DIFF
--- a/2021/22xxx/CVE-2021-22600.json
+++ b/2021/22xxx/CVE-2021-22600.json
@@ -1,18 +1,97 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2021-22600",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
-    }
+  "CVE_data_meta": {
+      "ASSIGNER": "security@google.com",
+      "ID": "CVE-2021-22600",
+      "STATE": "PUBLIC",
+      "TITLE": "Double Free in net/packet/af_packet.c leading to priviledge escalation"
+  },
+  "affects": {
+      "vendor": {
+          "vendor_data": [
+              {
+                  "product": {
+                      "product_data": [
+                          {
+                              "product_name": "Kernel",
+                              "version": {
+                                  "version_data": [
+                                      {
+                                          "version_affected": "<",
+                                          "version_value": "5.4.168"
+                                      },
+                                      {
+                                          "version_affected": "<",
+                                          "version_value": "5.10.88"
+                                      },
+                                      {
+                                          "version_affected": "<",
+                                          "version_value": "5.15.11"
+                                      },
+                                      {
+                                          "version_affected": "<",
+                                          "version_value": "5.16-rc6"
+                                      }
+                                  ]
+                              }
+                          }
+                      ]
+                  },
+                  "vendor_name": "Linux Kernel"
+              }
+          ]
+      }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+      "description_data": [
+          {
+              "lang": "eng",
+              "value": "A double free bug in packet_set_ring() in net/packet/af_packet.c can be exploited by a local user through crafted syscalls to escalate privileges or deny service. We recommend upgrading kernel past the effected versions or rebuilding past ec6af094ea28f0f2dda1a6a33b14cd57e36a9755"
+          }
+      ]
+  },
+  "generator": {
+      "engine": "Vulnogram 0.0.9"
+  },
+  "impact": {
+      "cvss": {
+          "attackComplexity": "HIGH",
+          "attackVector": "LOCAL",
+          "availabilityImpact": "HIGH",
+          "baseScore": 6.6,
+          "baseSeverity": "MEDIUM",
+          "confidentialityImpact": "LOW",
+          "integrityImpact": "LOW",
+          "privilegesRequired": "LOW",
+          "scope": "CHANGED",
+          "userInteraction": "REQUIRED",
+          "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:H",
+          "version": "3.1"
+      }
+  },
+  "problemtype": {
+      "problemtype_data": [
+          {
+              "description": [
+                  {
+                      "lang": "eng",
+                      "value": "CWE-415 Double Free"
+                  }
+              ]
+          }
+      ]
+  },
+  "references": {
+      "reference_data": [
+          {
+              "refsource": "CONFIRM",
+              "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=ec6af094ea28f0f2dda1a6a33b14cd57e36a9755"
+          }
+      ]
+  },
+  "source": {
+      "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
… priviledge escalation