### PR TITLE
Add CVE-2020-26208 for GHSA-7pr6-xq4f-qhgc

### DIFF
--- a/2020/26xxx/CVE-2020-26208.json
+++ b/2020/26xxx/CVE-2020-26208.json
@@ -1,18 +1,106 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2020-26208",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Heap-buffer-overflow in jhead"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "jhead",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 3.04"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "F-ZhaoYang"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "JHEAD is a simple command line tool for displaying and some manipulation of EXIF header data embedded in Jpeg images from digital cameras. In affected versions there is a heap-buffer-overflow on jhead-3.04/jpgfile.c:285 ReadJpegSections. Crafted jpeg images can be provided to the user resulting in a program crash or potentially incorrect exif information retrieval. Users are advised to upgrade. There is no known workaround for this issue."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "LOW",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-122: Heap-based Buffer Overflow"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-120: Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/F-ZhaoYang/jhead/security/advisories/GHSA-7pr6-xq4f-qhgc",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/F-ZhaoYang/jhead/security/advisories/GHSA-7pr6-xq4f-qhgc"
+            },
+            {
+                "name": "https://github.com/Matthias-Wandel/jhead/issues/7",
+                "refsource": "MISC",
+                "url": "https://github.com/Matthias-Wandel/jhead/issues/7"
+            },
+            {
+                "name": "https://github.com/F-ZhaoYang/jhead/commit/5186ddcf9e35a7aa0ff0539489a930434a1325f4",
+                "refsource": "MISC",
+                "url": "https://github.com/F-ZhaoYang/jhead/commit/5186ddcf9e35a7aa0ff0539489a930434a1325f4"
+            },
+            {
+                "name": "https://bugs.launchpad.net/ubuntu/+source/jhead/+bug/1900821",
+                "refsource": "MISC",
+                "url": "https://bugs.launchpad.net/ubuntu/+source/jhead/+bug/1900821"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-7pr6-xq4f-qhgc",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2020-26208 for GHSA-7pr6-xq4f-qhgc