### PR TITLE
Update CVE. Remote vector was added erroneously

### DIFF
--- a/2022/21xxx/CVE-2022-21724.json
+++ b/2022/21xxx/CVE-2022-21724.json
@@ -3,7 +3,7 @@
         "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-21724",
         "STATE": "PUBLIC",
-        "TITLE": "Remote code execution vulnerability using plugin features "
+        "TITLE": "Unchecked Class Instantiation when providing Plugin Classes"
     },
     "affects": {
         "vendor": {
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "pgjdbc is the offical PostgreSQL JDBC Driver. A security hole was found in the jdbc driver for postgresql database while doing security research. The system using the postgresql library will be attacked when attacker control the jdbc url or properties. pgjdbc instantiates plugin instances based on class names provided via `authenticationPluginClassName`, `sslhostnameverifier`, `socketFactory`, `sslfactory`, `sslpasswordcallback` connection properties. However, the driver did not verify if the class implements the expected interface before instantiating the class. This can lead to remote code execution loaded via arbitrary classes. Users using plugins are advised to upgrade. There are no known workarounds for this issue."
+                "value": "pgjdbc is the offical PostgreSQL JDBC Driver. A security hole was found in the jdbc driver for postgresql database while doing security research. The system using the postgresql library will be attacked when attacker control the jdbc url or properties. pgjdbc instantiates plugin instances based on class names provided via `authenticationPluginClassName`, `sslhostnameverifier`, `socketFactory`, `sslfactory`, `sslpasswordcallback` connection properties. However, the driver did not verify if the class implements the expected interface before instantiating the class. This can lead to code execution loaded via arbitrary classes. Users using plugins are advised to upgrade. There are no known workarounds for this issue."
             }
         ]
     },
@@ -51,7 +51,7 @@
             "privilegesRequired": "LOW",
             "scope": "CHANGED",
             "userInteraction": "NONE",
-            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
             "version": "3.1"
         }
     },


### PR DESCRIPTION
The maintainer got in contact after requesting a CVE to correct the attack vector.
The original publication mentioned a remote vector, but this was not accurate.