### PR TITLE
Add CVE-2021-25939

### DIFF
--- a/2021/25xxx/CVE-2021-25939.json
+++ b/2021/25xxx/CVE-2021-25939.json
@@ -1,18 +1,111 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "vulnerabilitylab@whitesourcesoftware.com",
+        "DATE_PUBLIC": "2022-02-05T22:00:00.000Z",
         "ID": "CVE-2021-25939",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "ArangoDB - Blind SSRF when Downloading Foxx Service from URL"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "arangodb",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v3.7.0"
+                                        },
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "v3.9.0-alpha.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "arangodb"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "WhiteSource Vulnerability Research Team (WVR)"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In ArangoDB, versions v3.7.0 through v3.9.0-alpha.1 have a feature which allows downloading a Foxx service from a publicly available URL. This feature does not enforce proper filtering of requests performed internally, which can be abused by a highly-privileged attacker to perform blind SSRF and send internal requests to localhost."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 2.7,
+            "baseSeverity": "LOW",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-918 Server-Side Request Forgery (SSRF)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "MISC",
+                "url": "https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-25939"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://github.com/arangodb/arangodb/commit/d7b35a6884c6b2802d34d79fb2a79fb2c9ec2175"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://github.com/arangodb/arangodb/commit/d9b7f019d2435f107b19a59190bf9cc27d5f34dd"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Upgrade to ArangoDB v3.9.0-beta.1 or later"
+        }
+    ],
+    "source": {
+        "advisory": "https://www.whitesourcesoftware.com/vulnerability-database/",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
ArangoDB - Blind SSRF when Downloading Foxx Service from URL
Committed by: Hagai Wechsler