### PR TITLE
Add CVE-2022-23633 for GHSA-wh98-p28r-vrc9

### DIFF
--- a/2022/23xxx/CVE-2022-23633.json
+++ b/2022/23xxx/CVE-2022-23633.json
@@ -1,18 +1,97 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-23633",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Exposure of sensitive information in Action Pack"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "rails",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 7.0.0.0, < 7.0.2.1"
+                                        },
+                                        {
+                                            "version_value": ">= 6.1.0.0, < 6.1.4.5"
+                                        },
+                                        {
+                                            "version_value": ">= 6.0.0.0, < 6.0.4.5"
+                                        },
+                                        {
+                                            "version_value": ">= 5.0.0, < 5.2.6.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "rails"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Action Pack is a framework for handling and responding to web requests. Under certain circumstances response bodies will not be closed.  In the event a response is *not* notified of a `close`, `ActionDispatch::Executor` will not know to reset thread local state for the next request.  This can lead to data being leaked to subsequent requests.This has been fixed in Rails 7.0.2.1, 6.1.4.5, 6.0.4.5, and 5.2.6.1. Upgrading is highly recommended, but to work around this problem a middleware described in GHSA-wh98-p28r-vrc9 can be used."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.4,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/rails/rails/security/advisories/GHSA-wh98-p28r-vrc9",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/rails/rails/security/advisories/GHSA-wh98-p28r-vrc9"
+            },
+            {
+                "name": "https://github.com/rails/rails/commit/f9a2ad03943d5c2ba54e1d45f155442b519c75da",
+                "refsource": "MISC",
+                "url": "https://github.com/rails/rails/commit/f9a2ad03943d5c2ba54e1d45f155442b519c75da"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-wh98-p28r-vrc9",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-23633 for GHSA-wh98-p28r-vrc9