### PR TITLE
Add CVE-2022-23639 for GHSA-qc84-gqf4-9926

### DIFF
--- a/2022/23xxx/CVE-2022-23639.json
+++ b/2022/23xxx/CVE-2022-23639.json
@@ -1,18 +1,101 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-23639",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Improper Restriction of Operations within the Bounds of a Memory Buffer and Race Condition in crossbeam-utils"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "crossbeam",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.8.7"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "crossbeam-rs"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "crossbeam-utils provides atomics, synchronization primitives, scoped threads, and other utilities for concurrent programming in Rust. crossbeam-utils prior to version 0.8.7 incorrectly assumed that the alignment of `{i,u}64` was always the same as `Atomic{I,U}64`. However, the alignment of `{i,u}64` on a 32-bit target can be smaller than `Atomic{I,U}64`. This can cause unaligned memory accesses and data race. Crates using `fetch_*` methods with `AtomicCell<{i,u}64>` are affected by this issue. 32-bit targets without `Atomic{I,U}64` and 64-bit targets are not affected by this issue. This has been fixed in crossbeam-utils 0.8.7. There are currently no known workarounds."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-362: Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-119: Improper Restriction of Operations within the Bounds of a Memory Buffer"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/crossbeam-rs/crossbeam/security/advisories/GHSA-qc84-gqf4-9926",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/crossbeam-rs/crossbeam/security/advisories/GHSA-qc84-gqf4-9926"
+            },
+            {
+                "name": "https://github.com/crossbeam-rs/crossbeam/pull/781",
+                "refsource": "MISC",
+                "url": "https://github.com/crossbeam-rs/crossbeam/pull/781"
+            },
+            {
+                "name": "https://github.com/crossbeam-rs/crossbeam/releases/tag/crossbeam-utils-0.8.7",
+                "refsource": "MISC",
+                "url": "https://github.com/crossbeam-rs/crossbeam/releases/tag/crossbeam-utils-0.8.7"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-qc84-gqf4-9926",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-23639 for GHSA-qc84-gqf4-9926