### PR TITLE
Add CVE-2022-0629 for 95e2b0da-e480-4ee8-9324-a93a2ab0a877

### DIFF
--- a/2022/0xxx/CVE-2022-0629.json
+++ b/2022/0xxx/CVE-2022-0629.json
@@ -1,18 +1,89 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-0629",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-0629",
+    "STATE": "PUBLIC",
+    "TITLE": "Stack-based Buffer Overflow in vim/vim"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "vim/vim",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "8.2"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "vim"
+        }
+      ]
     }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Stack-based Buffer Overflow in Conda vim prior to 8.2."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "HIGH",
+      "baseScore": 8.4,
+      "baseSeverity": "HIGH",
+      "confidentialityImpact": "HIGH",
+      "integrityImpact": "HIGH",
+      "privilegesRequired": "NONE",
+      "scope": "UNCHANGED",
+      "userInteraction": "NONE",
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121 Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/95e2b0da-e480-4ee8-9324-a93a2ab0a877",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/95e2b0da-e480-4ee8-9324-a93a2ab0a877"
+      },
+      {
+        "name": "https://github.com/vim/vim/commit/34f8117dec685ace52cd9e578e2729db278163fc",
+        "refsource": "MISC",
+        "url": "https://github.com/vim/vim/commit/34f8117dec685ace52cd9e578e2729db278163fc"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "95e2b0da-e480-4ee8-9324-a93a2ab0a877",
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
Add CVE-2022-0629 for [95e2b0da-e480-4ee8-9324-a93a2ab0a877](https://huntr.dev/bounties/95e2b0da-e480-4ee8-9324-a93a2ab0a877) @huntr-helper