### PR TITLE
Add CVE-2022-0543/redis (DSA-5081-1)

### DIFF
--- a/2022/0xxx/CVE-2022-0543.json
+++ b/2022/0xxx/CVE-2022-0543.json
@@ -1,18 +1,82 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security@debian.org",
+        "DATE_PUBLIC": "2022-02-18T00:00:00.000Z",
         "ID": "CVE-2022-0543",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "redis",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "n/a"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Debian"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "It was discovered, that redis, a persistent key-value database, due to a packaging issue, is prone to a (Debian-specific) Lua sandbox escape, which could result in remote code execution."
             }
         ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Lua sandbox escape"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "MISC",
+                "url": "https://bugs.debian.org/1005787",
+                "name": "https://bugs.debian.org/1005787"
+            },
+            {
+                "refsource": "MISC",
+                "url": "https://www.ubercomp.com/posts/2022-01-20_redis_on_debian_rce",
+                "name": "https://www.ubercomp.com/posts/2022-01-20_redis_on_debian_rce"
+            },
+            {
+                "refsource": "MLIST",
+                "name": "[debian-security-announce] 20220218 [SECURITY] [DSA 5081-1] redis security update",
+                "url": "https://lists.debian.org/debian-security-announce/2022/msg00048.html"
+            },
+            {
+                "refsource": "DEBIAN",
+                "name": "DSA-5081",
+                "url": "https://www.debian.org/security/2022/dsa-5081"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "DSA-5081-1",
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
Signed-off-by: Salvatore Bonaccorso <carnil@debian.org>