### PR TITLE
Add CVE-2022-23649 for GHSA-ccxc-vr6p-4858

### DIFF
--- a/2022/23xxx/CVE-2022-23649.json
+++ b/2022/23xxx/CVE-2022-23649.json
@@ -1,18 +1,88 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-23649",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Improper Certificate Validation in Cosign"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "cosign",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.5.2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "sigstore"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Cosign provides container signing, verification, and storage in an OCI registry for the sigstore project. Prior to version 1.5.2, Cosign can be manipulated to claim that an entry for a signature exists in the Rekor transparency log even if it doesn't. This requires the attacker to have pull and push permissions for the signature in OCI. This can happen with both standard signing with a keypair and \"keyless signing\" with Fulcio. If an attacker has access to the signature in OCI, they can manipulate cosign into believing the entry was stored in Rekor even though it wasn't. The vulnerability has been patched in v1.5.2 of Cosign. The `signature` in the `signedEntryTimestamp` provided by Rekor is now compared to the `signature` that is being verified. If these don't match, then an error is returned. If a valid bundle is copied to a different signature, verification should fail.  Cosign output now only informs the user that certificates were verified if a certificate was in fact verified. There is currently no known workaround."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 3.3,
+            "baseSeverity": "LOW",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-295: Improper Certificate Validation"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/sigstore/cosign/security/advisories/GHSA-ccxc-vr6p-4858",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/sigstore/cosign/security/advisories/GHSA-ccxc-vr6p-4858"
+            },
+            {
+                "name": "https://github.com/sigstore/cosign/commit/96d410a6580e4e81d24d112a0855c70ca3fb5b49",
+                "refsource": "MISC",
+                "url": "https://github.com/sigstore/cosign/commit/96d410a6580e4e81d24d112a0855c70ca3fb5b49"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-ccxc-vr6p-4858",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-23649 for GHSA-ccxc-vr6p-4858