### PR TITLE
Fix typo in CVE description for CVE-2016-1239/duck

### DIFF
--- a/2016/1xxx/CVE-2016-1239.json
+++ b/2016/1xxx/CVE-2016-1239.json
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "duck before 0.10 did not properly handle loading of untrusted code from the current directory.."
+                "value": "duck before 0.10 did not properly handle loading of untrusted code from the current directory."
             }
         ]
     },


### PR DESCRIPTION
Signed-off-by: Salvatore Bonaccorso <carnil@debian.org>