### PR TITLE
Add CVE-2022-0717 for 27a851a5-7ebf-409b-854f-b2614771e8f9

### DIFF
--- a/2022/0xxx/CVE-2022-0717.json
+++ b/2022/0xxx/CVE-2022-0717.json
@@ -1,0 +1,89 @@
+{
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-0717",
+    "STATE": "PUBLIC",
+    "TITLE": "Out-of-bounds Read in mruby/mruby"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "mruby/mruby",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "3.2"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "mruby"
+        }
+      ]
+    }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Out-of-bounds Read in GitHub repository mruby/mruby prior to 3.2."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "HIGH",
+      "baseScore": 6.8,
+      "baseSeverity": "MEDIUM",
+      "confidentialityImpact": "NONE",
+      "integrityImpact": "LOW",
+      "privilegesRequired": "NONE",
+      "scope": "UNCHANGED",
+      "userInteraction": "NONE",
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125 Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/27a851a5-7ebf-409b-854f-b2614771e8f9",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/27a851a5-7ebf-409b-854f-b2614771e8f9"
+      },
+      {
+        "name": "https://github.com/mruby/mruby/commit/f72315575f78a9a773adbce0ee7d3ec33434cb76",
+        "refsource": "MISC",
+        "url": "https://github.com/mruby/mruby/commit/f72315575f78a9a773adbce0ee7d3ec33434cb76"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "27a851a5-7ebf-409b-854f-b2614771e8f9",
+    "discovery": "EXTERNAL"
+  }
+}


### PR DESCRIPTION
Add CVE-2022-0717 for [27a851a5-7ebf-409b-854f-b2614771e8f9](https://huntr.dev/bounties/27a851a5-7ebf-409b-854f-b2614771e8f9) @huntr-helper