### PR TITLE
Add CVE-2022-23648 for GHSA-crp2-qrr5-8pq7

### DIFF
--- a/2022/23xxx/CVE-2022-23648.json
+++ b/2022/23xxx/CVE-2022-23648.json
@@ -1,18 +1,109 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-23648",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Insecure handling of image volumes in containerd CRI plugin"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "containerd",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": " < 1.4.13"
+                                        },
+                                        {
+                                            "version_value": ">= 1.5.0, < 1.5.10"
+                                        },
+                                        {
+                                            "version_value": ">= 1.6.0, < 1.6.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "containerd"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "containerd is a container runtime available as a daemon for Linux and Windows. A bug was found in containerd prior to versions 1.6.1, 1.5.10, and 1.14.12 where containers launched through containerd’s CRI implementation on Linux with a specially-crafted image configuration could gain access to read-only copies of arbitrary files and directories on the host.  This may bypass any policy-based enforcement on container setup (including a Kubernetes Pod Security Policy) and expose potentially sensitive information.  Kubernetes and crictl can both be configured to use containerd’s CRI implementation. This bug has been fixed in containerd 1.6.1, 1.5.10, and 1.4.12.  Users should update to these versions to resolve the issue."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/containerd/containerd/security/advisories/GHSA-crp2-qrr5-8pq7",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/containerd/containerd/security/advisories/GHSA-crp2-qrr5-8pq7"
+            },
+            {
+                "name": "https://github.com/containerd/containerd/commit/10f428dac7cec44c864e1b830a4623af27a9fc70",
+                "refsource": "MISC",
+                "url": "https://github.com/containerd/containerd/commit/10f428dac7cec44c864e1b830a4623af27a9fc70"
+            },
+            {
+                "name": "https://github.com/containerd/containerd/releases/tag/v1.4.13",
+                "refsource": "MISC",
+                "url": "https://github.com/containerd/containerd/releases/tag/v1.4.13"
+            },
+            {
+                "name": "https://github.com/containerd/containerd/releases/tag/v1.5.10",
+                "refsource": "MISC",
+                "url": "https://github.com/containerd/containerd/releases/tag/v1.5.10"
+            },
+            {
+                "name": "https://github.com/containerd/containerd/releases/tag/v1.6.1",
+                "refsource": "MISC",
+                "url": "https://github.com/containerd/containerd/releases/tag/v1.6.1"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-crp2-qrr5-8pq7",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-23648 for GHSA-crp2-qrr5-8pq7