### PR TITLE
XSA-396 CVE-2022-23036 CVE-2022-23037 CVE-2022-23038 CVE-2022-23039 CVE-2022-23040 CVE-2022-23041 CVE-2022-23042

### DIFF
--- a/2022/23xxx/CVE-2022-23036.json
+++ b/2022/23xxx/CVE-2022-23036.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23036",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-23036"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-396"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : ""
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Linux guests using PV devices are vulnerable in case potentially\nmalicious PV device backends are being used."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Demi Marie Obenour and Simon Gaiser of\nInvisible Things Lab."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Linux PV device frontends vulnerable to attacks by backends\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nSeveral Linux PV device frontends are using the grant table interfaces\nfor removing access rights of the backends in ways being subject to\nrace conditions, resulting in potential data leaks, data corruption\nby malicious backends, and denial of service triggered by malicious\nbackends:\n\nblkfront, netfront, scsifront and the gntalloc driver are testing\nwhether a grant reference is still in use. If this is not the case,\nthey assume that a following removal of the granted access will always\nsucceed, which is not true in case the backend has mapped the granted\npage between those two operations. As a result the backend can keep\naccess to the memory page of the guest no matter how the page will be\nused after the frontend I/O has finished. The xenbus driver has a\nsimilar problem, as it doesn't check the success of removing the\ngranted access of a shared ring buffer.\nblkfront: CVE-2022-23036\nnetfront: CVE-2022-23037\nscsifront: CVE-2022-23038\ngntalloc: CVE-2022-23039\nxenbus: CVE-2022-23040\n\nblkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront,\nand pvcalls are using a functionality to delay freeing a grant reference\nuntil it is no longer in use, but the freeing of the related data page\nis not synchronized with dropping the granted access. As a result the\nbackend can keep access to the memory page even after it has been freed\nand then re-used for a different purpose.\nCVE-2022-23041\n\n\nnetfront will fail a BUG_ON() assertion if it fails to revoke access in\nthe rx path. This will result in a Denial of Service (DoS) situation of\nthe guest which can be triggered by the backend.\nCVE-2022-23042"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Due to race conditions and missing tests of return codes in the Linux\nPV device frontend drivers a malicious backend could gain access (read\nand write) to memory pages it shouldn't have, or it could directly\ntrigger Denial of Service (DoS) in the guest."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-396.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no mitigation available other than not using PV devices in case\na backend is suspected to be potentially malicious."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2022/23xxx/CVE-2022-23037.json
+++ b/2022/23xxx/CVE-2022-23037.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23037",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-23037"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-396"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : ""
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Linux guests using PV devices are vulnerable in case potentially\nmalicious PV device backends are being used."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Demi Marie Obenour and Simon Gaiser of\nInvisible Things Lab."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Linux PV device frontends vulnerable to attacks by backends\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nSeveral Linux PV device frontends are using the grant table interfaces\nfor removing access rights of the backends in ways being subject to\nrace conditions, resulting in potential data leaks, data corruption\nby malicious backends, and denial of service triggered by malicious\nbackends:\n\nblkfront, netfront, scsifront and the gntalloc driver are testing\nwhether a grant reference is still in use. If this is not the case,\nthey assume that a following removal of the granted access will always\nsucceed, which is not true in case the backend has mapped the granted\npage between those two operations. As a result the backend can keep\naccess to the memory page of the guest no matter how the page will be\nused after the frontend I/O has finished. The xenbus driver has a\nsimilar problem, as it doesn't check the success of removing the\ngranted access of a shared ring buffer.\nblkfront: CVE-2022-23036\nnetfront: CVE-2022-23037\nscsifront: CVE-2022-23038\ngntalloc: CVE-2022-23039\nxenbus: CVE-2022-23040\n\nblkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront,\nand pvcalls are using a functionality to delay freeing a grant reference\nuntil it is no longer in use, but the freeing of the related data page\nis not synchronized with dropping the granted access. As a result the\nbackend can keep access to the memory page even after it has been freed\nand then re-used for a different purpose.\nCVE-2022-23041\n\n\nnetfront will fail a BUG_ON() assertion if it fails to revoke access in\nthe rx path. This will result in a Denial of Service (DoS) situation of\nthe guest which can be triggered by the backend.\nCVE-2022-23042"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Due to race conditions and missing tests of return codes in the Linux\nPV device frontend drivers a malicious backend could gain access (read\nand write) to memory pages it shouldn't have, or it could directly\ntrigger Denial of Service (DoS) in the guest."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-396.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no mitigation available other than not using PV devices in case\na backend is suspected to be potentially malicious."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2022/23xxx/CVE-2022-23038.json
+++ b/2022/23xxx/CVE-2022-23038.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23038",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-23038"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-396"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : ""
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Linux guests using PV devices are vulnerable in case potentially\nmalicious PV device backends are being used."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Demi Marie Obenour and Simon Gaiser of\nInvisible Things Lab."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Linux PV device frontends vulnerable to attacks by backends\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nSeveral Linux PV device frontends are using the grant table interfaces\nfor removing access rights of the backends in ways being subject to\nrace conditions, resulting in potential data leaks, data corruption\nby malicious backends, and denial of service triggered by malicious\nbackends:\n\nblkfront, netfront, scsifront and the gntalloc driver are testing\nwhether a grant reference is still in use. If this is not the case,\nthey assume that a following removal of the granted access will always\nsucceed, which is not true in case the backend has mapped the granted\npage between those two operations. As a result the backend can keep\naccess to the memory page of the guest no matter how the page will be\nused after the frontend I/O has finished. The xenbus driver has a\nsimilar problem, as it doesn't check the success of removing the\ngranted access of a shared ring buffer.\nblkfront: CVE-2022-23036\nnetfront: CVE-2022-23037\nscsifront: CVE-2022-23038\ngntalloc: CVE-2022-23039\nxenbus: CVE-2022-23040\n\nblkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront,\nand pvcalls are using a functionality to delay freeing a grant reference\nuntil it is no longer in use, but the freeing of the related data page\nis not synchronized with dropping the granted access. As a result the\nbackend can keep access to the memory page even after it has been freed\nand then re-used for a different purpose.\nCVE-2022-23041\n\n\nnetfront will fail a BUG_ON() assertion if it fails to revoke access in\nthe rx path. This will result in a Denial of Service (DoS) situation of\nthe guest which can be triggered by the backend.\nCVE-2022-23042"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Due to race conditions and missing tests of return codes in the Linux\nPV device frontend drivers a malicious backend could gain access (read\nand write) to memory pages it shouldn't have, or it could directly\ntrigger Denial of Service (DoS) in the guest."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-396.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no mitigation available other than not using PV devices in case\na backend is suspected to be potentially malicious."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2022/23xxx/CVE-2022-23039.json
+++ b/2022/23xxx/CVE-2022-23039.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23039",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-23039"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-396"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : ""
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Linux guests using PV devices are vulnerable in case potentially\nmalicious PV device backends are being used."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Demi Marie Obenour and Simon Gaiser of\nInvisible Things Lab."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Linux PV device frontends vulnerable to attacks by backends\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nSeveral Linux PV device frontends are using the grant table interfaces\nfor removing access rights of the backends in ways being subject to\nrace conditions, resulting in potential data leaks, data corruption\nby malicious backends, and denial of service triggered by malicious\nbackends:\n\nblkfront, netfront, scsifront and the gntalloc driver are testing\nwhether a grant reference is still in use. If this is not the case,\nthey assume that a following removal of the granted access will always\nsucceed, which is not true in case the backend has mapped the granted\npage between those two operations. As a result the backend can keep\naccess to the memory page of the guest no matter how the page will be\nused after the frontend I/O has finished. The xenbus driver has a\nsimilar problem, as it doesn't check the success of removing the\ngranted access of a shared ring buffer.\nblkfront: CVE-2022-23036\nnetfront: CVE-2022-23037\nscsifront: CVE-2022-23038\ngntalloc: CVE-2022-23039\nxenbus: CVE-2022-23040\n\nblkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront,\nand pvcalls are using a functionality to delay freeing a grant reference\nuntil it is no longer in use, but the freeing of the related data page\nis not synchronized with dropping the granted access. As a result the\nbackend can keep access to the memory page even after it has been freed\nand then re-used for a different purpose.\nCVE-2022-23041\n\n\nnetfront will fail a BUG_ON() assertion if it fails to revoke access in\nthe rx path. This will result in a Denial of Service (DoS) situation of\nthe guest which can be triggered by the backend.\nCVE-2022-23042"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Due to race conditions and missing tests of return codes in the Linux\nPV device frontend drivers a malicious backend could gain access (read\nand write) to memory pages it shouldn't have, or it could directly\ntrigger Denial of Service (DoS) in the guest."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-396.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no mitigation available other than not using PV devices in case\na backend is suspected to be potentially malicious."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2022/23xxx/CVE-2022-23040.json
+++ b/2022/23xxx/CVE-2022-23040.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23040",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-23040"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-396"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : ""
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Linux guests using PV devices are vulnerable in case potentially\nmalicious PV device backends are being used."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Demi Marie Obenour and Simon Gaiser of\nInvisible Things Lab."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Linux PV device frontends vulnerable to attacks by backends\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nSeveral Linux PV device frontends are using the grant table interfaces\nfor removing access rights of the backends in ways being subject to\nrace conditions, resulting in potential data leaks, data corruption\nby malicious backends, and denial of service triggered by malicious\nbackends:\n\nblkfront, netfront, scsifront and the gntalloc driver are testing\nwhether a grant reference is still in use. If this is not the case,\nthey assume that a following removal of the granted access will always\nsucceed, which is not true in case the backend has mapped the granted\npage between those two operations. As a result the backend can keep\naccess to the memory page of the guest no matter how the page will be\nused after the frontend I/O has finished. The xenbus driver has a\nsimilar problem, as it doesn't check the success of removing the\ngranted access of a shared ring buffer.\nblkfront: CVE-2022-23036\nnetfront: CVE-2022-23037\nscsifront: CVE-2022-23038\ngntalloc: CVE-2022-23039\nxenbus: CVE-2022-23040\n\nblkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront,\nand pvcalls are using a functionality to delay freeing a grant reference\nuntil it is no longer in use, but the freeing of the related data page\nis not synchronized with dropping the granted access. As a result the\nbackend can keep access to the memory page even after it has been freed\nand then re-used for a different purpose.\nCVE-2022-23041\n\n\nnetfront will fail a BUG_ON() assertion if it fails to revoke access in\nthe rx path. This will result in a Denial of Service (DoS) situation of\nthe guest which can be triggered by the backend.\nCVE-2022-23042"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Due to race conditions and missing tests of return codes in the Linux\nPV device frontend drivers a malicious backend could gain access (read\nand write) to memory pages it shouldn't have, or it could directly\ntrigger Denial of Service (DoS) in the guest."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-396.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no mitigation available other than not using PV devices in case\na backend is suspected to be potentially malicious."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2022/23xxx/CVE-2022-23041.json
+++ b/2022/23xxx/CVE-2022-23041.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23041",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-23041"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-396"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : ""
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Linux guests using PV devices are vulnerable in case potentially\nmalicious PV device backends are being used."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Demi Marie Obenour and Simon Gaiser of\nInvisible Things Lab."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Linux PV device frontends vulnerable to attacks by backends\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nSeveral Linux PV device frontends are using the grant table interfaces\nfor removing access rights of the backends in ways being subject to\nrace conditions, resulting in potential data leaks, data corruption\nby malicious backends, and denial of service triggered by malicious\nbackends:\n\nblkfront, netfront, scsifront and the gntalloc driver are testing\nwhether a grant reference is still in use. If this is not the case,\nthey assume that a following removal of the granted access will always\nsucceed, which is not true in case the backend has mapped the granted\npage between those two operations. As a result the backend can keep\naccess to the memory page of the guest no matter how the page will be\nused after the frontend I/O has finished. The xenbus driver has a\nsimilar problem, as it doesn't check the success of removing the\ngranted access of a shared ring buffer.\nblkfront: CVE-2022-23036\nnetfront: CVE-2022-23037\nscsifront: CVE-2022-23038\ngntalloc: CVE-2022-23039\nxenbus: CVE-2022-23040\n\nblkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront,\nand pvcalls are using a functionality to delay freeing a grant reference\nuntil it is no longer in use, but the freeing of the related data page\nis not synchronized with dropping the granted access. As a result the\nbackend can keep access to the memory page even after it has been freed\nand then re-used for a different purpose.\nCVE-2022-23041\n\n\nnetfront will fail a BUG_ON() assertion if it fails to revoke access in\nthe rx path. This will result in a Denial of Service (DoS) situation of\nthe guest which can be triggered by the backend.\nCVE-2022-23042"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Due to race conditions and missing tests of return codes in the Linux\nPV device frontend drivers a malicious backend could gain access (read\nand write) to memory pages it shouldn't have, or it could directly\ntrigger Denial of Service (DoS) in the guest."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-396.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no mitigation available other than not using PV devices in case\na backend is suspected to be potentially malicious."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2022/23xxx/CVE-2022-23042.json
+++ b/2022/23xxx/CVE-2022-23042.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23042",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-23042"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-396"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : ""
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Linux guests using PV devices are vulnerable in case potentially\nmalicious PV device backends are being used."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Demi Marie Obenour and Simon Gaiser of\nInvisible Things Lab."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Linux PV device frontends vulnerable to attacks by backends\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nSeveral Linux PV device frontends are using the grant table interfaces\nfor removing access rights of the backends in ways being subject to\nrace conditions, resulting in potential data leaks, data corruption\nby malicious backends, and denial of service triggered by malicious\nbackends:\n\nblkfront, netfront, scsifront and the gntalloc driver are testing\nwhether a grant reference is still in use. If this is not the case,\nthey assume that a following removal of the granted access will always\nsucceed, which is not true in case the backend has mapped the granted\npage between those two operations. As a result the backend can keep\naccess to the memory page of the guest no matter how the page will be\nused after the frontend I/O has finished. The xenbus driver has a\nsimilar problem, as it doesn't check the success of removing the\ngranted access of a shared ring buffer.\nblkfront: CVE-2022-23036\nnetfront: CVE-2022-23037\nscsifront: CVE-2022-23038\ngntalloc: CVE-2022-23039\nxenbus: CVE-2022-23040\n\nblkfront, netfront, scsifront, usbfront, dmabuf, xenbus, 9p, kbdfront,\nand pvcalls are using a functionality to delay freeing a grant reference\nuntil it is no longer in use, but the freeing of the related data page\nis not synchronized with dropping the granted access. As a result the\nbackend can keep access to the memory page even after it has been freed\nand then re-used for a different purpose.\nCVE-2022-23041\n\n\nnetfront will fail a BUG_ON() assertion if it fails to revoke access in\nthe rx path. This will result in a Denial of Service (DoS) situation of\nthe guest which can be triggered by the backend.\nCVE-2022-23042"
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Due to race conditions and missing tests of return codes in the Linux\nPV device frontend drivers a malicious backend could gain access (read\nand write) to memory pages it shouldn't have, or it could directly\ntrigger Denial of Service (DoS) in the guest."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-396.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no mitigation available other than not using PV devices in case\na backend is suspected to be potentially malicious."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-396 CVE-2022-23036 CVE-2022-23037 CVE-2022-23038 CVE-2022-23039 CVE-2022-23040 CVE-2022-23041 CVE-2022-23042

CVE data entry for:
  CVE-2022-23036

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2022-23037

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2022-23038

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2022-23039

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2022-23040

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2022-23041

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2022-23042

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
