### PR TITLE
CVE-2022-22273

### DIFF
--- a/2022/22xxx/CVE-2022-22273.json
+++ b/2022/22xxx/CVE-2022-22273.json
@@ -1,18 +1,65 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-22273",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "psirt@sonicwall.com",
+    "ID": "CVE-2022-22273",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "SonicWall SRA/SMA100",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "SRA Series 9.0.0.5-19sv and earlier versions."
+                    },
+                    {
+                      "version_value": "SMA100 Series 9.0.0.9-26sv and earlier versions."
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "SonicWall"
+        }
+      ]
     }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "** UNSUPPORTED WHEN ASSIGNED ** Improper neutralization of Special Elements leading to OS Command Injection vulnerability impacting end-of-life Secure Remote Access (SRA) products and older firmware versions of Secure Mobile Access (SMA) 100 series products, specifically the SRA appliances running all 8.x, 9.0.0.5-19sv and earlier versions and Secure Mobile Access (SMA) 100 series products running older firmware 9.0.0.9-26sv and earlier versions."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2022-0001",
+        "refsource": "CONFIRM",
+        "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2022-0001"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
SonicWall SRA/SMA100 product end of life and end of support CVE ID CVE-2022-22273 submission.