### PR TITLE
CVE-2022-22274 submission

### DIFF
--- a/2022/22xxx/CVE-2022-22274.json
+++ b/2022/22xxx/CVE-2022-22274.json
@@ -1,18 +1,68 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-22274",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "psirt@sonicwall.com",
+    "ID": "CVE-2022-22274",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "SonicOS",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "SonicOS 7.0.1-5050 and earlier"
+                    },
+                    {
+                      "version_value": "SonicOS 7.0.1-R579 and earlier"
+                    },
+                    {
+                      "version_value": "SonicOSv 6.5.4.4-44v-21-1452 and earlier"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "SonicWall"
+        }
+      ]
     }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "A Stack-based buffer overflow vulnerability in the SonicOS via HTTP request allows a remote unauthenticated attacker to cause Denial of Service (DoS) or potentially results in code execution in the firewall."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121: Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2022-0003",
+        "refsource": "CONFIRM",
+        "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2022-0003"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
CVE-2022-22274 - Gen 6 SonicOSv and Gen7 buffer overflow vulnerability