### PR TITLE
Add CVE-2022-1172 for a26cb79c-9257-4fbf-98c5-a5a331efa264

### DIFF
--- a/2022/1xxx/CVE-2022-1172.json
+++ b/2022/1xxx/CVE-2022-1172.json
@@ -1,0 +1,89 @@
+{
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-1172",
+    "STATE": "PUBLIC",
+    "TITLE": "Null Pointer Dereference Caused Segmentation Fault in gpac/gpac"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "gpac/gpac",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "2.1.0-DEV"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "gpac"
+        }
+      ]
+    }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Null Pointer Dereference Caused Segmentation Fault in GitHub repository gpac/gpac prior to 2.1.0-DEV."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "HIGH",
+      "baseScore": 5.6,
+      "baseSeverity": "MEDIUM",
+      "confidentialityImpact": "NONE",
+      "integrityImpact": "LOW",
+      "privilegesRequired": "LOW",
+      "scope": "UNCHANGED",
+      "userInteraction": "REQUIRED",
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:L/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-476 NULL Pointer Dereference"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/a26cb79c-9257-4fbf-98c5-a5a331efa264",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/a26cb79c-9257-4fbf-98c5-a5a331efa264"
+      },
+      {
+        "name": "https://github.com/gpac/gpac/commit/55a183e6b8602369c04ea3836e05436a79fbc7f8",
+        "refsource": "MISC",
+        "url": "https://github.com/gpac/gpac/commit/55a183e6b8602369c04ea3836e05436a79fbc7f8"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "a26cb79c-9257-4fbf-98c5-a5a331efa264",
+    "discovery": "EXTERNAL"
+  }
+}


### PR DESCRIPTION
Add CVE-2022-1172 for [a26cb79c-9257-4fbf-98c5-a5a331efa264](https://huntr.dev/bounties/a26cb79c-9257-4fbf-98c5-a5a331efa264) @huntr-helper