### PR TITLE
Add CVE-2022-24796 for GHSA-g7vv-7rmf-mff7

### DIFF
--- a/2022/24xxx/CVE-2022-24796.json
+++ b/2022/24xxx/CVE-2022-24796.json
@@ -1,18 +1,88 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-24796",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Remote Command Injection in RaspberryMatic"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "RaspberryMatic",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 2.31.25.20180428, < 3.63.8.20220330"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "jens-maus"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "RaspberryMatic is a free and open-source operating system for running a cloud-free smart-home using the homematicIP / HomeMatic hardware line of IoT devices. A Remote Code Execution (RCE) vulnerability in the file upload facility of the WebUI interface of RaspberryMatic exists. Missing input validation/sanitization in the file upload mechanism allows remote, unauthenticated attackers with network access to the WebUI interface to achieve arbitrary operating system command execution via shell metacharacters in the HTTP query string. Injected commands are executed as root, thus leading to a full compromise of the underlying system and all its components. Versions after `2.31.25.20180428` and prior to `3.63.8.20220330` are affected. Users are advised to update to version `3.63.8.20220330` or newer. There are currently no known workarounds to mitigate the security impact and users are advised to update to the latest version available."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 10.0,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/jens-maus/RaspberryMatic/security/advisories/GHSA-g7vv-7rmf-mff7",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/jens-maus/RaspberryMatic/security/advisories/GHSA-g7vv-7rmf-mff7"
+            },
+            {
+                "name": "https://github.com/jens-maus/RaspberryMatic/commit/34854659a63e9fb3ad529bb413e96978c6450a53",
+                "refsource": "MISC",
+                "url": "https://github.com/jens-maus/RaspberryMatic/commit/34854659a63e9fb3ad529bb413e96978c6450a53"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-g7vv-7rmf-mff7",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-24796 for GHSA-g7vv-7rmf-mff7