### PR TITLE
XSA-397 CVE-2022-26356

### DIFF
--- a/2022/26xxx/CVE-2022-26356.json
+++ b/2022/26xxx/CVE-2022-26356.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-26356",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-26356"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-397"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from at least 4.0 onwards are vulnerable.\n\nOnly x86 systems are vulnerable.  Arm systems are not vulnerable.\n\nOnly domains controlling an x86 HVM guest using Hardware Assisted Paging (HAP)\ncan leverage the vulnerability.  On common deployments this is limited to\ndomains that run device models on behalf of guests."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Roger Pau Monné of Citrix."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Racy interactions between dirty vram tracking and paging log dirty hypercalls\n\nActivation of log dirty mode done by XEN_DMOP_track_dirty_vram (was named\nHVMOP_track_dirty_vram before Xen 4.9) is racy with ongoing log dirty\nhypercalls.  A suitably timed call to XEN_DMOP_track_dirty_vram can enable\nlog dirty while another CPU is still in the process of tearing down the\nstructures related to a previously enabled log dirty mode\n(XEN_DOMCTL_SHADOW_OP_OFF).  This is due to lack of mutually exclusive locking\nbetween both operations and can lead to entries being added in already freed\nslots, resulting in a memory leak."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "An attacker can cause Xen to leak memory, eventually leading to a Denial of\nService (DoS) affecting the entire host."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-397.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Using only PV or PVH guests and/or running HVM guests in shadow mode will avoid\nthe vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-397 CVE-2022-26356

CVE data entry for:
  CVE-2022-26356

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
