### PR TITLE
XSA-399 CVE-2022-26357

### DIFF
--- a/2022/26xxx/CVE-2022-26357.json
+++ b/2022/26xxx/CVE-2022-26357.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-26357",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-26357"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-399"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Xen versions 4.11 through 4.16 are vulnerable.  Xen versions 4.10 and\nearlier are not vulnerable.\n\nOnly x86 systems with VT-d IOMMU hardware are vulnerable.  Arm systems\nas well as x86 systems without VT-d hardware or without any IOMMUs in\nuse are not vulnerable.\n\nOnly x86 guests which have physical devices passed through to them can\nleverage the vulnerability."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "race in VT-d domain ID cleanup\n\nXen domain IDs are up to 15 bits wide.  VT-d hardware may allow for only\nless than 15 bits to hold a domain ID associating a physical device with\na particular domain.  Therefore internally Xen domain IDs are mapped to\nthe smaller value range.  The cleaning up of the housekeeping structures\nhas a race, allowing for VT-d domain IDs to be leaked and flushes to be\nbypassed."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The precise impact is system specific, but would typically be a Denial\nof Service (DoS) affecting the entire host.  Privilege escalation and\ninformation leaks cannot be ruled out."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-399.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not passing through physical devices to untrusted guests will avoid\nthe vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-399 CVE-2022-26357

CVE data entry for:
  CVE-2022-26357

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
