### PR TITLE
Add CVE-2022-24795 for GHSA-jj47-x69x-mxrm

### DIFF
--- a/2022/24xxx/CVE-2022-24795.json
+++ b/2022/24xxx/CVE-2022-24795.json
@@ -1,18 +1,101 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-24795",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Buffer Overflow and Integer Overflow in yajl-ruby"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "yajl-ruby",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "<= 1.4.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "brianmario"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "yajl-riuby is a C binding to the YAJL JSON parsing and generation library. The 1.x branch and the 2.x branch of yajl contain an integer overflow which leads to subsequent heap memory corruption when dealing with large (~2GB) inputs. The reallocation logic at `yajl_buf.c#L64` may result in the `need` 32bit integer wrapping to 0 when `need` approaches a value of 0x80000000 (i.e. ~2GB of data), which results in a reallocation of buf->alloc into a small heap chunk. These integers are declared as `size_t` in the 2.x branch of `yajl`, which practically prevents the issue from triggering on 64bit platforms, however this does not preclude this issue triggering on 32bit builds on which `size_t` is a 32bit integer. Subsequent population of this under-allocated heap chunk is based on the original buffer size, leading to heap memory corruption. This vulnerability mostly impacts process availability. Maintainers believe exploitation for arbitrary code execution to be unlikely. A patch is available and anticipated to be part of version 1.4.2. As a workaround, avoid passing large inputs to YAJL."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.9,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-122: Heap-based Buffer Overflow"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-190: Integer Overflow or Wraparound"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/brianmario/yajl-ruby/security/advisories/GHSA-jj47-x69x-mxrm",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/brianmario/yajl-ruby/security/advisories/GHSA-jj47-x69x-mxrm"
+            },
+            {
+                "name": "https://github.com/brianmario/yajl-ruby/commit/7168bd79b888900aa94523301126f968a93eb3a6",
+                "refsource": "MISC",
+                "url": "https://github.com/brianmario/yajl-ruby/commit/7168bd79b888900aa94523301126f968a93eb3a6"
+            },
+            {
+                "name": "https://github.com/brianmario/yajl-ruby/blob/7168bd79b888900aa94523301126f968a93eb3a6/ext/yajl/yajl_buf.c#L64",
+                "refsource": "MISC",
+                "url": "https://github.com/brianmario/yajl-ruby/blob/7168bd79b888900aa94523301126f968a93eb3a6/ext/yajl/yajl_buf.c#L64"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-jj47-x69x-mxrm",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-24795 for GHSA-jj47-x69x-mxrm