### PR TITLE
Add CVE-2022-1253 for 1-other-strukturag/libde265

### DIFF
--- a/2022/1xxx/CVE-2022-1253.json
+++ b/2022/1xxx/CVE-2022-1253.json
@@ -1,0 +1,89 @@
+{
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-1253",
+    "STATE": "PUBLIC",
+    "TITLE": "Heap-based Buffer Overflow in strukturag/libde265"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "strukturag/libde265",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "1.0.8"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "strukturag"
+        }
+      ]
+    }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Heap-based Buffer Overflow in GitHub repository strukturag/libde265 prior to 1.0.8."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "NETWORK",
+      "availabilityImpact": "LOW",
+      "baseScore": 7.4,
+      "baseSeverity": "HIGH",
+      "confidentialityImpact": "LOW",
+      "integrityImpact": "LOW",
+      "privilegesRequired": "LOW",
+      "scope": "CHANGED",
+      "userInteraction": "NONE",
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:L",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-122 Heap-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/1-other-strukturag/libde265",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/1-other-strukturag/libde265"
+      },
+      {
+        "name": "https://github.com/strukturag/libde265/commit/8e89fe0e175d2870c39486fdd09250b230ec10b8",
+        "refsource": "MISC",
+        "url": "https://github.com/strukturag/libde265/commit/8e89fe0e175d2870c39486fdd09250b230ec10b8"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "1-other-strukturag/libde265",
+    "discovery": "EXTERNAL"
+  }
+}


### PR DESCRIPTION
Add CVE-2022-1253 for [1-other-strukturag/libde265](https://huntr.dev/bounties/1-other-strukturag/libde265) @huntr-helper