### PR TITLE
Add CVE-2022-1284 for e98ad92c-3a64-48fb-84d4-d13afdbcbdd7

### DIFF
--- a/2022/1xxx/CVE-2022-1284.json
+++ b/2022/1xxx/CVE-2022-1284.json
@@ -1,0 +1,89 @@
+{
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-1284",
+    "STATE": "PUBLIC",
+    "TITLE": "heap-use-after-free in radareorg/radare2"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "radareorg/radare2",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "5.6.8"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "radareorg"
+        }
+      ]
+    }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "heap-use-after-free in GitHub repository radareorg/radare2 prior to 5.6.8. This vulnerability is capable of inducing denial of service."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "NETWORK",
+      "availabilityImpact": "HIGH",
+      "baseScore": 7.5,
+      "baseSeverity": "HIGH",
+      "confidentialityImpact": "NONE",
+      "integrityImpact": "NONE",
+      "privilegesRequired": "NONE",
+      "scope": "UNCHANGED",
+      "userInteraction": "NONE",
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-416 Use After Free"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/e98ad92c-3a64-48fb-84d4-d13afdbcbdd7",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/e98ad92c-3a64-48fb-84d4-d13afdbcbdd7"
+      },
+      {
+        "name": "https://github.com/radareorg/radare2/commit/64a82e284dddabaeb549228380103b57dead32a6",
+        "refsource": "MISC",
+        "url": "https://github.com/radareorg/radare2/commit/64a82e284dddabaeb549228380103b57dead32a6"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "e98ad92c-3a64-48fb-84d4-d13afdbcbdd7",
+    "discovery": "EXTERNAL"
+  }
+}


### PR DESCRIPTION
Add CVE-2022-1284 for [e98ad92c-3a64-48fb-84d4-d13afdbcbdd7](https://huntr.dev/bounties/e98ad92c-3a64-48fb-84d4-d13afdbcbdd7) @huntr-helper