### PR TITLE
Add CVE-2022-24882 for GHSA-6x5p-gp49-3jhh

### DIFF
--- a/2022/24xxx/CVE-2022-24882.json
+++ b/2022/24xxx/CVE-2022-24882.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-24882",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Server side NTLM does not properly check parameters in FreeRDP"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "FreeRDP",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 2.7.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "FreeRDP"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "FreeRDP is a free implementation of the Remote Desktop Protocol (RDP). In versions prior to 2.7.0, NT LAN Manager (NTLM) authentication does not properly abort when someone provides and empty password value. This issue affects FreeRDP based RDP Server implementations. RDP clients are not affected. The vulnerability is patched in FreeRDP 2.7.0. There are currently no known workarounds."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 9.1,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-287: Improper Authentication"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/FreeRDP/FreeRDP/security/advisories/GHSA-6x5p-gp49-3jhh",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/FreeRDP/FreeRDP/security/advisories/GHSA-6x5p-gp49-3jhh"
+            },
+            {
+                "name": "https://github.com/FreeRDP/FreeRDP/pull/7750",
+                "refsource": "MISC",
+                "url": "https://github.com/FreeRDP/FreeRDP/pull/7750"
+            },
+            {
+                "name": "https://github.com/FreeRDP/FreeRDP/releases/tag/2.7.0",
+                "refsource": "MISC",
+                "url": "https://github.com/FreeRDP/FreeRDP/releases/tag/2.7.0"
+            },
+            {
+                "name": "https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/issues/95",
+                "refsource": "MISC",
+                "url": "https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/issues/95"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-6x5p-gp49-3jhh",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-24882 for GHSA-6x5p-gp49-3jhh