### PR TITLE
Update CVE-2022-24736 for GHSA-3qpw-7686-5984

### DIFF
--- a/2022/24xxx/CVE-2022-24736.json
+++ b/2022/24xxx/CVE-2022-24736.json
@@ -38,7 +38,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Redis is an in-memory database that persists on disk. Prior to versions 6.2.7 and 7.0.0, an attacker attempting to load a specially crafted Lua script can cause NULL pointer dereference which will result with a crash of the redis-server process. The problem is fixed in Redis versions 7.0.0, 6.2.X and 6.0.X. An additional workaround to mitigate this problem without patching the redis-server executable, if Lua scripting is not being used, is to block access to `SCRIPT LOAD` and `EVAL` commands using ACL rules."
+                "value": "Redis is an in-memory database that persists on disk. Prior to versions 6.2.7 and 7.0.0, an attacker attempting to load a specially crafted Lua script can cause NULL pointer dereference which will result with a crash of the redis-server process. The problem is fixed in Redis versions 7.0.0 and 6.2.7. An additional workaround to mitigate this problem without patching the redis-server executable, if Lua scripting is not being used, is to block access to `SCRIPT LOAD` and `EVAL` commands using ACL rules."
             }
         ]
     },
@@ -73,6 +73,11 @@
     "references": {
         "reference_data": [
             {
+                "name": "https://github.com/redis/redis/security/advisories/GHSA-3qpw-7686-5984",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/redis/redis/security/advisories/GHSA-3qpw-7686-5984"
+            },
+            {
                 "name": "https://github.com/redis/redis/pull/10651",
                 "refsource": "MISC",
                 "url": "https://github.com/redis/redis/pull/10651"
@@ -86,11 +91,6 @@
                 "name": "https://github.com/redis/redis/releases/tag/7.0.0",
                 "refsource": "MISC",
                 "url": "https://github.com/redis/redis/releases/tag/7.0.0"
-            },
-            {
-                "name": "https://github.com/redis/redis/security/advisories/GHSA-3qpw-7686-5984",
-                "refsource": "CONFIRM",
-                "url": "https://github.com/redis/redis/security/advisories/GHSA-3qpw-7686-5984"
             }
         ]
     },


### PR DESCRIPTION
Changed fixed versions to 6.2.7 and 7.0.0 per maintainer advisory.