### PR TITLE
Add CVE-2022-24897 for GHSA-cvx5-m8vg-vxgc

### DIFF
--- a/2022/24xxx/CVE-2022-24897.json
+++ b/2022/24xxx/CVE-2022-24897.json
@@ -88,9 +88,9 @@
                 "url": "https://github.com/xwiki/xwiki-commons/commit/215951cfb0f808d0bf5b1097c9e7d1e503449ab8"
             },
             {
-                "name": " https://jira.xwiki.org/browse/XWIKI-5168",
+                "name": "https://jira.xwiki.org/browse/XWIKI-5168",
                 "refsource": "MISC",
-                "url": " https://jira.xwiki.org/browse/XWIKI-5168"
+                "url": "https://jira.xwiki.org/browse/XWIKI-5168"
             }
         ]
     },

--- a/2022/24xxx/CVE-2022-24897.json
+++ b/2022/24xxx/CVE-2022-24897.json
@@ -1,18 +1,101 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-24897",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Arbitrary filesystem write access from Velocity"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "xwiki-commons",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 2.3, < 12.6.7"
+                                        },
+                                        {
+                                            "version_value": "12.7-rc-1, < 12.10.3"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "xwiki"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "APIs to evaluate content with Velocity is a package for APIs to evaluate content with Velocity. Starting with version 2.3 and prior to 12.6.7, 12.10.3, and 13.0, the velocity scripts are not properly sandboxed against using the Java File API to perform read or write operations on the filesystem. Writing an attacking script in Velocity requires the Script rights in XWiki so not all users can use it, and it also requires finding an XWiki API which returns a File. The problem has been patched in versions 12.6.7, 12.10.3, and 13.0. There is no easy workaround for fixing this vulnerability other than upgrading and being careful when giving Script rights."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/xwiki/xwiki-commons/security/advisories/GHSA-cvx5-m8vg-vxgc",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/xwiki/xwiki-commons/security/advisories/GHSA-cvx5-m8vg-vxgc"
+            },
+            {
+                "name": "https://github.com/xwiki/xwiki-commons/pull/127",
+                "refsource": "MISC",
+                "url": "https://github.com/xwiki/xwiki-commons/pull/127"
+            },
+            {
+                "name": "https://github.com/xwiki/xwiki-commons/commit/215951cfb0f808d0bf5b1097c9e7d1e503449ab8",
+                "refsource": "MISC",
+                "url": "https://github.com/xwiki/xwiki-commons/commit/215951cfb0f808d0bf5b1097c9e7d1e503449ab8"
+            },
+            {
+                "name": " https://jira.xwiki.org/browse/XWIKI-5168",
+                "refsource": "MISC",
+                "url": " https://jira.xwiki.org/browse/XWIKI-5168"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-cvx5-m8vg-vxgc",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-24897 for GHSA-cvx5-m8vg-vxgc. Now with no whitespace before the reference URLs.