### PR TITLE
Update CVE-2022-23601 for GHSA-vvmr-8829-6whx

### DIFF
--- a/2022/23xxx/CVE-2022-23601.json
+++ b/2022/23xxx/CVE-2022-23601.json
@@ -16,13 +16,19 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "< 5.3.15"
+                                            "version_affected": "=",
+                                            "version_name": "5.3.14",
+                                            "version_value": "5.3.14"
                                         },
                                         {
-                                            "version_value": ">= 5.4.0, < 5.4.4"
+                                            "version_affected": "=",
+                                            "version_name": "5.4.3",
+                                            "version_value": "5.4.3"
                                         },
                                         {
-                                            "version_value": ">= 6.0.0, < 6.0.4"
+                                            "version_affected": "=",
+                                            "version_name": "6.0.3",
+                                            "version_value": "6.0.3"
                                         }
                                     ]
                                 }


### PR DESCRIPTION
Change vulnerable version ranges to match maintainer advisory per maintainer request