### PR TITLE
Add CVE-2022-1714 for 1c22055b-b015-47a8-a57b-4982978751d0

### DIFF
--- a/2022/1xxx/CVE-2022-1714.json
+++ b/2022/1xxx/CVE-2022-1714.json
@@ -1,0 +1,89 @@
+{
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-1714",
+    "STATE": "PUBLIC",
+    "TITLE": "Heap-based Buffer Overflow in radareorg/radare2"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "radareorg/radare2",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "5.7.0"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "radareorg"
+        }
+      ]
+    }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Heap-based Buffer Overflow in GitHub repository radareorg/radare2 prior to 5.7.0. The bug causes the program reads data past the end of the intented buffer. Typically, this can allow attackers to read sensitive information from other memory locations or cause a crash."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "LOW",
+      "baseScore": 7.9,
+      "baseSeverity": "HIGH",
+      "confidentialityImpact": "LOW",
+      "integrityImpact": "HIGH",
+      "privilegesRequired": "LOW",
+      "scope": "CHANGED",
+      "userInteraction": "NONE",
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:L/I:H/A:L",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-122 Heap-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/1c22055b-b015-47a8-a57b-4982978751d0",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/1c22055b-b015-47a8-a57b-4982978751d0"
+      },
+      {
+        "name": "https://github.com/radareorg/radare2/commit/3ecdbf8e21186a9c5a4d3cfa3b1e9fd27045340e",
+        "refsource": "MISC",
+        "url": "https://github.com/radareorg/radare2/commit/3ecdbf8e21186a9c5a4d3cfa3b1e9fd27045340e"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "1c22055b-b015-47a8-a57b-4982978751d0",
+    "discovery": "EXTERNAL"
+  }
+}


### PR DESCRIPTION
Add CVE-2022-1714 for [1c22055b-b015-47a8-a57b-4982978751d0](https://huntr.dev/bounties/1c22055b-b015-47a8-a57b-4982978751d0) @huntr-helper