### PR TITLE
Add CVE-2022-24856 for GHSA-www6-hf2v-v9m9

### DIFF
--- a/2022/24xxx/CVE-2022-24856.json
+++ b/2022/24xxx/CVE-2022-24856.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-24856",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Server-Side Request Forgery in FlyteConsole"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "flyteconsole",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.52.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "flyteorg"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "FlyteConsole is the web user interface for the Flyte platform. FlyteConsole prior to version 0.52.0 is vulnerable to server-side request forgery (SSRF) when FlyteConsole is open to the general internet. An attacker can exploit any user of a vulnerable instance to access the internal metadata server or other unauthenticated URLs. Passing of headers to an unauthorized actor may occur. The patch for this issue deletes the entire `cors_proxy`, as this is not required for console anymore. A patch is available in FlyteConsole version 0.52.0. Disable FlyteConsole availability on the internet as a workaround.\n"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 9.1,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-918: Server-Side Request Forgery (SSRF)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/flyteorg/flyteconsole/security/advisories/GHSA-www6-hf2v-v9m9",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/flyteorg/flyteconsole/security/advisories/GHSA-www6-hf2v-v9m9"
+            },
+            {
+                "name": "https://github.com/flyteorg/flyteconsole/pull/389",
+                "refsource": "MISC",
+                "url": "https://github.com/flyteorg/flyteconsole/pull/389"
+            },
+            {
+                "name": "https://github.com/flyteorg/flyteconsole/commit/05b88ed2d2ecdb5d8a8404efea25414e57189709",
+                "refsource": "MISC",
+                "url": "https://github.com/flyteorg/flyteconsole/commit/05b88ed2d2ecdb5d8a8404efea25414e57189709"
+            },
+            {
+                "name": "https://github.com/flyteorg/flyteconsole/releases/tag/v0.52.0",
+                "refsource": "MISC",
+                "url": "https://github.com/flyteorg/flyteconsole/releases/tag/v0.52.0"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-www6-hf2v-v9m9",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-24856 for GHSA-www6-hf2v-v9m9