### PR TITLE
Add CVE-2022-1769 for 522076b2-96cb-4df6-a504-e6e2f64c171c

### DIFF
--- a/2022/1xxx/CVE-2022-1769.json
+++ b/2022/1xxx/CVE-2022-1769.json
@@ -1,0 +1,89 @@
+{
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-1769",
+    "STATE": "PUBLIC",
+    "TITLE": "Buffer Over-read in vim/vim"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "vim/vim",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "8.2"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "vim"
+        }
+      ]
+    }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Buffer Over-read in GitHub repository vim/vim prior to 8.2."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "HIGH",
+      "baseScore": 6.6,
+      "baseSeverity": "MEDIUM",
+      "confidentialityImpact": "LOW",
+      "integrityImpact": "LOW",
+      "privilegesRequired": "LOW",
+      "scope": "UNCHANGED",
+      "userInteraction": "NONE",
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-126 Buffer Over-read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/522076b2-96cb-4df6-a504-e6e2f64c171c",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/522076b2-96cb-4df6-a504-e6e2f64c171c"
+      },
+      {
+        "name": "https://github.com/vim/vim/commit/4748c4bd64610cf943a431d215bb1aad51f8d0b4",
+        "refsource": "MISC",
+        "url": "https://github.com/vim/vim/commit/4748c4bd64610cf943a431d215bb1aad51f8d0b4"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "522076b2-96cb-4df6-a504-e6e2f64c171c",
+    "discovery": "EXTERNAL"
+  }
+}


### PR DESCRIPTION
Add CVE-2022-1769 for [522076b2-96cb-4df6-a504-e6e2f64c171c](https://huntr.dev/bounties/522076b2-96cb-4df6-a504-e6e2f64c171c) @huntr-helper