### PR TITLE
Add CVE-2022-1735 for c9f85608-ff11-48e4-933d-53d1759d44d9

### DIFF
--- a/2022/1xxx/CVE-2022-1735.json
+++ b/2022/1xxx/CVE-2022-1735.json
@@ -1,18 +1,89 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-1735",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-1735",
+    "STATE": "PUBLIC",
+    "TITLE": " Classic Buffer Overflow in vim/vim"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "vim/vim",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "8.2"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "vim"
+        }
+      ]
     }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": " Classic Buffer Overflow in GitHub repository vim/vim prior to 8.2."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "HIGH",
+      "baseScore": 6.6,
+      "baseSeverity": "MEDIUM",
+      "confidentialityImpact": "LOW",
+      "integrityImpact": "LOW",
+      "privilegesRequired": "LOW",
+      "scope": "UNCHANGED",
+      "userInteraction": "NONE",
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-120 Buffer Copy without Checking Size of Input"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/c9f85608-ff11-48e4-933d-53d1759d44d9",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/c9f85608-ff11-48e4-933d-53d1759d44d9"
+      },
+      {
+        "name": "https://github.com/vim/vim/commit/7ce5b2b590256ce53d6af28c1d203fb3bc1d2d97",
+        "refsource": "MISC",
+        "url": "https://github.com/vim/vim/commit/7ce5b2b590256ce53d6af28c1d203fb3bc1d2d97"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "c9f85608-ff11-48e4-933d-53d1759d44d9",
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
Add CVE-2022-1735 for [c9f85608-ff11-48e4-933d-53d1759d44d9](https://huntr.dev/bounties/c9f85608-ff11-48e4-933d-53d1759d44d9) @huntr-helper