### PR TITLE
Add CVE-2022-1795 for 9c312763-41a6-4fc7-827b-269eb86efcbc

### DIFF
--- a/2022/1xxx/CVE-2022-1795.json
+++ b/2022/1xxx/CVE-2022-1795.json
@@ -1,0 +1,89 @@
+{
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-1795",
+    "STATE": "PUBLIC",
+    "TITLE": "Use After Free in gpac/gpac"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "gpac/gpac",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "v2.1.0-DEV"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "gpac"
+        }
+      ]
+    }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Use After Free in GitHub repository gpac/gpac prior to v2.1.0-DEV."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "HIGH",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "HIGH",
+      "baseScore": 7.3,
+      "baseSeverity": "HIGH",
+      "confidentialityImpact": "LOW",
+      "integrityImpact": "LOW",
+      "privilegesRequired": "NONE",
+      "scope": "CHANGED",
+      "userInteraction": "NONE",
+      "vectorString": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:C/C:L/I:L/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-416 Use After Free"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/9c312763-41a6-4fc7-827b-269eb86efcbc",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/9c312763-41a6-4fc7-827b-269eb86efcbc"
+      },
+      {
+        "name": "https://github.com/gpac/gpac/commit/c535bad50d5812d27ee5b22b54371bddec411514",
+        "refsource": "MISC",
+        "url": "https://github.com/gpac/gpac/commit/c535bad50d5812d27ee5b22b54371bddec411514"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "9c312763-41a6-4fc7-827b-269eb86efcbc",
+    "discovery": "EXTERNAL"
+  }
+}


### PR DESCRIPTION
Add CVE-2022-1795 for [9c312763-41a6-4fc7-827b-269eb86efcbc](https://huntr.dev/bounties/9c312763-41a6-4fc7-827b-269eb86efcbc) @huntr-helper