### PR TITLE
[ISC] document BIND9 CVE-2022-1183

### DIFF
--- a/2022/1xxx/CVE-2022-1183.json
+++ b/2022/1xxx/CVE-2022-1183.json
@@ -3,16 +3,110 @@
     "data_format": "MITRE",
     "data_version": "4.0",
     "CVE_data_meta": {
+        "DATE_PUBLIC": "2022-05-18T13:36:59.000Z",
         "ID": "CVE-2022-1183",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security-officer@isc.org",
+        "STATE": "PUBLIC",
+        "TITLE": "Destroying a TLS session early causes assertion failure"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "BIND9",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_name": "Open Source Branch 9.18",
+                                            "version_value": "9.18.0 through versions before 9.18.3"
+                                        },
+                                        {
+                                            "version_name": "Development Branch 9.19",
+                                            "version_value": "9.19.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ISC"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "ISC would like to thank Thomas Amgarten from arcade solutions ag for bringing this vulnerability to our attention."
+        }
+    ],
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "On vulnerable configurations, the named daemon may, in some circumstances, terminate with an assertion failure. Vulnerable configurations are those that include a reference to http within the listen-on statements in their named.conf. TLS is used by both DNS over TLS (DoT) and DNS over HTTPS (DoH), but configurations using DoT alone are unaffected. Affects BIND 9.18.0 -> 9.18.2 and version 9.19.0 of the BIND 9.19 development branch."
             }
         ]
-    }
+    },
+    "exploit": [
+        {
+            "lang": "eng",
+            "value": "We are not aware of any active exploits."
+        }
+    ],
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "In BIND 9.18.0 -> 9.18.2 and version 9.19.0 of the BIND 9.19 development branch, an assertion failure can be triggered if a TLS connection to a configured http TLS listener with a defined endpoint is destroyed too early."
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://kb.isc.org/docs/cve-2022-1183",
+                "refsource": "CONFIRM",
+                "url": "https://kb.isc.org/docs/cve-2022-1183"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Upgrade to the patched release most closely related to your current version of BIND: BIND 9.18.3 or BIND 9.19.1."
+        }
+    ],
+    "source": {
+        "discovery": "EXTERNAL"
+    },
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "No workarounds known."
+        }
+    ]
 }


### PR DESCRIPTION
One BIND 9 vulnerability was publicly disclosed yesterday:

https://lists.isc.org/pipermail/bind-announce/2022-May/001219.html