### PR TITLE
Correct typo in CVE-2022-29192 for GHSA-h2wq-prv9-2f56

### DIFF
--- a/2022/29xxx/CVE-2022-29192.json
+++ b/2022/29xxx/CVE-2022-29192.json
@@ -44,7 +44,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "TensorFlow is an open source platform for machine learning. Prior to versions 2.9.0, 2.8.1, 2.7.2, and 2.6.4,\nThe implementation of `tf.raw_ops.QuantizeAndDequantizeV4Grad` does not fully validate the input arguments. This results in a `CHECK`-failure which can be used to trigger a denial of service attack. Versions 2.9.0, 2.8.1, 2.7.2, and 2.6.4 contain a patch for this issue."
+                "value": "TensorFlow is an open source platform for machine learning. Prior to versions 2.9.0, 2.8.1, 2.7.2, and 2.6.4, the implementation of `tf.raw_ops.QuantizeAndDequantizeV4Grad` does not fully validate the input arguments. This results in a `CHECK`-failure which can be used to trigger a denial of service attack. Versions 2.9.0, 2.8.1, 2.7.2, and 2.6.4 contain a patch for this issue."
             }
         ]
     },


### PR DESCRIPTION
Correct typo in CVE-2022-29192 for GHSA-h2wq-prv9-2f56