### PR TITLE
Add CVE-2022-29219 for GHSA-cvj7-5f3c-9vg9

### DIFF
--- a/2022/29xxx/CVE-2022-29219.json
+++ b/2022/29xxx/CVE-2022-29219.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-29219",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Integer Overflow in Lodestar"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "lodestar",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.36.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "ChainSafe"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Lodestar is a TypeScript implementation of the Ethereum Consensus specification. Prior to version 0.36.0, there is a possible consensus split given maliciously-crafted `AttesterSlashing` or `ProposerSlashing` being included on-chain. Because the developers represent `uint64` values as native javascript `number`s, there is an issue when those variables with large (greater than 2^53) `uint64` values are included on chain. In those cases, Lodestar may view valid_`AttesterSlashing` or `ProposerSlashing` as invalid, due to rounding errors in large `number` values. This causes a consensus split, where Lodestar nodes are forked away from the main network. Similarly, Lodestar may consider invalid `ProposerSlashing` as valid, thus including in proposed blocks that will be considered invalid by the network. Version 0.36.0 contains a fix for this issue. As a workaround, use `BigInt` to represent `Slot` and `Epoch` values in `AttesterSlashing` and `ProposerSlashing` objects. `BigInt` is too slow to be used in all `Slot` and `Epoch` cases, so one may carefully use `BigInt` just where necessary for consensus."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-190: Integer Overflow or Wraparound"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/ChainSafe/lodestar/security/advisories/GHSA-cvj7-5f3c-9vg9",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/ChainSafe/lodestar/security/advisories/GHSA-cvj7-5f3c-9vg9"
+            },
+            {
+                "name": "https://github.com/ChainSafe/lodestar/pull/3977",
+                "refsource": "MISC",
+                "url": "https://github.com/ChainSafe/lodestar/pull/3977"
+            },
+            {
+                "name": "https://github.com/ChainSafe/lodestar/releases/tag/v0.36.0",
+                "refsource": "MISC",
+                "url": "https://github.com/ChainSafe/lodestar/releases/tag/v0.36.0"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-cvj7-5f3c-9vg9",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-29219 for GHSA-cvj7-5f3c-9vg9