### PR TITLE
Add CVE-2022-29242 for GHSA-2rmw-8wpg-vgw5

### DIFF
--- a/2022/29xxx/CVE-2022-29242.json
+++ b/2022/29xxx/CVE-2022-29242.json
@@ -1,18 +1,103 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-29242",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Buffer Overflow on creating key transport blob in GOST Engine"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "engine",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 3.0.1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "gost-engine"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "GOST engine is a reference implementation of the Russian GOST crypto algorithms for OpenSSL. TLS clients using GOST engine when ciphersuite `TLS_GOSTR341112_256_WITH_KUZNYECHIK_CTR_OMAC` is agreed and the server uses 512 bit GOST secret keys are vulnerable to buffer overflow. GOST engine version 3.0.1 contains a patch for this issue. Disabling ciphersuite `TLS_GOSTR341112_256_WITH_KUZNYECHIK_CTR_OMAC` is a possible workaround."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.9,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-120: Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/gost-engine/engine/security/advisories/GHSA-2rmw-8wpg-vgw5",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/gost-engine/engine/security/advisories/GHSA-2rmw-8wpg-vgw5"
+            },
+            {
+                "name": "https://github.com/gost-engine/engine/commit/7df766124f87768b43b9e8947c5a01e17545772c",
+                "refsource": "MISC",
+                "url": "https://github.com/gost-engine/engine/commit/7df766124f87768b43b9e8947c5a01e17545772c"
+            },
+            {
+                "name": "https://github.com/gost-engine/engine/commit/b2b4d629f100eaee9f5942a106b1ccefe85b8808",
+                "refsource": "MISC",
+                "url": "https://github.com/gost-engine/engine/commit/b2b4d629f100eaee9f5942a106b1ccefe85b8808"
+            },
+            {
+                "name": "https://github.com/gost-engine/engine/commit/c6655a0b620a3e31f085cc906f8073fe81b2fad3",
+                "refsource": "MISC",
+                "url": "https://github.com/gost-engine/engine/commit/c6655a0b620a3e31f085cc906f8073fe81b2fad3"
+            },
+            {
+                "name": "https://github.com/gost-engine/engine/releases/tag/v3.0.1",
+                "refsource": "MISC",
+                "url": "https://github.com/gost-engine/engine/releases/tag/v3.0.1"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-2rmw-8wpg-vgw5",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-29242 for GHSA-2rmw-8wpg-vgw5