### PR TITLE
Add CVE-2022-1927 for 945107ef-0b27-41c7-a03c-db99def0e777

### DIFF
--- a/2022/1xxx/CVE-2022-1927.json
+++ b/2022/1xxx/CVE-2022-1927.json
@@ -1,0 +1,89 @@
+{
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-1927",
+    "STATE": "PUBLIC",
+    "TITLE": "Buffer Over-read in vim/vim"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "vim/vim",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "8.2"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "vim"
+        }
+      ]
+    }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Buffer Over-read in GitHub repository vim/vim prior to 8.2."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "HIGH",
+      "baseScore": 7.8,
+      "baseSeverity": "HIGH",
+      "confidentialityImpact": "HIGH",
+      "integrityImpact": "HIGH",
+      "privilegesRequired": "NONE",
+      "scope": "UNCHANGED",
+      "userInteraction": "REQUIRED",
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-126 Buffer Over-read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/945107ef-0b27-41c7-a03c-db99def0e777",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/945107ef-0b27-41c7-a03c-db99def0e777"
+      },
+      {
+        "name": "https://github.com/vim/vim/commit/4d97a565ae8be0d4debba04ebd2ac3e75a0c8010",
+        "refsource": "MISC",
+        "url": "https://github.com/vim/vim/commit/4d97a565ae8be0d4debba04ebd2ac3e75a0c8010"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "945107ef-0b27-41c7-a03c-db99def0e777",
+    "discovery": "EXTERNAL"
+  }
+}


### PR DESCRIPTION
Add CVE-2022-1927 for [945107ef-0b27-41c7-a03c-db99def0e777](https://huntr.dev/bounties/945107ef-0b27-41c7-a03c-db99def0e777) @huntr-helper