### PR TITLE
Reject CVE-2016-1000027

### DIFF
--- a/2016/1000xxx/CVE-2016-1000027.json
+++ b/2016/1000xxx/CVE-2016-1000027.json
@@ -2,30 +2,7 @@
     "CVE_data_meta": {
         "ASSIGNER": "cve@mitre.org",
         "ID": "CVE-2016-1000027",
-        "STATE": "PUBLIC"
-    },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "n/a",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "n/a"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    },
-                    "vendor_name": "n/a"
-                }
-            ]
-        }
+        "STATE": "REJECT"
     },
     "data_format": "MITRE",
     "data_type": "CVE",
@@ -34,44 +11,12 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Pivotal Spring Framework through 5.3.16 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and authentication may be required. NOTE: the vendor's position is that untrusted data is not an intended use case. The product's behavior will not be changed because some users rely on deserialization of trusted data."
-            }
-        ]
-    },
-    "problemtype": {
-        "problemtype_data": [
-            {
-                "description": [
-                    {
-                        "lang": "eng",
-                        "value": "n/a"
-                    }
-                ]
+                "value": " ** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: None. Reason: This candidate is a duplicate of [CVE-2011-2894]. Notes: All CVE users should reference [CVE-2011-2894] instead of this candidate. All descriptions in this candidate have been removed to prevent accidental usage. References have been kept for historical purposes."
             }
         ]
     },
     "references": {
         "reference_data": [
-            {
-                "url": "https://www.tenable.com/security/research/tra-2016-20",
-                "refsource": "MISC",
-                "name": "https://www.tenable.com/security/research/tra-2016-20"
-            },
-            {
-                "refsource": "MISC",
-                "name": "https://raw.githubusercontent.com/distributedweaknessfiling/cvelist/master/2016/1000xxx/CVE-2016-1000027.json",
-                "url": "https://raw.githubusercontent.com/distributedweaknessfiling/cvelist/master/2016/1000xxx/CVE-2016-1000027.json"
-            },
-            {
-                "url": "https://security-tracker.debian.org/tracker/CVE-2016-1000027",
-                "refsource": "MISC",
-                "name": "https://security-tracker.debian.org/tracker/CVE-2016-1000027"
-            },
-            {
-                "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2016-1000027",
-                "refsource": "MISC",
-                "name": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2016-1000027"
-            },
             {
                 "refsource": "MISC",
                 "name": "https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-579669626",


### PR DESCRIPTION
As explained in spring-projects/spring-framework#24434, this CVE has
been reported through a now disbanded CNA and is invalid.

A similar issue has been reported with CVE-2011-2894, which got closed
with documentation updates. This is not a vulnerability in Spring
Framework, but rather a well-known security concern in all Java
applications.

This commit rejects this CVE as a duplicate of CVE-2011-2894 as a
result.
