### PR TITLE
Add CVE-2022-1987 for e8197737-7557-443e-a59f-2a86e8dda75f

### DIFF
--- a/2022/1xxx/CVE-2022-1987.json
+++ b/2022/1xxx/CVE-2022-1987.json
@@ -1,0 +1,89 @@
+{
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-1987",
+    "STATE": "PUBLIC",
+    "TITLE": "Buffer Over-read in bfabiszewski/libmobi"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "bfabiszewski/libmobi",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "0.11"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "bfabiszewski"
+        }
+      ]
+    }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Buffer Over-read in GitHub repository bfabiszewski/libmobi prior to 0.11."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "HIGH",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "NONE",
+      "baseScore": 2.5,
+      "baseSeverity": "LOW",
+      "confidentialityImpact": "LOW",
+      "integrityImpact": "NONE",
+      "privilegesRequired": "NONE",
+      "scope": "UNCHANGED",
+      "userInteraction": "REQUIRED",
+      "vectorString": "CVSS:3.0/AV:L/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-126 Buffer Over-read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/e8197737-7557-443e-a59f-2a86e8dda75f",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/e8197737-7557-443e-a59f-2a86e8dda75f"
+      },
+      {
+        "name": "https://github.com/bfabiszewski/libmobi/commit/612562bc1ea38f1708b044e7a079c47a05b1291d",
+        "refsource": "MISC",
+        "url": "https://github.com/bfabiszewski/libmobi/commit/612562bc1ea38f1708b044e7a079c47a05b1291d"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "e8197737-7557-443e-a59f-2a86e8dda75f",
+    "discovery": "EXTERNAL"
+  }
+}


### PR DESCRIPTION
Add CVE-2022-1987 for [e8197737-7557-443e-a59f-2a86e8dda75f](https://huntr.dev/bounties/e8197737-7557-443e-a59f-2a86e8dda75f) @huntr-helper