### PR TITLE
Add CVE-2022-31038 for GHSA-xq4v-vrp9-vcf2

### DIFF
--- a/2022/31xxx/CVE-2022-31038.json
+++ b/2022/31xxx/CVE-2022-31038.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-31038",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "XSS vulnerability in repository issue list in Gogs"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "gogs",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.12.9"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "gogs"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": " Gogs is an open source self-hosted Git service. In versions of gogs prior to 0.12.9 `DisplayName` does not filter characters input from users, which leads to an XSS vulnerability when directly displayed in the issue list. This issue has been resolved in commit 155cae1d which sanitizes `DisplayName` prior to display to the user. All users of gogs are advised to upgrade. Users unable to upgrade should check their users' display names for malicious characters."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/gogs/gogs/security/advisories/GHSA-xq4v-vrp9-vcf2",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/gogs/gogs/security/advisories/GHSA-xq4v-vrp9-vcf2"
+            },
+            {
+                "name": "https://github.com/gogs/gogs/pull/7009",
+                "refsource": "MISC",
+                "url": "https://github.com/gogs/gogs/pull/7009"
+            },
+            {
+                "name": "https://github.com/gogs/gogs/commit/155cae1de8916fc3fde78f350763034b7422caee",
+                "refsource": "MISC",
+                "url": "https://github.com/gogs/gogs/commit/155cae1de8916fc3fde78f350763034b7422caee"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-xq4v-vrp9-vcf2",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-31038 for GHSA-xq4v-vrp9-vcf2