### PR TITLE
XSA-401 CVE-2022-26362

### DIFF
--- a/2022/26xxx/CVE-2022-26362.json
+++ b/2022/26xxx/CVE-2022-26362.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-26362",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-26362"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-401"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All versions of Xen are vulnerable.\n\nOnly x86 PV guests can trigger this vulnerability.\n\nTo exploit the vulnerability, there needs to be an undue delay at just\nthe wrong moment in _get_page_type().  The degree to which an x86 PV\nguest can practically control this race condition is unknown."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jann Horn of Google Project Zero."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "x86 pv: Race condition in typeref acquisition\n\nXen maintains a type reference count for pages, in addition to a regular\nreference count.  This scheme is used to maintain invariants required\nfor Xen's safety, e.g. PV guests may not have direct writeable access to\npagetables; updates need auditing by Xen.\n\nUnfortunately, the logic for acquiring a type reference has a race\ncondition, whereby a safely TLB flush is issued too early and creates a\nwindow where the guest can re-establish the read/write mapping before\nwriteability is prohibited."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Malicious x86 PV guest administrators may be able to escalate privilege\nso as to control the whole system."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-401.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not running x86 PV guests will avoid the vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-401 CVE-2022-26362

CVE data entry for:
  CVE-2022-26362

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
