### PR TITLE
Zephyr - Publish 2021-34xx CVEs

### DIFF
--- a/2021/3xxx/CVE-2021-3430.json
+++ b/2021/3xxx/CVE-2021-3430.json
@@ -4,15 +4,87 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2021-3430",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "vulnerabilities@zephyrproject.org",
+        "DATE_PUBLIC": "2021-06-21T00:00:00.000Z",
+        "STATE": "PUBLIC",
+        "TITLE": "BT: Assertion failure on repeated LL_CONNECTION_PARAM_REQ"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "zephyrproject-rtos",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "zephyr",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v1.14.0"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v2.5.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Assertion reachable with repeated LL_CONNECTION_PARAM_REQ. Zephyr versions >= v1.14 contain Reachable Assertion (CWE-617). For more information, see https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-46h3-hjcq-2jjr"
             }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "attackVector": "ADJACENT",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.5,
+            "environmentalScore": 6.5,
+            "temporalScore": 6.5,
+            "baseSeverity": "MODERATE"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Reachable Assertion (CWE-617)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "http://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-46h3-hjcq-2jjr"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-46h3-hjcq-2jjr"
         ]
     }
 }

--- a/2021/3xxx/CVE-2021-3431.json
+++ b/2021/3xxx/CVE-2021-3431.json
@@ -4,15 +4,83 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2021-3431",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "vulnerabilities@zephyrproject.org",
+        "DATE_PUBLIC": "2021-06-21T00:00:00.000Z",
+        "STATE": "PUBLIC",
+        "TITLE": "BT: Assertion failure on repeated LL_FEATURE_REQ"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "zephyrproject-rtos",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "zephyr",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v2.5.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Assertion reachable with repeated LL_FEATURE_REQ. Zephyr versions >= v2.5.0 contain Reachable Assertion (CWE-617). For more information, see https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-7548-5m6f-mqv9"
             }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "attackVector": "ADJACENT",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "LOW",
+            "baseScore": 4.3,
+            "environmentalScore": 4.3,
+            "temporalScore": 4.3,
+            "baseSeverity": "MODERATE"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Reachable Assertion (CWE-617)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "http://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-7548-5m6f-mqv9"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-7548-5m6f-mqv9"
         ]
     }
 }

--- a/2021/3xxx/CVE-2021-3432.json
+++ b/2021/3xxx/CVE-2021-3432.json
@@ -4,15 +4,87 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2021-3432",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "vulnerabilities@zephyrproject.org",
+        "DATE_PUBLIC": "2021-06-21T00:00:00.000Z",
+        "STATE": "PUBLIC",
+        "TITLE": "BT: Invalid interval in CONNECT_IND leads to Division by Zero"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "zephyrproject-rtos",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "zephyr",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v1.14.0"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v2.5.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Invalid interval in CONNECT_IND leads to Division by Zero. Zephyr versions >= v1.14.0 Divide By Zero (CWE-369). For more information, see https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-7364-p4wc-8mj4"
             }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "attackVector": "ADJACENT",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "LOW",
+            "baseScore": 4.3,
+            "environmentalScore": 4.3,
+            "temporalScore": 4.3,
+            "baseSeverity": "MODERATE"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Divide By Zero (CWE-369)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "http://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-7364-p4wc-8mj4"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-7364-p4wc-8mj4"
         ]
     }
 }

--- a/2021/3xxx/CVE-2021-3433.json
+++ b/2021/3xxx/CVE-2021-3433.json
@@ -4,15 +4,83 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2021-3433",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "vulnerabilities@zephyrproject.org",
+        "DATE_PUBLIC": "2021-06-21T00:00:00.000Z",
+        "STATE": "PUBLIC",
+        "TITLE": "BT: Invalid channel map in CONNECT_IND results to Deadlock"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "zephyrproject-rtos",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "zephyr",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v2.5.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Invalid channel map in CONNECT_IND results to Deadlock. Zephyr versions >= v2.5.0 Improper Check or Handling of Exceptional Conditions (CWE-703). For more information, see https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3c2f-w4v6-qxrp"
             }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "attackVector": "LOCAL",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "LOW",
+            "baseScore": 4.0,
+            "environmentalScore": 4.0,
+            "temporalScore": 4.0,
+            "baseSeverity": "MODERATE"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Improper Check or Handling of Exceptional Conditions (CWE-703)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "http://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3c2f-w4v6-qxrp"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3c2f-w4v6-qxrp"
         ]
     }
 }

--- a/2021/3xxx/CVE-2021-3434.json
+++ b/2021/3xxx/CVE-2021-3434.json
@@ -4,15 +4,87 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2021-3434",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "vulnerabilities@zephyrproject.org",
+        "DATE_PUBLIC": "2021-06-21T00:00:00.000Z",
+        "STATE": "PUBLIC",
+        "TITLE": "L2CAP: Stack based buffer overflow in le_ecred_conn_req()"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "zephyrproject-rtos",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "zephyr",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v2.5.0"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v2.6.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Stack based buffer overflow in le_ecred_conn_req(). Zephyr versions >= v2.5.0 Stack-based Buffer Overflow (CWE-121). For more information, see https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-8w87-6rfp-cfrm"
             }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
+            "attackVector": "LOCAL",
+            "attackComplexity": "HIGH",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "availabilityImpact": "LOW",
+            "baseScore": 4.9,
+            "environmentalScore": 4.9,
+            "temporalScore": 4.9,
+            "baseSeverity": "MODERATE"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Stack-based Buffer Overflow (CWE-121)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "http://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-8w87-6rfp-cfrm"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-8w87-6rfp-cfrm"
         ]
     }
 }

--- a/2021/3xxx/CVE-2021-3435.json
+++ b/2021/3xxx/CVE-2021-3435.json
@@ -4,15 +4,87 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2021-3435",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "vulnerabilities@zephyrproject.org",
+        "DATE_PUBLIC": "2021-06-21T00:00:00.000Z",
+        "STATE": "PUBLIC",
+        "TITLE": "L2CAP: Information leakage in le_ecred_conn_req()"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "zephyrproject-rtos",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "zephyr",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v2.4.0"
+                                        },
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "v2.5.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Information leakage in le_ecred_conn_req(). Zephyr versions >= v2.4.0 Use of Uninitialized Resource (CWE-908). For more information, see https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-xhg3-gvj6-4rqh"
             }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            "attackVector": "LOCAL",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.0,
+            "environmentalScore": 4.0,
+            "temporalScore": 4.0,
+            "baseSeverity": "MODERATE"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Use of Uninitialized Resource (CWE-908)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "http://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-xhg3-gvj6-4rqh"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-xhg3-gvj6-4rqh"
         ]
     }
 }


### PR DESCRIPTION
`CVE-2021-3430`
`CVE-2021-3431`
`CVE-2021-3432`
`CVE-2021-3433`
`CVE-2021-3434`
`CVE-2021-3435`
