### PR TITLE
Add CVE-2022-31110 for GHSA-jvxx-v45p-v5vf

### DIFF
--- a/2022/31xxx/CVE-2022-31110.json
+++ b/2022/31xxx/CVE-2022-31110.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-31110",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Denial of Service (DoS) vulnerability in RSSHub"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "RSSHub",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "commits prior to 5c4177441417b44a6e45c3c63e9eac2504abeb5b"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "DIYgod"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "RSSHub is an open source, extensible RSS feed generator. In commits prior to 5c4177441417 passing some special values to the `filter` and `filterout` parameters can cause an abnormally high CPU. This results in an impact on the performance of the servers and RSSHub services which may lead to a denial of service. This issue has been fixed in commit 5c4177441417 and all users are advised to upgrade. There are no known workarounds for this issue."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-400: Uncontrolled Resource Consumption"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/DIYgod/RSSHub/security/advisories/GHSA-jvxx-v45p-v5vf",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/DIYgod/RSSHub/security/advisories/GHSA-jvxx-v45p-v5vf"
+            },
+            {
+                "name": "https://github.com/DIYgod/RSSHub/issues/10045",
+                "refsource": "MISC",
+                "url": "https://github.com/DIYgod/RSSHub/issues/10045"
+            },
+            {
+                "name": "https://github.com/DIYgod/RSSHub/commit/5c4177441417b44a6e45c3c63e9eac2504abeb5b",
+                "refsource": "MISC",
+                "url": "https://github.com/DIYgod/RSSHub/commit/5c4177441417b44a6e45c3c63e9eac2504abeb5b"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-jvxx-v45p-v5vf",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-31110 for GHSA-jvxx-v45p-v5vf