### PR TITLE
Add CVE-2022-2279 for 68c249e2-779d-4871-b7e3-851f03aca2de

### DIFF
--- a/2022/2xxx/CVE-2022-2279.json
+++ b/2022/2xxx/CVE-2022-2279.json
@@ -1,0 +1,89 @@
+{
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-2279",
+    "STATE": "PUBLIC",
+    "TITLE": "NULL Pointer Dereference in bfabiszewski/libmobi"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "bfabiszewski/libmobi",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "0.11"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "bfabiszewski"
+        }
+      ]
+    }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "NULL Pointer Dereference in GitHub repository bfabiszewski/libmobi prior to 0.11."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "HIGH",
+      "baseScore": 6.6,
+      "baseSeverity": "MEDIUM",
+      "confidentialityImpact": "LOW",
+      "integrityImpact": "LOW",
+      "privilegesRequired": "LOW",
+      "scope": "UNCHANGED",
+      "userInteraction": "NONE",
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-476 NULL Pointer Dereference"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/68c249e2-779d-4871-b7e3-851f03aca2de",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/68c249e2-779d-4871-b7e3-851f03aca2de"
+      },
+      {
+        "name": "https://github.com/bfabiszewski/libmobi/commit/c0699c8693c47f14a2e57dec7292e862ac7adf9c",
+        "refsource": "MISC",
+        "url": "https://github.com/bfabiszewski/libmobi/commit/c0699c8693c47f14a2e57dec7292e862ac7adf9c"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "68c249e2-779d-4871-b7e3-851f03aca2de",
+    "discovery": "EXTERNAL"
+  }
+}


### PR DESCRIPTION
Add CVE-2022-2279 for [68c249e2-779d-4871-b7e3-851f03aca2de](https://huntr.dev/bounties/68c249e2-779d-4871-b7e3-851f03aca2de) @huntr-helper