### PR TITLE
XSA-406 CVE-2022-33744

### DIFF
--- a/2022/33xxx/CVE-2022-33744.json
+++ b/2022/33xxx/CVE-2022-33744.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-33744",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-33744"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Linux",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-406"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Linux"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Only Arm systems (32-bit and 64-bit) are vulnerable. Dom0 Linux versions\n3.13 - 5.18 are vulnerable.\n\nX86 systems are not vulnerable."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Oleksandr Tyshchenko of EPAM."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Arm guests can cause Dom0 DoS via PV devices\n\nWhen mapping pages of guests on Arm, dom0 is using an rbtree to keep\ntrack of the foreign mappings.\n\nUpdating of that rbtree is not always done completely with the related\nlock held, resulting in a small race window, which can be used by\nunprivileged guests via PV devices to cause inconsistencies of the\nrbtree. These inconsistencies can lead to Denial of Service (DoS) of\ndom0, e.g. by causing crashes or the inability to perform further\nmappings of other guests' memory pages."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "A guest performing multiple I/Os of PV devices in parallel can cause\nDoS of dom0 and thus of the complete host."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-406.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "There is no mitigation available."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-406 CVE-2022-33744

CVE data entry for:
  CVE-2022-33744

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
