### PR TITLE
Mark CVE-2022-29926 as REJECT

### DIFF
--- a/2022/29xxx/CVE-2022-29926.json
+++ b/2022/29xxx/CVE-2022-29926.json
@@ -1,18 +1,18 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-29926",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
-    }
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "CVE_data_meta": {
+    "ID": "CVE-2022-29926",
+    "ASSIGNER": "vultures@jpert.or.jp",
+    "STATE": "REJECT"
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": " ** REJECT **  DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation in Cybozu, Inc. showed that it was not a vulnerability. Notes: https://jvn.jp/en/jp/JVN14077132/"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
At a vendor's request, JPCERT/CC marks CVE-2022-29926 as "REJECT".