### PR TITLE
Add CVE-2022-31138 for GHSA-vx9w-h33p-5vhc

### DIFF
--- a/2022/31xxx/CVE-2022-31138.json
+++ b/2022/31xxx/CVE-2022-31138.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-31138",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "OS Command Injection in mailcow"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "mailcow-dockerized",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 2022-06a"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "mailcow"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "mailcow is a mailserver suite. Prior to mailcow-dockerized version 2022-06a, an extended privilege vulnerability can be exploited by manipulating the custom parameters regexmess, skipmess, regexflag, delete2foldersonly, delete2foldersbutnot, regextrans2, pipemess, or maxlinelengthcmd to execute arbitrary code. Users should update their mailcow instances with the `update.sh` script in the mailcow root directory to 2022-06a or newer to receive a patch for this issue. As a temporary workaround, the Syncjob ACL can be removed from all mailbox users, preventing changes to those settings."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/mailcow/mailcow-dockerized/security/advisories/GHSA-vx9w-h33p-5vhc",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/mailcow/mailcow-dockerized/security/advisories/GHSA-vx9w-h33p-5vhc"
+            },
+            {
+                "name": "https://github.com/mailcow/mailcow-dockerized/commit/d373164e13a14e058f82c9f1918a5612f375a9f9",
+                "refsource": "MISC",
+                "url": "https://github.com/mailcow/mailcow-dockerized/commit/d373164e13a14e058f82c9f1918a5612f375a9f9"
+            },
+            {
+                "name": "https://github.com/ly1g3/Mailcow-CVE-2022-31138",
+                "refsource": "MISC",
+                "url": "https://github.com/ly1g3/Mailcow-CVE-2022-31138"
+            },
+            {
+                "name": "https://github.com/mailcow/mailcow-dockerized/releases/tag/2022-06a",
+                "refsource": "MISC",
+                "url": "https://github.com/mailcow/mailcow-dockerized/releases/tag/2022-06a"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-vx9w-h33p-5vhc",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-31138 for GHSA-vx9w-h33p-5vhc