### PR TITLE
Add CVE-2022-31139 for GHSA-cr6p-23cf-w9g9

### DIFF
--- a/2022/31xxx/CVE-2022-31139.json
+++ b/2022/31xxx/CVE-2022-31139.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-31139",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "No security checking for UnsafeAccess.getInstance() in UnsafeAccessor"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "UnsafeAccessor",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 1.4.0, < 1.7.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Karlatemp"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "UnsafeAccessor (UA) is a bridge to access jdk.internal.misc.Unsafe & sun.misc.Unsafe. Normally, if UA is loaded as a named module, the internal data of UA is protected by JVM and others can only access UA via UA's standard API. The main application can set up `SecurityCheck.AccessLimiter` for UA to limit access to UA. Starting with version 1.4.0 and prior to version 1.7.0, when `SecurityCheck.AccessLimiter` is set up, untrusted code can access UA without limitation, even when UA is loaded as a named module. This issue does not affect those for whom `SecurityCheck.AccessLimiter` is not set up. Version 1.7.0 contains a patch."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.9,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/Karlatemp/UnsafeAccessor/security/advisories/GHSA-cr6p-23cf-w9g9",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/Karlatemp/UnsafeAccessor/security/advisories/GHSA-cr6p-23cf-w9g9"
+            },
+            {
+                "name": "https://github.com/Karlatemp/UnsafeAccessor/commit/4ef83000184e8f13239a1ea2847ee401d81585fd",
+                "refsource": "MISC",
+                "url": "https://github.com/Karlatemp/UnsafeAccessor/commit/4ef83000184e8f13239a1ea2847ee401d81585fd"
+            },
+            {
+                "name": "https://github.com/Karlatemp/UnsafeAccessor/releases/tag/1.7.0",
+                "refsource": "MISC",
+                "url": "https://github.com/Karlatemp/UnsafeAccessor/releases/tag/1.7.0"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-cr6p-23cf-w9g9",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-31139 for GHSA-cr6p-23cf-w9g9