### PR TITLE
Add CVE-2022-2453 for c8c964de-046a-41b2-9ff5-e25cfdb36b5a

### DIFF
--- a/2022/2xxx/CVE-2022-2453.json
+++ b/2022/2xxx/CVE-2022-2453.json
@@ -1,0 +1,89 @@
+{
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-2453",
+    "STATE": "PUBLIC",
+    "TITLE": "Use After Free in gpac/gpac"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "gpac/gpac",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "2.1-DEV"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "gpac"
+        }
+      ]
+    }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Use After Free in GitHub repository gpac/gpac prior to 2.1-DEV."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "HIGH",
+      "baseScore": 7.8,
+      "baseSeverity": "HIGH",
+      "confidentialityImpact": "HIGH",
+      "integrityImpact": "HIGH",
+      "privilegesRequired": "NONE",
+      "scope": "UNCHANGED",
+      "userInteraction": "REQUIRED",
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-416 Use After Free"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/c8c964de-046a-41b2-9ff5-e25cfdb36b5a",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/c8c964de-046a-41b2-9ff5-e25cfdb36b5a"
+      },
+      {
+        "name": "https://github.com/gpac/gpac/commit/dc7de8d3d604426c7a6e628d90cb9fb88e7b4c2c",
+        "refsource": "MISC",
+        "url": "https://github.com/gpac/gpac/commit/dc7de8d3d604426c7a6e628d90cb9fb88e7b4c2c"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "c8c964de-046a-41b2-9ff5-e25cfdb36b5a",
+    "discovery": "EXTERNAL"
+  }
+}


### PR DESCRIPTION
Add CVE-2022-2453 for [c8c964de-046a-41b2-9ff5-e25cfdb36b5a](https://huntr.dev/bounties/c8c964de-046a-41b2-9ff5-e25cfdb36b5a) @huntr-helper