### PR TITLE
Add CVE-2022-31162 for GHSA-99j7-mhfh-w84p

### DIFF
--- a/2022/31xxx/CVE-2022-31162.json
+++ b/2022/31xxx/CVE-2022-31162.json
@@ -1,18 +1,96 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-31162",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Slack Morphism for Rust before 0.41.0 can accidentally leak Slack OAuth client information in application debug logs"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "slack-morphism-rust",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.41.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "abdolence"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Slack Morphism is an async client library for Rust. Prior to 0.41.0, it was possible for Slack OAuth client information to leak in application debug logs. Stricter and more secure debug formatting was introduced in v0.41.0 for OAuth secret types to reduce the possibility of printing sensitive information in application logs. As a workaround, do not print/output requests and responses for OAuth and client configurations in logs."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-1258: Exposure of Sensitive System Information Due to Uncleared Debug Information"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/abdolence/slack-morphism-rust/security/advisories/GHSA-99j7-mhfh-w84p",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/abdolence/slack-morphism-rust/security/advisories/GHSA-99j7-mhfh-w84p"
+            },
+            {
+                "name": "https://github.com/abdolence/slack-morphism-rust/releases/tag/v0.41.0",
+                "refsource": "MISC",
+                "url": "https://github.com/abdolence/slack-morphism-rust/releases/tag/v0.41.0"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-99j7-mhfh-w84p",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-31162 for GHSA-99j7-mhfh-w84p