### PR TITLE
Publish CVE-2022-1042 and CVE-2022-1041

### DIFF
--- a/2022/1xxx/CVE-2022-1041.json
+++ b/2022/1xxx/CVE-2022-1041.json
@@ -4,15 +4,80 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2022-1041",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "vulnerabilities@zephyrproject.org",
+        "DATE_PUBLIC": "2022-07-25T00:00:00.000Z",
+        "STATE": "PUBLIC",
+        "TITLE": "Out-of-bound write vulnerability in the Bluetooth mesh core stack can be triggered during provisioning"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "zephyrproject-rtos",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "zephyr",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "v3.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Zephyr bluetooth mesh core stack, an out-of-bound write vulnerability can be triggered during provisioning."
             }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:L",
+            "attackVector": "Adjacent",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "LOW",
+            "userInteraction": "NONE",
+            "scope": "CHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "LOW",
+            "availabilityImpact": "LOW",
+            "baseSeverity": "HIGH"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Out-of-bounds Write (CWE-787)"
+                    }
+                ]
+             }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "http://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-p449-9hv9-pj38"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-p449-9hv9-pj38"
         ]
     }
 }

--- a/2022/1xxx/CVE-2022-1042.json
+++ b/2022/1xxx/CVE-2022-1042.json
@@ -4,15 +4,80 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2022-1042",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "vulnerabilities@zephyrproject.org",
+        "DATE_PUBLIC": "2022-07-25T00:00:00.000Z",
+        "STATE": "PUBLIC",
+        "TITLE": "Out-of-bound write vulnerability in the Bluetooth mesh core stack can be triggered during provisioning"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "zephyrproject-rtos",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "zephyr",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_value": "v3.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "In Zephyr bluetooth mesh core stack, an out-of-bound write vulnerability can be triggered during provisioning."
             }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:L",
+            "attackVector": "Adjacent",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "LOW",
+            "userInteraction": "NONE",
+            "scope": "CHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "LOW",
+            "availabilityImpact": "LOW",
+            "baseSeverity": "HIGH"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Out-of-bounds Write (CWE-787)"
+                    }
+                ]
+             }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "http://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-j7v7-w73r-mm5x"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-j7v7-w73r-mm5x"
         ]
     }
 }


### PR DESCRIPTION
Publish CVEs for Zephyr.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>