### PR TITLE
Add CVE-2022-23733

### DIFF
--- a/2022/23xxx/CVE-2022-23733.json
+++ b/2022/23xxx/CVE-2022-23733.json
@@ -1,18 +1,91 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23733",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "product-cna@github.com",
+    "ID": "CVE-2022-23733",
+    "STATE": "PUBLIC",
+    "TITLE": "Stored XSS vulnerability in GitHub Enterprise Server leading to injection of arbitrary attributes"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "GitHub Enterprise Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.3",
+                      "version_value": "3.3.11"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.4",
+                      "version_value": "3.4.6"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.5",
+                      "version_value": "3.5.3"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "GitHub"
+        }
+      ]
     }
+  },
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "None"
+    }
+  ],
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "A stored XSS vulnerability was identified in GitHub Enterprise Server that allowed the injection of arbitrary attributes. This injection was blocked by Github's Content Security Policy (CSP). This vulnerability affected all versions of GitHub Enterprise Server prior to 3.6 and was fixed in versions 3.3.11, 3.4.6 and 3.5.3. This vulnerability was reported via the GitHub Bug Bounty program."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-79 Cross-site Scripting (XSS) - Stored"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.3/admin/release-notes#3.3.11"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.4/admin/release-notes#3.4.6"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.5/admin/release-notes#3.5.3"
+      }
+    ]
+  },
+  "source": {
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
This PR adds [CVE-2022-23733](https://www.cve.org/CVERecord?id=CVE-2022-23733) which was made public in a batch of updates to GitHub Enterprise Server release notes that were amended on 7/31/2022.