### PR TITLE
Add CVE-2021-32771 for GHSA-jqjf-v7v9-xp6w

### DIFF
--- a/2021/32xxx/CVE-2021-32771.json
+++ b/2021/32xxx/CVE-2021-32771.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2021-32771",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Buffer overflow in contiki-ng"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "contiki-ng",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 4.8"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "contiki-ng"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Contiki-NG is an open-source, cross-platform operating system for IoT devices. In affected versions it is possible to cause a buffer overflow when copying an IPv6 address prefix in the RPL-Classic implementation in Contiki-NG. In order to trigger the vulnerability, the Contiki-NG system must have joined an RPL DODAG. After that, an attacker can send a DAO packet with a Target option that contains a prefix length larger than 128 bits. The problem was fixed after the release of Contiki-NG 4.7. Users unable to upgrade may apply the patch in Contiki-NG PR #1615."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-120: Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/contiki-ng/contiki-ng/security/advisories/GHSA-jqjf-v7v9-xp6w",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/contiki-ng/contiki-ng/security/advisories/GHSA-jqjf-v7v9-xp6w"
+            },
+            {
+                "name": "https://github.com/contiki-ng/contiki-ng/pull/1615",
+                "refsource": "MISC",
+                "url": "https://github.com/contiki-ng/contiki-ng/pull/1615"
+            },
+            {
+                "name": "https://github.com/contiki-ng/contiki-ng/pull/1615/commits/587ae59956e00316fd44fd7072ac3a6a07b4b20f",
+                "refsource": "MISC",
+                "url": "https://github.com/contiki-ng/contiki-ng/pull/1615/commits/587ae59956e00316fd44fd7072ac3a6a07b4b20f"
+            },
+            {
+                "name": "https://github.com/contiki-ng/contiki-ng/releases/tag/release%2Fv4.8",
+                "refsource": "MISC",
+                "url": "https://github.com/contiki-ng/contiki-ng/releases/tag/release%2Fv4.8"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-jqjf-v7v9-xp6w",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2021-32771 for GHSA-jqjf-v7v9-xp6w