### PR TITLE
Add CVE-2022-35926 for GHSA-4hpq-4f53-w386

### DIFF
--- a/2022/35xxx/CVE-2022-35926.json
+++ b/2022/35xxx/CVE-2022-35926.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-35926",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Out-of-bounds read in IPv6 neighbor solicitation in Contiki-NG"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "contiki-ng",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 4.8"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "contiki-ng"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Contiki-NG is an open-source, cross-platform operating system for IoT devices. Because of insufficient validation of IPv6 neighbor discovery options in Contiki-NG, attackers can send neighbor solicitation packets that trigger an out-of-bounds read. The problem exists in the module os/net/ipv6/uip-nd6.c, where memory read operations from the main packet buffer, <code>uip_buf</code>, are not checked if they go out of bounds. In particular, this problem can occur when attempting to read the 2-byte option header and the Source Link-Layer Address Option (SLLAO). This attack requires ipv6 be enabled for the network. The problem has been patched in the develop branch of Contiki-NG. The upcoming 4.8 release of Contiki-NG will include the patch.Users unable to upgrade may apply the patch in Contiki-NG PR #1654.\n"
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.9,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-125: Out-of-bounds Read"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/contiki-ng/contiki-ng/security/advisories/GHSA-4hpq-4f53-w386",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/contiki-ng/contiki-ng/security/advisories/GHSA-4hpq-4f53-w386"
+            },
+            {
+                "name": "https://github.com/contiki-ng/contiki-ng/pull/1654",
+                "refsource": "MISC",
+                "url": "https://github.com/contiki-ng/contiki-ng/pull/1654"
+            },
+            {
+                "name": "https://github.com/contiki-ng/contiki-ng/pull/1654/commits/a4597001d50a04f4b9c78f323ba731e2f979802c",
+                "refsource": "MISC",
+                "url": "https://github.com/contiki-ng/contiki-ng/pull/1654/commits/a4597001d50a04f4b9c78f323ba731e2f979802c"
+            },
+            {
+                "name": "https://github.com/contiki-ng/contiki-ng/releases/tag/release%2Fv4.8",
+                "refsource": "MISC",
+                "url": "https://github.com/contiki-ng/contiki-ng/releases/tag/release%2Fv4.8"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-4hpq-4f53-w386",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-35926 for GHSA-4hpq-4f53-w386