### PR TITLE
Add CVE-2022-35927 for GHSA-9rm9-3phh-p4wm

### DIFF
--- a/2022/35xxx/CVE-2022-35927.json
+++ b/2022/35xxx/CVE-2022-35927.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-35927",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Unverified DIO prefix info lengths in RPL-Classic in Contiki-NG"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "contiki-ng",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 4.7"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "contiki-ng"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Contiki-NG is an open-source, cross-platform operating system for IoT devices. In the RPL-Classic routing protocol implementation in the Contiki-NG operating system, an incoming DODAG Information Option (DIO) control message can contain a prefix information option with a length parameter. The value of the length parameter is not validated, however, and it is possible to cause a buffer overflow when copying the prefix in the set_ip_from_prefix function. This vulnerability affects anyone running a Contiki-NG version prior to 4.7 that can receive RPL DIO messages from external parties. To obtain a patched version, users should upgrade to Contiki-NG 4.7 or later. There are no workarounds for this issue."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-120: Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/contiki-ng/contiki-ng/security/advisories/GHSA-9rm9-3phh-p4wm",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/contiki-ng/contiki-ng/security/advisories/GHSA-9rm9-3phh-p4wm"
+            },
+            {
+                "name": "https://github.com/contiki-ng/contiki-ng/pull/1589",
+                "refsource": "MISC",
+                "url": "https://github.com/contiki-ng/contiki-ng/pull/1589"
+            },
+            {
+                "name": "https://github.com/contiki-ng/contiki-ng/pull/1589/commits/4fffab0e632c4d01910fa957d1fd9ef321eb87d2",
+                "refsource": "MISC",
+                "url": "https://github.com/contiki-ng/contiki-ng/pull/1589/commits/4fffab0e632c4d01910fa957d1fd9ef321eb87d2"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-9rm9-3phh-p4wm",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-35927 for GHSA-9rm9-3phh-p4wm