### PR TITLE
Add CVE-2022-2849 for 389aeccd-deb9-49ae-9b6a-24c12d79b02e

### DIFF
--- a/2022/2xxx/CVE-2022-2849.json
+++ b/2022/2xxx/CVE-2022-2849.json
@@ -1,18 +1,89 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-2849",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-2849",
+    "STATE": "PUBLIC",
+    "TITLE": "Heap-based Buffer Overflow in vim/vim"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "vim/vim",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "9.0.0219"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "vim"
+        }
+      ]
     }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Heap-based Buffer Overflow in GitHub repository vim/vim prior to 9.0.0219."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "LOCAL",
+      "availabilityImpact": "HIGH",
+      "baseScore": 7.8,
+      "baseSeverity": "HIGH",
+      "confidentialityImpact": "HIGH",
+      "integrityImpact": "HIGH",
+      "privilegesRequired": "NONE",
+      "scope": "UNCHANGED",
+      "userInteraction": "REQUIRED",
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-122 Heap-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/389aeccd-deb9-49ae-9b6a-24c12d79b02e",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/389aeccd-deb9-49ae-9b6a-24c12d79b02e"
+      },
+      {
+        "name": "https://github.com/vim/vim/commit/f6d39c31d2177549a986d170e192d8351bd571e2",
+        "refsource": "MISC",
+        "url": "https://github.com/vim/vim/commit/f6d39c31d2177549a986d170e192d8351bd571e2"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "389aeccd-deb9-49ae-9b6a-24c12d79b02e",
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
Add CVE-2022-2849 for [389aeccd-deb9-49ae-9b6a-24c12d79b02e](https://huntr.dev/bounties/389aeccd-deb9-49ae-9b6a-24c12d79b02e) @huntr-helper