### PR TITLE
Add CVE-2022-2714 for 430aedac-c7d9-4acb-9bab-bcc0595d9e95

### DIFF
--- a/2022/2xxx/CVE-2022-2714.json
+++ b/2022/2xxx/CVE-2022-2714.json
@@ -1,18 +1,89 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-2714",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "security@huntr.dev",
+    "ID": "CVE-2022-2714",
+    "STATE": "PUBLIC",
+    "TITLE": "Improper Handling of Length Parameter Inconsistency in francoisjacquet/rosariosis"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "francoisjacquet/rosariosis",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_value": "10.0"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "francoisjacquet"
+        }
+      ]
     }
+  },
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Improper Handling of Length Parameter Inconsistency in GitHub repository francoisjacquet/rosariosis prior to 10.0."
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "attackComplexity": "LOW",
+      "attackVector": "NETWORK",
+      "availabilityImpact": "HIGH",
+      "baseScore": 8.1,
+      "baseSeverity": "HIGH",
+      "confidentialityImpact": "NONE",
+      "integrityImpact": "HIGH",
+      "privilegesRequired": "LOW",
+      "scope": "UNCHANGED",
+      "userInteraction": "NONE",
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H",
+      "version": "3.0"
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-130 Improper Handling of Length Parameter Inconsistency"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "name": "https://huntr.dev/bounties/430aedac-c7d9-4acb-9bab-bcc0595d9e95",
+        "refsource": "CONFIRM",
+        "url": "https://huntr.dev/bounties/430aedac-c7d9-4acb-9bab-bcc0595d9e95"
+      },
+      {
+        "name": "https://github.com/francoisjacquet/rosariosis/commit/4022954c3f41462bf6225c302a28b0429f6f4df3",
+        "refsource": "MISC",
+        "url": "https://github.com/francoisjacquet/rosariosis/commit/4022954c3f41462bf6225c302a28b0429f6f4df3"
+      }
+    ]
+  },
+  "source": {
+    "advisory": "430aedac-c7d9-4acb-9bab-bcc0595d9e95",
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
Add CVE-2022-2714 for [430aedac-c7d9-4acb-9bab-bcc0595d9e95](https://huntr.dev/bounties/430aedac-c7d9-4acb-9bab-bcc0595d9e95) @huntr-helper