### PR TITLE
Modify CVE-2022-36058 for GHSA-qf7j-25g9-r63f

### DIFF
--- a/2022/36xxx/CVE-2022-36058.json
+++ b/2022/36xxx/CVE-2022-36058.json
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Elrond go is the go implementation for the Elrond Network protocol. In versions prior to 1.3.44, anyone who uses elrond-go to process blocks (historical or actual) could encounter a `MultiESDTNFTTransfer` transaction like this: `MultiESDTNFTTransfer` with a missing function name. Basic functionality like p2p messaging, storage, API requests and such are unaffected. Version 1.3.34 contains a fix for this issue. There are no known workarounds."
+                "value": "Elrond go is the go implementation for the Elrond Network protocol. In versions prior to 1.3.34, anyone who uses elrond-go to process blocks (historical or actual) could encounter a `MultiESDTNFTTransfer` transaction like this: `MultiESDTNFTTransfer` with a missing function name. Basic functionality like p2p messaging, storage, API requests and such are unaffected. Version 1.3.34 contains a fix for this issue. There are no known workarounds."
             }
         ]
     },


### PR DESCRIPTION
Corrected typo. 1.3.44 -> 1.3.34