### PR TITLE
Add CVE-2022-36095 for GHSA-fxwr-4vq9-9vhj

### DIFF
--- a/2022/36xxx/CVE-2022-36095.json
+++ b/2022/36xxx/CVE-2022-36095.json
@@ -1,18 +1,96 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-36095",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "XWiki Cross-Site Request Forgery (CSRF) for actions on tags"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "xwiki-platform",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 2.0-milestone-1, < 13.10.5"
+                                        },
+                                        {
+                                            "version_value": ">= 14.0, < 14.3"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "xwiki"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "XWiki Platform is a generic wiki platform. Prior to versions 13.10.5 and 14.3, it is possible to perform a Cross-Site Request Forgery (CSRF) attack for adding or removing tags on XWiki pages. The problem has been patched in XWiki 13.10.5 and 14.3. As a workaround, one may locally modify the `documentTags.vm` template in one's filesystem, to apply the changes exposed there."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-352: Cross-Site Request Forgery (CSRF)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/xwiki/xwiki-platform/security/advisories/GHSA-fxwr-4vq9-9vhj",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/xwiki/xwiki-platform/security/advisories/GHSA-fxwr-4vq9-9vhj"
+            },
+            {
+                "name": "https://github.com/xwiki/xwiki-platform/commit/7ca56e40cf79a468cea54d3480b6b403f259f9ae",
+                "refsource": "MISC",
+                "url": "https://github.com/xwiki/xwiki-platform/commit/7ca56e40cf79a468cea54d3480b6b403f259f9ae"
+            },
+            {
+                "name": "https://jira.xwiki.org/browse/XWIKI-19550",
+                "refsource": "MISC",
+                "url": "https://jira.xwiki.org/browse/XWIKI-19550"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-fxwr-4vq9-9vhj",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-36095 for GHSA-fxwr-4vq9-9vhj