### PR TITLE
Add CVE-2022-36109 for GHSA-rc4r-wh2q-q6c4

### DIFF
--- a/2022/36xxx/CVE-2022-36109.json
+++ b/2022/36xxx/CVE-2022-36109.json
@@ -1,18 +1,93 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-36109",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Moby vulnerability relating to supplementary group permissions"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "moby",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 20.10.18"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "moby"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Moby is an open-source project created by Docker to enable software containerization. A bug was found in Moby (Docker Engine) where supplementary groups are not set up properly. If an attacker has direct access to a container and manipulates their supplementary group access, they may be able to use supplementary group access to bypass primary group restrictions in some cases, potentially gaining access to sensitive information or gaining the ability to execute code in that container.  This bug is fixed in Moby (Docker Engine) 20.10.18. Running containers should be stopped and restarted for the permissions to be fixed. For users unable to upgrade, this problem can be worked around by not using the `\"USER $USERNAME\"` Dockerfile instruction. Instead by calling `ENTRYPOINT [\"su\", \"-\", \"user\"]` the supplementary groups will be set up properly."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 6.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-863: Incorrect Authorization"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/moby/moby/security/advisories/GHSA-rc4r-wh2q-q6c4",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/moby/moby/security/advisories/GHSA-rc4r-wh2q-q6c4"
+            },
+            {
+                "name": "https://github.com/moby/moby/commit/de7af816e76a7fd3fbf06bffa6832959289fba32",
+                "refsource": "MISC",
+                "url": "https://github.com/moby/moby/commit/de7af816e76a7fd3fbf06bffa6832959289fba32"
+            },
+            {
+                "name": "https://github.com/moby/moby/releases/tag/v20.10.18",
+                "refsource": "MISC",
+                "url": "https://github.com/moby/moby/releases/tag/v20.10.18"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-rc4r-wh2q-q6c4",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-36109 for GHSA-rc4r-wh2q-q6c4