### PR TITLE
Add CVE-2022-39215 for GHSA-28m8-9j7v-x499

### DIFF
--- a/2022/39xxx/CVE-2022-39215.json
+++ b/2022/39xxx/CVE-2022-39215.json
@@ -1,18 +1,98 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-39215",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "The readDir Endpoint Scope can be Bypassed With Symbolic Links in Tauri"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "tauri",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.0.6"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "tauri-apps"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Tauri is a framework for building binaries for all major desktop platforms. Due to missing canonicalization when `readDir` is called recursively, it was possible to display directory listings outside of the defined `fs` scope. This required a crafted symbolic link or junction folder inside an allowed path of the `fs` scope. No arbitrary file content could be leaked. The issue has been resolved in version 1.0.6 and the implementation now properly checks if the requested (sub) directory is a symbolic link outside of the defined `scope`. Users are advised to upgrade. Users unable to upgrade should disable the `readDir` endpoint in the `allowlist` inside the `tauri.conf.json`."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 8.3,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/tauri-apps/tauri/security/advisories/GHSA-28m8-9j7v-x499",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/tauri-apps/tauri/security/advisories/GHSA-28m8-9j7v-x499"
+            },
+            {
+                "name": "https://github.com/tauri-apps/tauri/issues/4882",
+                "refsource": "MISC",
+                "url": "https://github.com/tauri-apps/tauri/issues/4882"
+            },
+            {
+                "name": "https://github.com/tauri-apps/tauri/pull/5123",
+                "refsource": "MISC",
+                "url": "https://github.com/tauri-apps/tauri/pull/5123"
+            },
+            {
+                "name": "https://github.com/tauri-apps/tauri/pull/5123/commits/1f9b9e8d26a2c915390323e161020bcb36d44678",
+                "refsource": "MISC",
+                "url": "https://github.com/tauri-apps/tauri/pull/5123/commits/1f9b9e8d26a2c915390323e161020bcb36d44678"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-28m8-9j7v-x499",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-39215 for GHSA-28m8-9j7v-x499