### PR TITLE
Modify CVE-2022-36113 for GHSA-rfj2-q3h3-hm5j

### DIFF
--- a/2022/36xxx/CVE-2022-36113.json
+++ b/2022/36xxx/CVE-2022-36113.json
@@ -44,14 +44,14 @@
             "attackComplexity": "HIGH",
             "attackVector": "NETWORK",
             "availabilityImpact": "LOW",
-            "baseScore": 4.6,
-            "baseSeverity": "MEDIUM",
+            "baseScore": 3.9,
+            "baseSeverity": "LOW",
             "confidentialityImpact": "LOW",
             "integrityImpact": "LOW",
-            "privilegesRequired": "LOW",
+            "privilegesRequired": "HIGH",
             "scope": "UNCHANGED",
             "userInteraction": "REQUIRED",
-            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:L/I:L/A:L",
             "version": "3.1"
         }
     },


### PR DESCRIPTION
Change CVSS to CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:L/I:L/A:L and severity to low by changing `PR:L` to `PR:H`