### PR TITLE
Modify CVE-2022-36114 for GHSA-2hvr-h6gw-qrxp

### DIFF
--- a/2022/36xxx/CVE-2022-36114.json
+++ b/2022/36xxx/CVE-2022-36114.json
@@ -44,14 +44,14 @@
             "attackComplexity": "HIGH",
             "attackVector": "NETWORK",
             "availabilityImpact": "HIGH",
-            "baseScore": 4.8,
+            "baseScore": 4.2,
             "baseSeverity": "MEDIUM",
             "confidentialityImpact": "NONE",
             "integrityImpact": "NONE",
-            "privilegesRequired": "LOW",
+            "privilegesRequired": "HIGH",
             "scope": "UNCHANGED",
             "userInteraction": "REQUIRED",
-            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:H",
             "version": "3.1"
         }
     },


### PR DESCRIPTION
Change `CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H` to `CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:H`