### PR TITLE
Modify CVE-2022-39249 for GHSA-6263-x97c-c4gg

### DIFF
--- a/2022/39xxx/CVE-2022-39249.json
+++ b/2022/39xxx/CVE-2022-39249.json
@@ -41,17 +41,17 @@
     },
     "impact": {
         "cvss": {
-            "attackComplexity": "HIGH",
+            "attackComplexity": "LOW",
             "attackVector": "NETWORK",
             "availabilityImpact": "NONE",
-            "baseScore": 5.9,
-            "baseSeverity": "MEDIUM",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
             "confidentialityImpact": "NONE",
             "integrityImpact": "HIGH",
             "privilegesRequired": "NONE",
             "scope": "UNCHANGED",
             "userInteraction": "NONE",
-            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
             "version": "3.1"
         }
     },
@@ -78,16 +78,6 @@
     "references": {
         "reference_data": [
             {
-                "name": "https://github.com/matrix-org/matrix-js-sdk/commit/a587d7c36026fe1fcf93dfff63588abee359be76",
-                "refsource": "MISC",
-                "url": "https://github.com/matrix-org/matrix-js-sdk/commit/a587d7c36026fe1fcf93dfff63588abee359be76"
-            },
-            {
-                "name": "https://github.com/matrix-org/matrix-js-sdk/releases/tag/v19.7.0",
-                "refsource": "MISC",
-                "url": "https://github.com/matrix-org/matrix-js-sdk/releases/tag/v19.7.0"
-            },
-            {
                 "name": "https://github.com/matrix-org/matrix-js-sdk/security/advisories/GHSA-6263-x97c-c4gg",
                 "refsource": "CONFIRM",
                 "url": "https://github.com/matrix-org/matrix-js-sdk/security/advisories/GHSA-6263-x97c-c4gg"
@@ -96,6 +86,16 @@
                 "name": "https://github.com/matrix-org/matrix-spec-proposals/pull/3061",
                 "refsource": "MISC",
                 "url": "https://github.com/matrix-org/matrix-spec-proposals/pull/3061"
+            },
+            {
+                "name": "https://github.com/matrix-org/matrix-js-sdk/commit/a587d7c36026fe1fcf93dfff63588abee359be76",
+                "refsource": "MISC",
+                "url": "https://github.com/matrix-org/matrix-js-sdk/commit/a587d7c36026fe1fcf93dfff63588abee359be76"
+            },
+            {
+                "name": "https://github.com/matrix-org/matrix-js-sdk/releases/tag/v19.7.0",
+                "refsource": "MISC",
+                "url": "https://github.com/matrix-org/matrix-js-sdk/releases/tag/v19.7.0"
             },
             {
                 "name": "https://matrix.org/blog/2022/09/28/upgrade-now-to-address-encryption-vulns-in-matrix-sdks-and-clients",


### PR DESCRIPTION
Changed attack complexity from high to low