### PR TITLE
Add CVE-2022-39252 for GHSA-vp68-2wrm-69qm

### DIFF
--- a/2022/39xxx/CVE-2022-39252.json
+++ b/2022/39xxx/CVE-2022-39252.json
@@ -1,18 +1,106 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-39252",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "When matrix-rust-sdk recieves forwarded room keys, the reciever doesn't check if it requested the key from the forwarder"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "matrix-rust-sdk",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 0.6"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "matrix-org"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "matrix-rust-sdk is an implementation of a Matrix client-server library in Rust, and matrix-sdk-crypto is the Matrix encryption library. Prior to version 0.6, when a user requests a room key from their devices, the software correctly remembers the request. When the user receives a forwarded room key, the software accepts it without checking who the room key came from. This allows homeservers to try to insert room keys of questionable validity, potentially mounting an impersonation attack. Version 0.6 fixes this issue."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 8.6,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-322: Key Exchange without Entity Authentication"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-287: Improper Authentication"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-vp68-2wrm-69qm",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-vp68-2wrm-69qm"
+            },
+            {
+                "name": "https://github.com/matrix-org/matrix-rust-sdk/commit/093fb5d0aa21c0b5eaea6ec96b477f1075271cbb",
+                "refsource": "MISC",
+                "url": "https://github.com/matrix-org/matrix-rust-sdk/commit/093fb5d0aa21c0b5eaea6ec96b477f1075271cbb"
+            },
+            {
+                "name": "https://github.com/matrix-org/matrix-rust-sdk/commit/41449d2cc360e347f5d4e1c154ec1e3185f11acd",
+                "refsource": "MISC",
+                "url": "https://github.com/matrix-org/matrix-rust-sdk/commit/41449d2cc360e347f5d4e1c154ec1e3185f11acd"
+            },
+            {
+                "name": "https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-0.6.0",
+                "refsource": "MISC",
+                "url": "https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-0.6.0"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-vp68-2wrm-69qm",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-39252 for GHSA-vp68-2wrm-69qm