### PR TITLE
Add CVE-2022-39278 for GHSA-86vr-4wcv-mm9w

### DIFF
--- a/2022/39xxx/CVE-2022-39278.json
+++ b/2022/39xxx/CVE-2022-39278.json
@@ -1,18 +1,104 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-39278",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Istio vulnerable to denial of service attack due to Golang Regex Library"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "istio",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 1.13.9"
+                                        },
+                                        {
+                                            "version_value": ">= 1.14.0, < 1.14.5"
+                                        },
+                                        {
+                                            "version_value": ">= 1.15.0, < 1.15.2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "istio"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Istio is an open platform-independent service mesh that provides traffic management, policy enforcement, and telemetry collection. Prior to versions 1.15.2, 1.14.5, and 1.13.9, the Istio control plane, istiod, is vulnerable to a request processing error, allowing a malicious attacker that sends a specially crafted or oversized message which results in the control plane crashing when the Kubernetes validating or mutating webhook service is exposed publicly. This endpoint is served over TLS port 15017, but does not require any authentication from the attacker. For simple installations, Istiod is typically only reachable from within the cluster, limiting the blast radius. However, for some deployments, especially external istiod topologies, this port is exposed over the public internet. Versions 1.15.2, 1.14.5, and 1.13.9 contain patches for this issue. There are no effective workarounds, beyond upgrading. This bug is due to an error in `regexp.Compile` in Go."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-400: Uncontrolled Resource Consumption"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/istio/istio/security/advisories/GHSA-86vr-4wcv-mm9w",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/istio/istio/security/advisories/GHSA-86vr-4wcv-mm9w"
+            },
+            {
+                "name": "https://istio.io/latest/news/releases/1.13.x/announcing-1.13.9/",
+                "refsource": "MISC",
+                "url": "https://istio.io/latest/news/releases/1.13.x/announcing-1.13.9/"
+            },
+            {
+                "name": "https://istio.io/latest/news/releases/1.15.x/announcing-1.15.2/",
+                "refsource": "MISC",
+                "url": "https://istio.io/latest/news/releases/1.15.x/announcing-1.15.2/"
+            },
+            {
+                "name": "https://istio.io/news/releases/1.14.x/announcing-1.14.5/",
+                "refsource": "MISC",
+                "url": "https://istio.io/news/releases/1.14.x/announcing-1.14.5/"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-86vr-4wcv-mm9w",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-39278 for GHSA-86vr-4wcv-mm9w