### PR TITLE
Add CVE-2022-39315 for GHSA-c27j-76xg-6x4f

### DIFF
--- a/2022/39xxx/CVE-2022-39315.json
+++ b/2022/39xxx/CVE-2022-39315.json
@@ -1,18 +1,112 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-39315",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Kirby CMS vulnerable to user enumeration in the brute force protection"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "kirby",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 3.5.8.2"
+                                        },
+                                        {
+                                            "version_value": ">= 3.6.0, < 3.6.6.2"
+                                        },
+                                        {
+                                            "version_value": ">= 3.7.0, < 3.7.5.1"
+                                        },
+                                        {
+                                            "version_value": "= 3.8.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "getkirby"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Kirby is a Content Management System. Prior to versions 3.5.8.2, 3.6.6.2, 3.7.5.1, and 3.8.1, a user enumeration vulnerability affects all Kirby sites with user accounts unless Kirby's API and Panel are disabled in the config. It can only be exploited for targeted attacks because the attack does not scale to brute force. The problem has been patched in Kirby 3.5.8.2, Kirby 3.6.6.2, Kirby 3.7.5.1, and Kirby 3.8.1. In all of the mentioned releases, the maintainers have rewritten the affected code so that the delay is also inserted after the brute force limit is reached."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-204: Observable Response Discrepancy"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/getkirby/kirby/security/advisories/GHSA-c27j-76xg-6x4f",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/getkirby/kirby/security/advisories/GHSA-c27j-76xg-6x4f"
+            },
+            {
+                "name": "https://github.com/getkirby/kirby/releases/tag/3.5.8.2",
+                "refsource": "MISC",
+                "url": "https://github.com/getkirby/kirby/releases/tag/3.5.8.2"
+            },
+            {
+                "name": "https://github.com/getkirby/kirby/releases/tag/3.6.6.2",
+                "refsource": "MISC",
+                "url": "https://github.com/getkirby/kirby/releases/tag/3.6.6.2"
+            },
+            {
+                "name": "https://github.com/getkirby/kirby/releases/tag/3.7.5.1",
+                "refsource": "MISC",
+                "url": "https://github.com/getkirby/kirby/releases/tag/3.7.5.1"
+            },
+            {
+                "name": "https://github.com/getkirby/kirby/releases/tag/3.8.1",
+                "refsource": "MISC",
+                "url": "https://github.com/getkirby/kirby/releases/tag/3.8.1"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-c27j-76xg-6x4f",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-39315 for GHSA-c27j-76xg-6x4f