### PR TITLE
Reorder version ranges in some Jenkins CVEs towards JSON v5

### DIFF
--- a/2022/20xxx/CVE-2022-20613.json
+++ b/2022/20xxx/CVE-2022-20613.json
@@ -16,12 +16,12 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "391.ve4a_38c1b_cf4b_",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "1.34.2",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "391.ve4a_38c1b_cf4b_",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/20xxx/CVE-2022-20614.json
+++ b/2022/20xxx/CVE-2022-20614.json
@@ -16,12 +16,12 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "391.ve4a_38c1b_cf4b_",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "1.34.2",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "391.ve4a_38c1b_cf4b_",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/23xxx/CVE-2022-23106.json
+++ b/2022/23xxx/CVE-2022-23106.json
@@ -16,10 +16,6 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "1.55",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "1.47.1",
                                             "version_affected": "!"
                                         },
@@ -30,6 +26,10 @@
                                         {
                                             "version_value": "1.54.1",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1.55",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/25xxx/CVE-2022-25175.json
+++ b/2022/25xxx/CVE-2022-25175.json
@@ -16,10 +16,6 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "706.vd43c65dec013",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "2.26.1",
                                             "version_affected": "!"
                                         },
@@ -30,6 +26,10 @@
                                         {
                                             "version_value": "696.698.v9b4218eea50f",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "706.vd43c65dec013",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/25xxx/CVE-2022-25179.json
+++ b/2022/25xxx/CVE-2022-25179.json
@@ -16,10 +16,6 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "706.vd43c65dec013",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "2.26.1",
                                             "version_affected": "!"
                                         },
@@ -30,6 +26,10 @@
                                         {
                                             "version_value": "696.698.v9b4218eea50f",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "706.vd43c65dec013",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/29xxx/CVE-2022-29036.json
+++ b/2022/29xxx/CVE-2022-29036.json
@@ -16,10 +16,6 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "1111.v35a_307992395",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "2.6.1.1",
                                             "version_affected": "!"
                                         },
@@ -30,6 +26,10 @@
                                         {
                                             "version_value": "1087.1089.v2f1b_9a_b_040e4",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1111.v35a_307992395",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/29xxx/CVE-2022-29045.json
+++ b/2022/29xxx/CVE-2022-29045.json
@@ -16,12 +16,12 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "873.v6149db_d64130",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "3.10.1",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "873.v6149db_d64130",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/29xxx/CVE-2022-29049.json
+++ b/2022/29xxx/CVE-2022-29049.json
@@ -16,12 +16,12 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "873.v6149db_d64130",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "3.10.1",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "873.v6149db_d64130",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/34xxx/CVE-2022-34176.json
+++ b/2022/34xxx/CVE-2022-34176.json
@@ -16,12 +16,12 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "1119.va_a_5e9068da_d7",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "1.53.0.1",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1119.va_a_5e9068da_d7",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/34xxx/CVE-2022-34177.json
+++ b/2022/34xxx/CVE-2022-34177.json
@@ -16,16 +16,16 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "448.v37cea_9a_10a_70",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "447.449.v193fd29f6021",
                                             "version_affected": "!"
                                         },
                                         {
                                             "version_value": "2.12.2",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "448.v37cea_9a_10a_70",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/43xxx/CVE-2022-43401.json
+++ b/2022/43xxx/CVE-2022-43401.json
@@ -16,12 +16,12 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "1183.v774b_0b_0a_a_451",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "1175.1177.vda_175b_77d144",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1183.v774b_0b_0a_a_451",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/43xxx/CVE-2022-43402.json
+++ b/2022/43xxx/CVE-2022-43402.json
@@ -16,16 +16,16 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "2802.v5ea_628154b_c2",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "2759.2761.vd6e8d2a_15980",
                                             "version_affected": "!"
                                         },
                                         {
                                             "version_value": "2746.2748.v365128b_c26d7",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "2802.v5ea_628154b_c2",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/43xxx/CVE-2022-43403.json
+++ b/2022/43xxx/CVE-2022-43403.json
@@ -16,12 +16,12 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "1183.v774b_0b_0a_a_451",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "1175.1177.vda_175b_77d144",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1183.v774b_0b_0a_a_451",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/43xxx/CVE-2022-43404.json
+++ b/2022/43xxx/CVE-2022-43404.json
@@ -16,12 +16,12 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "1183.v774b_0b_0a_a_451",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "1175.1177.vda_175b_77d144",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "1183.v774b_0b_0a_a_451",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/43xxx/CVE-2022-43405.json
+++ b/2022/43xxx/CVE-2022-43405.json
@@ -16,12 +16,12 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "612.v84da_9c54906d",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "593.595.vfc6485d13dcd",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "612.v84da_9c54906d",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/43xxx/CVE-2022-43407.json
+++ b/2022/43xxx/CVE-2022-43407.json
@@ -16,12 +16,12 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "451.vf1a_a_4f405289",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "449.451.v9c3d42f23975",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "451.vf1a_a_4f405289",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }

--- a/2022/43xxx/CVE-2022-43408.json
+++ b/2022/43xxx/CVE-2022-43408.json
@@ -16,12 +16,12 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "2.26",
-                                            "version_affected": "<="
-                                        },
-                                        {
                                             "version_value": "2.24.2",
                                             "version_affected": "!"
+                                        },
+                                        {
+                                            "version_value": "2.26",
+                                            "version_affected": "<="
                                         }
                                     ]
                                 }


### PR DESCRIPTION
[CVE JSON v5](https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/docs/versions.md) has an unambiguous definition how to interpret version ranges, something previously missing (as discussed in https://github.com/github/advisory-database/issues/771).

(While JSON v5 states that

> The versions matched by different objects should be disjoint

it is not a requirement, and the algorithm
```
for entry in product.versions {
	if entry matches V {
		return status specified by entry for V
	}
}
return product.defaultStatus
```
provides an unambiguous result for overlapping version range specifications.)

This is an update of some affected Jenkins CVEs to see whether they'd be migrated to JSON v5 in a way that properly excludes the specified backports from the version ranges.

This does not address the problem of future releases on the backport branch, but I don't think that can be done with JSON v4 anyway. This also does not fix all 2020-2022 CVEs in Jenkins affected by this problem -- that's a followup PR if this one is successful.