### PR TITLE
XSA-412 CVE-2022-42327

### DIFF
--- a/2022/42xxx/CVE-2022-42327.json
+++ b/2022/42xxx/CVE-2022-42327.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-42327",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-42327"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-412"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Only Xen version 4.16 is vulnerable.  Other Xen versions are not vulnerable.\n\nx86 HVM or PVH guests running on Intel systems with the \"virtualize APIC\naccesses\" feature are affected.  This is believed to be all 64-bit\ncapable Intel CPUs.\n\nx86 HVM or PVH guests running on AMD hardware, Arm or x86 PV guests are\nnot affected."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Andrew Cooper of Citrix."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "x86: unintended memory sharing between guests\n\nOn Intel systems that support the \"virtualize APIC accesses\" feature, a\nguest can read and write the global shared xAPIC page by moving the\nlocal APIC out of xAPIC mode.\n\nAccess to this shared page bypasses the expected isolation that should\nexist between two guests."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Guests are able to access an unintended shared memory page.  Note the\ncontents of the page are not interpreted by Xen or hardware."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-412.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Only running PV guests will mitigate the vulnerability on affected\nhardware."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-412 CVE-2022-42327

CVE data entry for:
  CVE-2022-42327

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
