### PR TITLE
XSA-420 CVE-2022-42324

### DIFF
--- a/2022/42xxx/CVE-2022-42324.json
+++ b/2022/42xxx/CVE-2022-42324.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-42324",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-42324"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-420"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All versions of Xen are affected.\n\nSystems running a 32-bit build of oxenstored are affected.\n\nSystems running a 64-bit build of oxenstored, or systems running (C)\nxenstored are not affected."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jürgen Groß of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Oxenstored 32->31 bit integer truncation issues\n\nIntegers in Ocaml are 63 or 31 bits of signed precision.\n\nThe Ocaml Xenbus library takes a C uint32_t out of the ring and casts it\ndirectly to an Ocaml integer.  In 64-bit Ocaml builds this is fine, but\nin 32-bit builds, it truncates off the most significant bit, and then\ncreates unsigned/signed confusion in the remainder.\n\nThis in turn can feed a negative value into logic not expecting a\nnegative value, resulting in unexpected exceptions being thrown.\n\nThe unexpected exception is not handled suitably, creating a busy-loop\ntrying (and failing) to take the bad packet out of the xenstore ring."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "A malicious or buggy guest can write a packet into the xenstore ring\nwhich causes 32-bit builds of oxenstored to busy loop."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-420.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Running xenstored instead of oxenstored will avoid the vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-420 CVE-2022-42324

CVE data entry for:
  CVE-2022-42324

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
