### PR TITLE
Add CVE-2022-41887 for GHSA-8fvv-46hw-vpg3

### DIFF
--- a/2022/41xxx/CVE-2022-41887.json
+++ b/2022/41xxx/CVE-2022-41887.json
@@ -1,18 +1,104 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-41887",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Overflow in `tf.keras.losses.poisson` in Tensorflow"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "tensorflow",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": ">= 2.10.0, < 2.10.1"
+                                        },
+                                        {
+                                            "version_value": ">= 2.9.0, < 2.9.3"
+                                        },
+                                        {
+                                            "version_value": "< 2.8.4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "tensorflow"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "TensorFlow is an open source platform for machine learning. `tf.keras.losses.poisson` receives a `y_pred` and `y_true` that are passed through `functor::mul` in `BinaryOp`. If the resulting dimensions overflow an `int32`, TensorFlow will crash due to a size mismatch during broadcast assignment. We have patched the issue in GitHub commit c5b30379ba87cbe774b08ac50c1f6d36df4ebb7c. The fix will be included in TensorFlow 2.11. We will also cherrypick this commit on TensorFlow 2.10.1 and 2.9.3, as these are also affected and still in supported range. However, we will not cherrypick this commit into TensorFlow 2.8.x, as it depends on Eigen behavior that changed between 2.8 and 2.9."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 4.8,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-131: Incorrect Calculation of Buffer Size"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8fvv-46hw-vpg3",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8fvv-46hw-vpg3"
+            },
+            {
+                "name": "https://github.com/tensorflow/tensorflow/commit/c5b30379ba87cbe774b08ac50c1f6d36df4ebb7c",
+                "refsource": "MISC",
+                "url": "https://github.com/tensorflow/tensorflow/commit/c5b30379ba87cbe774b08ac50c1f6d36df4ebb7c"
+            },
+            {
+                "name": "https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/cwise_ops_common.h",
+                "refsource": "MISC",
+                "url": "https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/cwise_ops_common.h"
+            },
+            {
+                "name": "https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/losses.py",
+                "refsource": "MISC",
+                "url": "https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/losses.py"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-8fvv-46hw-vpg3",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-41887 for GHSA-8fvv-46hw-vpg3