### PR TITLE
Update affected version range - CVE-2022-41885

### DIFF
--- a/2022/41xxx/CVE-2022-41885.json
+++ b/2022/41xxx/CVE-2022-41885.json
@@ -16,13 +16,13 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": ">= 2.10.0, < 2.10.1"
+                                            "version_value": ">= 2.9.0, < 2.9.1"
                                         },
                                         {
-                                            "version_value": ">= 2.9.0, < 2.9.3"
+                                            "version_value": ">= 2.8.0, < 2.8.1"
                                         },
                                         {
-                                            "version_value": "< 2.8.4"
+                                            "version_value": "< 2.7.4"
                                         }
                                     ]
                                 }


### PR DESCRIPTION
Version range was entered incorrectly. This PR resolves the error.