### PR TITLE
Update affected version range - CVE-2022-41887

### DIFF
--- a/2022/41xxx/CVE-2022-41887.json
+++ b/2022/41xxx/CVE-2022-41887.json
@@ -19,10 +19,7 @@
                                             "version_value": ">= 2.10.0, < 2.10.1"
                                         },
                                         {
-                                            "version_value": ">= 2.9.0, < 2.9.3"
-                                        },
-                                        {
-                                            "version_value": "< 2.8.4"
+                                            "version_value": "< 2.9.3"
                                         }
                                     ]
                                 }


### PR DESCRIPTION
Version range was entered incorrectly. This PR resolves the error.