### PR TITLE
Add CVE-2022-23740

### DIFF
--- a/2022/23xxx/CVE-2022-23740.json
+++ b/2022/23xxx/CVE-2022-23740.json
@@ -1,18 +1,73 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23740",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "product-cna@github.com",
+    "ID": "CVE-2022-23740",
+    "STATE": "PUBLIC",
+    "TITLE": "Improper Neutralization of Argument Delimiters in a Command in GitHub Enterprise Server leading to Remote Code Execution"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "GitHub Enterprise Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.7",
+                      "version_value": "3.7.1"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "GitHub"
+        }
+      ]
     }
+  },
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "yvvdwf"
+    }
+  ],
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "CRITICAL: An improper neutralization of argument delimiters in a command vulnerability was identified in GitHub Enterprise Server that enabled remote code execution. To exploit this vulnerability, an attacker would need permission to create and build GitHub Pages using GitHub Actions. This vulnerability affected only version 3.7.0 of GitHub Enterprise Server and was fixed in version 3.7.1. This vulnerability was reported via the GitHub Bug Bounty program."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-88"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.7/admin/release-notes#3.7.1"
+      }
+    ]
+  },
+  "source": {
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
CVE for Critical security fix in GHES 3.7.1: An improper neutralization of argument delimiters in a command vulnerability was identified in GitHub Enterprise Server that enabled remote code execution. To exploit this vulnerability, an attacker would need permission to create and build GitHub Pages using GitHub Actions.