### PR TITLE
Add CVE-2022-41957 for GHSA-2r7v-cmch-5x26

### DIFF
--- a/2022/41xxx/CVE-2022-41957.json
+++ b/2022/41xxx/CVE-2022-41957.json
@@ -1,18 +1,96 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2022-41957",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "muhammara vulnerable to Unchecked Return Value to NULL Pointer Dereference"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "MuhammaraJS",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "< 2.6.2"
+                                        },
+                                        {
+                                            "version_value": ">= 3.0.0, < 3.4.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "julianhille"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Muhammara is a node module with c/cpp bindings to modify PDF with JavaScript for node or electron. The package muhammara before 2.6.2 and from 3.0.0 and before 3.3.0, as well as all versions of muhammara's predecessor package hummus, are vulnerable to Denial of Service (DoS) when supplied with a maliciously crafted PDF file to be parsed. The issue has been patched in muhammara version 3.4.0 and the fix has been backported to version 2.6.2. As a workaround, do not process files from untrusted sources. If using hummus, replace the package with muhammara."
             }
         ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-690: Unchecked Return Value to NULL Pointer Dereference"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/julianhille/MuhammaraJS/security/advisories/GHSA-2r7v-cmch-5x26",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/julianhille/MuhammaraJS/security/advisories/GHSA-2r7v-cmch-5x26"
+            },
+            {
+                "name": "https://github.com/julianhille/MuhammaraJS/pull/235",
+                "refsource": "MISC",
+                "url": "https://github.com/julianhille/MuhammaraJS/pull/235"
+            },
+            {
+                "name": "https://github.com/julianhille/MuhammaraJS/pull/238",
+                "refsource": "MISC",
+                "url": "https://github.com/julianhille/MuhammaraJS/pull/238"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-2r7v-cmch-5x26",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Add CVE-2022-41957 for GHSA-2r7v-cmch-5x26