### PR TITLE
Sophos CVEs for SFOS 19.5 GA

### DIFF
--- a/2022/3xxx/CVE-2022-3226.json
+++ b/2022/3xxx/CVE-2022-3226.json
@@ -4,14 +4,83 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2022-3226",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security-alert@sophos.com",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Sophos Firewall",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.5 GA"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.0 MR2"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "18.5 MR5"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Sophos"
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An OS command injection vulnerability allows admins to execute code via SSL VPN configuration uploads in Sophos Firewall older than version 19.5 GA."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.2,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0",
+                "refsource": "CONFIRM",
+                "url": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0"
             }
         ]
     }

--- a/2022/3xxx/CVE-2022-3696.json
+++ b/2022/3xxx/CVE-2022-3696.json
@@ -4,14 +4,79 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2022-3696",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security-alert@sophos.com",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Sophos Firewall",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.5 GA"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.0 MR2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Sophos"
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A post-auth code injection vulnerability allows admins to execute code in Webadmin of Sophos Firewall older than version 19.5 GA."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.2,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0",
+                "refsource": "CONFIRM",
+                "url": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0"
             }
         ]
     }

--- a/2022/3xxx/CVE-2022-3709.json
+++ b/2022/3xxx/CVE-2022-3709.json
@@ -4,14 +4,83 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2022-3709",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security-alert@sophos.com",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Sophos Firewall",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.5 GA"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.0 MR2"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "18.5 MR5"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Sophos"
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A stored XSS vulnerability allows admin to super-admin privilege escalation in the Webadmin import group wizard of Sophos Firewall older than version 19.5 GA."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.8,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0",
+                "refsource": "CONFIRM",
+                "url": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0"
             }
         ]
     }

--- a/2022/3xxx/CVE-2022-3710.json
+++ b/2022/3xxx/CVE-2022-3710.json
@@ -4,14 +4,79 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2022-3710",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security-alert@sophos.com",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Sophos Firewall",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.5 GA"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.0 MR2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Sophos"
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A post-auth read-only SQL injection vulnerability allows API clients to read non-sensitive configuration database contents in the API controller of Sophos Firewall older than version 19.5 GA."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 2.7,
+            "baseSeverity": "LOW",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0",
+                "refsource": "CONFIRM",
+                "url": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0"
             }
         ]
     }

--- a/2022/3xxx/CVE-2022-3711.json
+++ b/2022/3xxx/CVE-2022-3711.json
@@ -4,14 +4,79 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2022-3711",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security-alert@sophos.com",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Sophos Firewall",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.5 GA"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.0 MR2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Sophos"
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A post-auth read-only SQL injection vulnerability allows users to read non-sensitive configuration database contents in the User Portal of Sophos Firewall older than version 19.5 GA."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0",
+                "refsource": "CONFIRM",
+                "url": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0"
             }
         ]
     }

--- a/2022/3xxx/CVE-2022-3713.json
+++ b/2022/3xxx/CVE-2022-3713.json
@@ -4,14 +4,83 @@
     "data_version": "4.0",
     "CVE_data_meta": {
         "ID": "CVE-2022-3713",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "security-alert@sophos.com",
+        "STATE": "PUBLIC"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Sophos Firewall",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.5 GA"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "19.0 MR2"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_value": "18.5 MR5"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Sophos"
+                }
+            ]
+        }
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "A code injection vulnerability allows adjacent attackers to execute code in the Wifi controller of Sophos Firewall older than version 19.5 GA."
+            }
+        ]
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "ADJACENT",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0",
+                "refsource": "CONFIRM",
+                "url": "https://www.sophos.com/en-us/security-advisories/sophos-sa-20221201-sfos-19-5-0"
             }
         ]
     }


### PR DESCRIPTION
CVE-2022-3226, CVE-2022-3696, CVE-2022-3709, CVE-2022-3710, CVE-2022-3711, CVE-2022-3713