### PR TITLE
XSA-423 CVE-2022-3643

### DIFF
--- a/2022/3xxx/CVE-2022-3643.json
+++ b/2022/3xxx/CVE-2022-3643.json
@@ -1,18 +1,96 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-3643",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-3643"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "Linux",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-423"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Linux"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All systems using a Linux based network backend with kernel 3.19 and\nnewer are vulnerable. Systems using other network backends are not\nknown to be vulnerable.\n\nSystems using Cisco (enic driver) and Broadcom NetXtrem II BCM5780\n(bnx2x driver) NICs for guest network access are known to be vulnerable.\nSystems using other NICs for guest network access cannot be ruled out\nto be vulnerable."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Guests can trigger NIC interface reset/abort/crash via netback\n\nIt is possible for a guest to trigger a NIC interface reset/abort/crash in\na Linux based network backend by sending certain kinds of packets.\n\nIt appears to be an (unwritten?) assumption in the rest of the Linux network\nstack that packet protocol headers are all contained within the linear\nsection of the SKB and some NICs behave badly if this is not the case.\n\nThis has been reported to occur with Cisco (enic) and Broadcom NetXtrem II\nBCM5780 (bnx2x) though it may be an issue with other NICs/drivers as well.\n\nIn case the frontend is sending requests with split headers, netback will\nforward those violating above mentioned assumption to the networking core,\nresulting in said misbehavior."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "An unprivileged guest can cause network Denial of Service (DoS) of the\nhost by sending network packets to the backend causing the related\nphysical NIC to reset, abort, or crash.\n\nData corruption or privilege escalation seem unlikely but have not been\nruled out."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-423.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Using another PV network backend (e.g. the qemu based \"qnic\" backend)\nwill mitigate the problem.\n\nUsing a dedicated network driver domain per guest will mitigate the\nproblem."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-423 CVE-2022-3643

CVE data entry for:
  CVE-2022-3643

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
