### PR TITLE
Add CVE-2022-4261 for Nexpose

### DIFF
--- a/2022/4xxx/CVE-2022-4261.json
+++ b/2022/4xxx/CVE-2022-4261.json
@@ -1,18 +1,119 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-4261",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "defaultStatus": "unaffected",
+                    "product": "Nexpose",
+                    "vendor": "Rapid7",
+                    "versions": [
+                        {
+                            "lessThanOrEqual": "6.6.171",
+                            "status": "affected",
+                            "version": "0",
+                            "versionType": "semver"
+                        }
+                    ]
+                }
+            ],
+            "credits": [
+                {
+                    "lang": "en",
+                    "type": "finder",
+                    "user": "00000000-0000-4000-9000-000000000000",
+                    "value": "Emmett Kelly, Rapid7 Principal Software Engineer"
+                },
+                {
+                    "lang": "en",
+                    "type": "coordinator",
+                    "user": "00000000-0000-4000-9000-000000000000",
+                    "value": "Tod Beardsley, Rapid7 Director of Research"
+                }
+            ],
+            "datePublic": "2022-12-07T19:00:00.000Z",
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "supportingMedia": [
+                        {
+                            "base64": false,
+                            "type": "text/html",
+                            "value": "Rapid7 Nexpose versions prior to 6.6.172 failed to reliably validate the authenticity of update contents. This failure could allow an attacker to provide a malicious update and alter the functionality of Rapid7 Nexpose. The attacker would need some pre-existing mechanism to provide a malicious update, either through a social engineering effort, privileged access to replace downloaded updates in transit, or by performing an Attacker-in-the-Middle attack on the update service itself."
+                        }
+                    ],
+                    "value": "Rapid7 Nexpose versions prior to 6.6.172 failed to reliably validate the authenticity of update contents. This failure could allow an attacker to provide a malicious update and alter the functionality of Rapid7 Nexpose. The attacker would need some pre-existing mechanism to provide a malicious update, either through a social engineering effort, privileged access to replace downloaded updates in transit, or by performing an Attacker-in-the-Middle attack on the update service itself."
+                }
+            ],
+            "metrics": [
+                {
+                    "cvssV3_1": {
+                        "attackComplexity": "HIGH",
+                        "attackVector": "LOCAL",
+                        "availabilityImpact": "NONE",
+                        "baseScore": 4.4,
+                        "baseSeverity": "MEDIUM",
+                        "confidentialityImpact": "NONE",
+                        "integrityImpact": "HIGH",
+                        "privilegesRequired": "LOW",
+                        "scope": "UNCHANGED",
+                        "userInteraction": "REQUIRED",
+                        "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:N/I:H/A:N",
+                        "version": "3.1"
+                    },
+                    "format": "CVSS",
+                    "scenarios": [
+                        {
+                            "lang": "en",
+                            "value": "GENERAL"
+                        }
+                    ]
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "cweId": "CWE-494",
+                            "description": "CWE-494 Download of Code Without Integrity Check",
+                            "lang": "en",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "00000000-0000-4000-9000-000000000000"
+            },
+            "references": [
+                {
+                    "tags": [
+                        "release-notes"
+                    ],
+                    "url": "https://docs.rapid7.com/release-notes/nexpose/20221207/"
+                },
+                {
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://www.rapid7.com/blog/post/2022/12/7/cve-2022-4261-rapid7-nexpose-update-validation-issue-fixed"
+                }
+            ],
+            "source": {
+                "discovery": "INTERNAL"
+            },
+            "title": "Rapid7 Nexpose Update Validation Issue",
+            "x_generator": {
+                "engine": "Vulnogram 0.1.0-dev"
             }
-        ]
-    }
+        }
+    },
+    "cveMetadata": {
+        "assignerOrgId": "00000000-0000-4000-9000-000000000000",
+        "cveId": "CVE-2022-4261",
+        "requesterUserId": "00000000-0000-4000-9000-000000000000",
+        "serial": 1,
+        "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0"
 }

--- a/2022/4xxx/CVE-2022-4261.json
+++ b/2022/4xxx/CVE-2022-4261.json
@@ -1,119 +1,99 @@
 {
-    "containers": {
-        "cna": {
-            "affected": [
+    "CVE_data_meta": {
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2022-12-07T19:00:00.000Z",
+        "ID": "CVE-2022-4261",
+        "STATE": "PUBLIC",
+        "TITLE": "Rapid7 Nexpose Update Validation Issue"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
                 {
-                    "defaultStatus": "unaffected",
-                    "product": "Nexpose",
-                    "vendor": "Rapid7",
-                    "versions": [
-                        {
-                            "lessThanOrEqual": "6.6.171",
-                            "status": "affected",
-                            "version": "0",
-                            "versionType": "semver"
-                        }
-                    ]
-                }
-            ],
-            "credits": [
-                {
-                    "lang": "en",
-                    "type": "finder",
-                    "user": "00000000-0000-4000-9000-000000000000",
-                    "value": "Emmett Kelly, Rapid7 Principal Software Engineer"
-                },
-                {
-                    "lang": "en",
-                    "type": "coordinator",
-                    "user": "00000000-0000-4000-9000-000000000000",
-                    "value": "Tod Beardsley, Rapid7 Director of Research"
-                }
-            ],
-            "datePublic": "2022-12-07T19:00:00.000Z",
-            "descriptions": [
-                {
-                    "lang": "en",
-                    "supportingMedia": [
-                        {
-                            "base64": false,
-                            "type": "text/html",
-                            "value": "Rapid7 Nexpose versions prior to 6.6.172 failed to reliably validate the authenticity of update contents. This failure could allow an attacker to provide a malicious update and alter the functionality of Rapid7 Nexpose. The attacker would need some pre-existing mechanism to provide a malicious update, either through a social engineering effort, privileged access to replace downloaded updates in transit, or by performing an Attacker-in-the-Middle attack on the update service itself."
-                        }
-                    ],
-                    "value": "Rapid7 Nexpose versions prior to 6.6.172 failed to reliably validate the authenticity of update contents. This failure could allow an attacker to provide a malicious update and alter the functionality of Rapid7 Nexpose. The attacker would need some pre-existing mechanism to provide a malicious update, either through a social engineering effort, privileged access to replace downloaded updates in transit, or by performing an Attacker-in-the-Middle attack on the update service itself."
-                }
-            ],
-            "metrics": [
-                {
-                    "cvssV3_1": {
-                        "attackComplexity": "HIGH",
-                        "attackVector": "LOCAL",
-                        "availabilityImpact": "NONE",
-                        "baseScore": 4.4,
-                        "baseSeverity": "MEDIUM",
-                        "confidentialityImpact": "NONE",
-                        "integrityImpact": "HIGH",
-                        "privilegesRequired": "LOW",
-                        "scope": "UNCHANGED",
-                        "userInteraction": "REQUIRED",
-                        "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:N/I:H/A:N",
-                        "version": "3.1"
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Nexpose",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "6.6.171",
+                                            "version_value": "6.6.171"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
                     },
-                    "format": "CVSS",
-                    "scenarios": [
-                        {
-                            "lang": "en",
-                            "value": "GENERAL"
-                        }
-                    ]
+                    "vendor_name": "Rapid7"
                 }
-            ],
-            "problemTypes": [
-                {
-                    "descriptions": [
-                        {
-                            "cweId": "CWE-494",
-                            "description": "CWE-494 Download of Code Without Integrity Check",
-                            "lang": "en",
-                            "type": "CWE"
-                        }
-                    ]
-                }
-            ],
-            "providerMetadata": {
-                "orgId": "00000000-0000-4000-9000-000000000000"
-            },
-            "references": [
-                {
-                    "tags": [
-                        "release-notes"
-                    ],
-                    "url": "https://docs.rapid7.com/release-notes/nexpose/20221207/"
-                },
-                {
-                    "tags": [
-                        "vendor-advisory"
-                    ],
-                    "url": "https://www.rapid7.com/blog/post/2022/12/7/cve-2022-4261-rapid7-nexpose-update-validation-issue-fixed"
-                }
-            ],
-            "source": {
-                "discovery": "INTERNAL"
-            },
-            "title": "Rapid7 Nexpose Update Validation Issue",
-            "x_generator": {
-                "engine": "Vulnogram 0.1.0-dev"
-            }
+            ]
         }
     },
-    "cveMetadata": {
-        "assignerOrgId": "00000000-0000-4000-9000-000000000000",
-        "cveId": "CVE-2022-4261",
-        "requesterUserId": "00000000-0000-4000-9000-000000000000",
-        "serial": 1,
-        "state": "PUBLISHED"
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Emmett Kelly, Rapid7 Principal Software Engineer"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "Rapid7 Nexpose versions prior to 6.6.172 failed to reliably validate the authenticity of update contents. This failure could allow an attacker to provide a malicious update and alter the functionality of Rapid7 Nexpose. The attacker would need some pre-existing mechanism to provide a malicious update, either through a social engineering effort, privileged access to replace downloaded updates in transit, or by performing an Attacker-in-the-Middle attack on the update service itself."
+            }
+        ]
     },
-    "dataType": "CVE_RECORD",
-    "dataVersion": "5.0"
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.4,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-494 Download of Code Without Integrity Check"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://docs.rapid7.com/release-notes/nexpose/20221207/",
+                "refsource": "CONFIRM",
+                "url": "https://docs.rapid7.com/release-notes/nexpose/20221207/"
+            },
+            {
+                "name": "https://www.rapid7.com/blog/post/2022/12/7/cve-2022-4261-rapid7-nexpose-update-validation-issue-fixed",
+                "refsource": "CONFIRM",
+                "url": "https://www.rapid7.com/blog/post/2022/12/7/cve-2022-4261-rapid7-nexpose-update-validation-issue-fixed"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "INTERNAL"
+    }
 }


### PR DESCRIPTION
* Add CVE-2022-4261 for Nexpose
* Fix wordchoice, trailing newlines

Signed-off-by: Tod Beardsley <tod_beardsley@rapid7.com>

Note: This is one of the first JSON 5 version CVE's I've submitted, so please let me know if I borked something up. Notably, I'm not 100% sure what to do with all the zeroed-out UUIDs for credit and org ID and all, but I presume they get fixed properly on intake and publishing to cve.org.