### PR TITLE
update_CVE-2022-41881

### DIFF
--- a/2022/41xxx/CVE-2022-41881.json
+++ b/2022/41xxx/CVE-2022-41881.json
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Netty project is an event-driven asynchronous network application framework. In versions prior 4.1.8.5.Final, a StackOverflowError can be raised when parsing a malformed crafted message due to an infinite recursion. This issue is patched in version 4.1.85.Final. There is no workaround, except using a custom HaProxyMessageDecoder."
+                "value": "Netty project is an event-driven asynchronous network application framework. In versions prior 4.1.8.6.Final, a StackOverflowError can be raised when parsing a malformed crafted message due to an infinite recursion. This issue is patched in version 4.1.85.Final. There is no workaround, except using a custom HaProxyMessageDecoder."
             }
         ]
     },
@@ -40,7 +40,7 @@
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "< 4.1.85.Final",
+                                            "version_value": "< 4.1.86.Final",
                                             "version_affected": "="
                                         }
                                     ]

--- a/2022/41xxx/CVE-2022-41881.json
+++ b/2022/41xxx/CVE-2022-41881.json
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Netty project is an event-driven asynchronous network application framework. In versions prior 4.1.8.6.Final, a StackOverflowError can be raised when parsing a malformed crafted message due to an infinite recursion. This issue is patched in version 4.1.85.Final. There is no workaround, except using a custom HaProxyMessageDecoder."
+                "value": "Netty project is an event-driven asynchronous network application framework. In versions prior to 4.1.86.Final, a StackOverflowError can be raised when parsing a malformed crafted message due to an infinite recursion. This issue is patched in version 4.1.86.Final. There is no workaround, except using a custom HaProxyMessageDecoder."
             }
         ]
     },


### PR DESCRIPTION
Correct patch version and typos in CVE-2022-41881.