### PR TITLE
Update CVE-2022-40144.json

### DIFF
--- a/2022/40xxx/CVE-2022-40144.json
+++ b/2022/40xxx/CVE-2022-40144.json
@@ -34,7 +34,7 @@
 		"description_data" : [
 			{
 				"lang" : "eng",
-				"value" : "A vulnerability in Trend Micro Apex One and Trend Micro Apex One as a Service could allow an attacker to bypass the product’s login authentication by falsifying request parameters on affected installations."
+				"value" : "A vulnerability in Trend Micro Apex One and Trend Micro Apex One as a Service could allow an attacker to bypass the productâ€™s login authentication by falsifying request parameters on affected installations."
 			}
 		]
 	},


### PR DESCRIPTION
I found that the character encoding rule used by the CVE-2022-40144.json file is not standard utf-8. When I use a program to parse the json file, errors will occur, while other files will not. The encoding method should be the same according to the CVE ID JSON File Format, So I modified the exception code of the file to make it look better.