### PR TITLE
Juniper out of cycle JSA publication 2022-12.

### DIFF
--- a/2022/22xxx/CVE-2022-22184.json
+++ b/2022/22xxx/CVE-2022-22184.json
@@ -1,18 +1,138 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "sirt@juniper.net",
+        "DATE_PUBLIC": "2022-12-22T20:00:00.000Z",
         "ID": "CVE-2022-22184",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Junos OS and Junos OS Evolved: A BGP session will flap upon receipt of a specific, optional transitive attribute in version 22.3R1"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Junos OS",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "22.3",
+                                            "version_value": "22.3R1-S1"
+                                        },
+                                        {
+                                            "version_affected": "!<",
+                                            "version_value": "22.3R1"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "product_name": "Junos OS Evolved",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "22.3-EVO",
+                                            "version_value": "22.3R1-S1-EVO"
+                                        },
+                                        {
+                                            "version_affected": "!<",
+                                            "version_value": "22.3R1-EVO"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Juniper Networks"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An Improper Input Validation vulnerability in the Routing Protocol Daemon (rpd) of Juniper Networks Junos OS and Junos OS Evolved allows an unauthenticated network-based attacker to cause a Denial of Service (DoS).\n\nIf a BGP update message is received over an established BGP session, and that message contains a specific, optional transitive attribute, this session will be torn down with an update message error. This issue cannot propagate beyond an affected system as the processing error occurs as soon as the update is received. This issue is exploitable remotely as the respective attribute will propagate through unaffected systems and intermediate AS (if any).\nContinuous receipt of a BGP update containing this attribute will create a sustained Denial of Service (DoS) condition.\n\nSince this issue only affects 22.3R1, Juniper strongly encourages customers to move to 22.3R1-S1.  Juniper SIRT felt that the need to promptly warn customers about this issue affecting the 22.3R1 versions of Junos OS and Junos OS Evolved warranted an Out of Cycle JSA.\nThis issue affects:\nJuniper Networks Junos OS version 22.3R1.\nJuniper Networks Junos OS Evolved version 22.3R1-EVO.\n\nThis issue does not affect:\nJuniper Networks Junos OS versions prior to 22.3R1.\nJuniper Networks Junos OS Evolved versions prior to 22.3R1-EVO."
             }
         ]
-    }
+    },
+    "exploit": [
+        {
+            "lang": "eng",
+            "value": "Juniper SIRT is not aware of any malicious exploitation of this vulnerability."
+        }
+    ],
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-20 Improper Input Validation"
+                    }
+                ]
+            },
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "Denial of Service (DoS)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://kb.juniper.net/JSA70175",
+                "refsource": "CONFIRM",
+                "url": "https://kb.juniper.net/JSA70175"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "The following software releases have been updated to resolve this specific issue:\nJunos OS: 22.3R1-S1, 22.3R2, 22.4R1, and all subsequent releases;\nJunos OS Evolved: 22.3R1-S1-EVO, 22.3R2-EVO, 22.4R1-EVO, and all subsequent releases."
+        }
+    ],
+    "source": {
+        "advisory": "JSA70175",
+        "defect": [
+            "1698446"
+        ],
+        "discovery": "USER"
+    },
+    "work_around": [
+        {
+            "lang": "eng",
+            "value": "There are no known workarounds for this issue."
+        }
+    ]
 }


### PR DESCRIPTION
Juniper out of cycle JSA publication 2022-12. See https://advisory.juniper.net for more information.