### PR TITLE
add_CVE-2022-46258

### DIFF
--- a/2022/46xxx/CVE-2022-46258.json
+++ b/2022/46xxx/CVE-2022-46258.json
@@ -1,18 +1,100 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-46258",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "product-cna@github.com",
+    "ID": "CVE-2022-46258",
+    "STATE": "PUBLIC",
+    "TITLE": "Incorrect Authorization in GitHub Enterprise Server leads to Action Workflow modifications without Workflow Scope"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "GitHub Enterprise Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.3",
+                      "version_value": "3.3.16"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.4",
+                      "version_value": "3.4.11"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.5",
+                      "version_value": "3.5.8"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.6",
+                      "version_value": "3.6.4"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "GitHub"
+        }
+      ]
     }
+  },
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "Vaibhav Singh (@vaib25vicky)"
+    }
+  ],
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "An incorrect authorization vulnerability was identified in GitHub Enterprise Server that allowed a repository-scoped token with read/write access to modify Action Workflow files without a Workflow scope. The Create or Update file contents API should enforce workflow scope. This vulnerability affected all versions of GitHub Enterprise Server prior to version 3.7 and was fixed in versions 3.3.16, 3.4.11, 3.5.8, and 3.6.4. This vulnerability was reported via the GitHub Bug Bounty program."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-863"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.3/admin/release-notes#3.3.16"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.4/admin/release-notes#3.4.11"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.5/admin/release-notes#3.5.8"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.6/admin/release-notes#3.6.4"
+      }
+    ]
+  },
+  "source": {
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
This PR adds CVE-2022-46258, which will be linked to several GitHub Enterprise Server release note versions, shortly. 