### PR TITLE
Update CVE-2022-41915.json

### DIFF
--- a/2022/41xxx/CVE-2022-41915.json
+++ b/2022/41xxx/CVE-2022-41915.json
@@ -1,95 +1,108 @@
 {
-    "data_version": "4.0",
     "data_type": "CVE",
     "data_format": "MITRE",
+    "data_version": "4.0",
     "CVE_data_meta": {
-        "ID": "CVE-2022-41915",
-        "ASSIGNER": "security-advisories@github.com",
-        "STATE": "PUBLIC"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "Netty project is an event-driven asynchronous network application framework. In versions prior to 4.1.86.Final, when calling `DefaultHttpHeadesr.set` with an _iterator_ of values, header value validation was not performed, allowing malicious header values in the iterator to perform HTTP Response Splitting. This issue has been patched in version 4.1.86.Final. Integrators can work around the issue by changing the `DefaultHttpHeaders.set(CharSequence, Iterator<?>)` call, into a `remove()` call, and call `add()` in a loop over the iterator of values."
-            }
-        ]
-    },
-    "problemtype": {
-        "problemtype_data": [
-            {
-                "description": [
-                    {
-                        "lang": "eng",
-                        "value": "CWE-436: Interpretation Conflict",
-                        "cweId": "CWE-436"
-                    }
-                ]
-            },
-            {
-                "description": [
-                    {
-                        "lang": "eng",
-                        "value": "CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')",
-                        "cweId": "CWE-113"
-                    }
-                ]
-            }
-        ]
-    },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "netty",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "netty",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "< 4.1.86.Final",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "references": {
-        "reference_data": [
-            {
-                "url": "https://github.com/netty/netty/security/advisories/GHSA-hh82-3pmq-7frp",
-                "refsource": "MISC",
-                "name": "https://github.com/netty/netty/security/advisories/GHSA-hh82-3pmq-7frp"
-            }
-        ]
+      "ID": "CVE-2022-41915",
+      "ASSIGNER": "security-advisories@github.com",
+      "STATE": "PUBLIC"
     },
     "source": {
-        "advisory": "GHSA-hh82-3pmq-7frp",
-        "discovery": "UNKNOWN"
+      "advisory": "GHSA-hh82-3pmq-7frp",
+      "discovery": "UNKNOWN"
+    },
+    "affects": {
+      "vendor": {
+        "vendor_data": [
+          {
+            "vendor_name": "netty",
+            "product": {
+              "product_data": [
+                {
+                  "product_name": "netty",
+                  "version": {
+                    "version_data": [
+                      {
+                        "version_name": "4.1.86.Final",
+                        "version_affected": "<",
+                        "version_value": "4.1.86.Final",
+                        "platform": ""
+                      },
+                      {
+                        "version_name": "4.1.83.Final",
+                        "version_affected": ">=",
+                        "version_value": "4.1.83.Final",
+                        "platform": ""
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "problemtype": {
+      "problemtype_data": [
+        {
+          "description": [
+            {
+              "lang": "eng",
+              "value": "CWE-436: Interpretation Conflict",
+              "cweId": "CWE-436"
+            }
+          ]
+        },
+        {
+          "description": [
+            {
+              "lang": "eng",
+              "value": "CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')",
+              "cweId": "CWE-113"
+            }
+          ]
+        }
+      ]
+    },
+    "description": {
+      "description_data": [
+        {
+          "lang": "eng",
+          "value": "Netty project is an event-driven asynchronous network application framework. Starting in version 4.1.83.Final and prior to 4.1.86.Final, when calling `DefaultHttpHeadesr.set` with an _iterator_ of values, header value validation was not performed, allowing malicious header values in the iterator to perform HTTP Response Splitting. This issue has been patched in version 4.1.86.Final. Integrators can work around the issue by changing the `DefaultHttpHeaders.set(CharSequence, Iterator<?>)` call, into a `remove()` call, and call `add()` in a loop over the iterator of values."
+        }
+      ]
+    },
+    "references": {
+      "reference_data": [
+        {
+          "refsource": "CONFIRM",
+          "url": "https://github.com/netty/netty/security/advisories/GHSA-hh82-3pmq-7frp",
+          "name": "https://github.com/netty/netty/security/advisories/GHSA-hh82-3pmq-7frp"
+        },
+        {
+          "refsource": "MISC",
+          "url": "https://github.com/netty/netty/issues/13084",
+          "name": "https://github.com/netty/netty/issues/13084"
+        },
+        {
+          "refsource": "MISC",
+          "url": "https://github.com/netty/netty/pull/12760",
+          "name": "https://github.com/netty/netty/pull/12760"
+        },
+        {
+          "refsource": "MISC",
+          "url": "https://github.com/netty/netty/commit/fe18adff1c2b333acb135ab779a3b9ba3295a1c4",
+          "name": "https://github.com/netty/netty/commit/fe18adff1c2b333acb135ab779a3b9ba3295a1c4"
+        }
+      ]
     },
     "impact": {
-        "cvss": [
-            {
-                "attackComplexity": "LOW",
-                "attackVector": "NETWORK",
-                "availabilityImpact": "NONE",
-                "baseScore": 6.5,
-                "baseSeverity": "MEDIUM",
-                "confidentialityImpact": "LOW",
-                "integrityImpact": "LOW",
-                "privilegesRequired": "NONE",
-                "scope": "UNCHANGED",
-                "userInteraction": "NONE",
-                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
-                "version": "3.1"
-            }
-        ]
+      "cvss": {
+        "version": "3.1",
+        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+        "baseScore": 6.5,
+        "baseSeverity": "MEDIUM"
+      }
     }
-}
+  }


### PR DESCRIPTION
Change vulnerable version range and description, as well as including reference links to justify the changes.