### PR TITLE
CVE-2022-24750 - fix typos in description

### DIFF
--- a/2022/24xxx/CVE-2022-24750.json
+++ b/2022/24xxx/CVE-2022-24750.json
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "UltraVNC is a free and open source remote pc access software. A vulnerability has been found in versions prior to 1.3.8.0 in which the DSM plugin module, which allows a local authenticated user to achieve local privilege escalation (LPE) on a vulnerable system. The vulnerability has been fixed to allow loading of plugins from the installed directory. Affected users should upgrade their UltraVNC to 1.3.8.0. Users unable to upgrade should not install and run UltraVNC server as a service. It is advisable to create a scheduled task on a low privilege account to launch WinVNC.exe instead. There are no known workarounds if wincnc needs to be started as a service."
+                "value": "UltraVNC is a free and open source remote pc access software. A vulnerability has been found in versions prior to 1.3.8.0 in which the DSM plugin module, which allows a local authenticated user to achieve local privilege escalation (LPE) on a vulnerable system. The vulnerability has been fixed to allow loading of plugins from the installed directory. Affected users should upgrade their UltraVNC to 1.3.8.1. Users unable to upgrade should not install and run UltraVNC server as a service. It is advisable to create a scheduled task on a low privilege account to launch WinVNC.exe instead. There are no known workarounds if winvnc needs to be started as a service."
             }
         ]
     },


### PR DESCRIPTION
Fixing two typos in the description. The correct version information can be found on the [maintainer advisory](https://github.com/ultravnc/UltraVNC/security/advisories/GHSA-3mvp-cp5x-vj5g). The original reporter alerted us to the `wincnc` > `winvnc` typo so the change is in the CVE record is deliberate, though it's still present on the maintainer advisory.