### PR TITLE
Modify CVE-2022-23548 for GHSA-7rw2-f4x7-7pxf

### DIFF
--- a/2022/23xxx/CVE-2022-23548.json
+++ b/2022/23xxx/CVE-2022-23548.json
@@ -21,8 +21,8 @@
                 "description": [
                     {
                         "lang": "eng",
-                        "value": "CWE-400: Uncontrolled Resource Consumption",
-                        "cweId": "CWE-400"
+                        "value": "CWE-1333: Inefficient Regular Expression Complexity",
+                        "cweId": "CWE-1333"
                     }
                 ]
             }

--- a/2022/23xxx/CVE-2022-23548.json
+++ b/2022/23xxx/CVE-2022-23548.json
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Discourse is an option source discussion platform. Prior to version 2.8.14 on the `stable` branch and version 2.9.0.beta16 on the `beta` and `tests-passed` branches, parsing posts can be susceptible to XSS attacks. This issue is patched in versions 2.8.14 and 2.9.0.beta16. There are no known workarounds."
+                "value": "Discourse is an option source discussion platform. Prior to version 2.8.14 on the `stable` branch and version 2.9.0.beta16 on the `beta` and `tests-passed` branches, parsing posts can be susceptible to regular expression denial of service (ReDoS) attacks. This issue is patched in versions 2.8.14 and 2.9.0.beta16. There are no known workarounds."
             }
         ]
     },


### PR DESCRIPTION
Replace "XSS attacks" with ReDoS attacks to match the contents of the public-facing maintainer advisory