### PR TITLE
Update CVE-2022-35948 cvss score

### DIFF
--- a/2022/35xxx/CVE-2022-35948.json
+++ b/2022/35xxx/CVE-2022-35948.json
@@ -51,7 +51,7 @@
             "privilegesRequired": "LOW",
             "scope": "UNCHANGED",
             "userInteraction": "NONE",
-            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:H",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
             "version": "3.1"
         }
     },


### PR DESCRIPTION
This PR updates CVE-2022-35948 which was initially incorrectly scored.