### PR TITLE
XSA-425 CVE-2022-42330

### DIFF
--- a/2022/42xxx/CVE-2022-42330.json
+++ b/2022/42xxx/CVE-2022-42330.json
@@ -1,18 +1,96 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-42330",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-42330"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-425"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Only Xen version 4.17 is vulnerable. Systems running an older version\nof Xen are not vulnerable.\n\nAll Xen systems using C xenstored are vulnerable. Systems using the\nOCaml variant of xenstored are not vulnerable.\n\nSystems running only PV guests (x86 only) are not vulnerable, as long as\nthey are using a libxl based toolstack."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Guests can cause Xenstore crash via soft reset\n\nWhen a guest issues a \"Soft Reset\" (e.g. for performing a kexec) the\nlibxl based Xen toolstack will normally perform a XS_RELEASE Xenstore\noperation.\n\nDue to a bug in xenstored this can result in a crash of xenstored.\n\nAny other use of XS_RELEASE will have the same impact."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "A malicious guest could try to kexec until it hits the xenstored bug,\nresulting in the inability to perform any further domain administration\nlike starting new guests, or adding/removing resources to or from any\nexisting guest."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-425.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "The problem can be avoided by either:\n\n- - using the OCaml xenstored variant\n\n- - explicitly configuring guests to NOT perform the \"Soft Reset\" action\n  by adding:\n    on_soft_reset=\"reboot\"\n  or similar to the guest's configuration. This will break kexec in the\n  guest, though."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-425 CVE-2022-42330

CVE data entry for:
  CVE-2022-42330

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
