### PR TITLE
Fix 2022-12-07 and 2023-01-24 Jenkins CVEs

### DIFF
--- a/2022/46xxx/CVE-2022-46682.json
+++ b/2022/46xxx/CVE-2022-46682.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2022-46682",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Plot Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.1.11",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Plot Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2940",
                 "url": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2940",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2940"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2022/46xxx/CVE-2022-46683.json
+++ b/2022/46xxx/CVE-2022-46683.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2022-46683",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Google Login Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.4",
+                                            "version_affected": ">="
+                                        },
+                                        {
+                                            "version_value": "1.6",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Google Login Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "1.4",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2967",
                 "url": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2967",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2967"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2022/46xxx/CVE-2022-46684.json
+++ b/2022/46xxx/CVE-2022-46684.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2022-46684",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Checkmarx Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2022.3.3",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Checkmarx Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2869",
                 "url": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2869",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2869"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2022/46xxx/CVE-2022-46685.json
+++ b/2022/46xxx/CVE-2022-46685.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2022-46685",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Gitea Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.4.4",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Gitea Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2661",
                 "url": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2661",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2661"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2022/46xxx/CVE-2022-46686.json
+++ b/2022/46xxx/CVE-2022-46686.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2022-46686",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Custom Build Properties Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.79.vc095ccc85094",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Custom Build Properties Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2810",
                 "url": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2810",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2810"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2022/46xxx/CVE-2022-46687.json
+++ b/2022/46xxx/CVE-2022-46687.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2022-46687",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Spring Config Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.0.0",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Spring Config Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2814",
                 "url": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2814",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2814"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2022/46xxx/CVE-2022-46688.json
+++ b/2022/46xxx/CVE-2022-46688.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2022-46688",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Sonar Gerrit Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "377.v8f3808963dc5",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "377.v8f3808963dc5",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Sonar Gerrit Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-1002",
                 "url": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-1002",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-1002"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24422.json
+++ b/2023/24xxx/CVE-2023-24422.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24422",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Script Security Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1228.vd93135a_2fb_25",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1175.1180.v36a_3fb_2dec9c",
+                                            "version_affected": "!"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,44 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Script Security Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        },
-                                        {
-                                            "version_value": "1175.1180.v36a_3fb_2dec9c",
-                                            "version_affected": "!"
-                                        },
-                                        {
-                                            "version_value": "1176",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-3016",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-3016",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-3016"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24423.json
+++ b/2023/24xxx/CVE-2023-24423.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24423",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Gerrit Trigger Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.38.0",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Gerrit Trigger Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2137",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2137",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2137"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24424.json
+++ b/2023/24xxx/CVE-2023-24424.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24424",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins OpenId Connect Authentication Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.4",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins OpenId Connect Authentication Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2978",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2978",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2978"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24425.json
+++ b/2023/24xxx/CVE-2023-24425.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24425",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Kubernetes Credentials Provider Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.208.v128ee9800c04",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Kubernetes Credentials Provider Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-3022",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-3022",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-3022"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24426.json
+++ b/2023/24xxx/CVE-2023-24426.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24426",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Azure AD Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "303.va_91ef20ee49f",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Azure AD Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2980",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2980",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2980"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24427.json
+++ b/2023/24xxx/CVE-2023-24427.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24427",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Bitbucket OAuth Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "0.12",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Bitbucket OAuth Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2982",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2982",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2982"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24428.json
+++ b/2023/24xxx/CVE-2023-24428.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24428",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Bitbucket OAuth Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "0.12",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Bitbucket OAuth Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2981",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2981",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2981"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24429.json
+++ b/2023/24xxx/CVE-2023-24429.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24429",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Semantic Versioning Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.14",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Semantic Versioning Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2973%20(1)",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2973%20(1)",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2973%20(1)"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24430.json
+++ b/2023/24xxx/CVE-2023-24430.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24430",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Semantic Versioning Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.14",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Semantic Versioning Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2973%20(2)",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2973%20(2)",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2973%20(2)"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24431.json
+++ b/2023/24xxx/CVE-2023-24431.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24431",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Orka by MacStadium Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.31",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Orka by MacStadium Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2772%20(1)",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2772%20(1)",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2772%20(1)"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24432.json
+++ b/2023/24xxx/CVE-2023-24432.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24432",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Orka by MacStadium Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.31",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Orka by MacStadium Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2772%20(2)",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2772%20(2)",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2772%20(2)"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24433.json
+++ b/2023/24xxx/CVE-2023-24433.json
@@ -1,12 +1,35 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24433",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Orka by MacStadium Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.31",
+                                            "version_affected": "<="
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +50,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Orka by MacStadium Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2772%20(2)",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2772%20(2)",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2772%20(2)"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24434.json
+++ b/2023/24xxx/CVE-2023-24434.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24434",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins GitHub Pull Request Builder Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.42.2",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.42.2",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins GitHub Pull Request Builder Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2789%20(2)",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2789%20(2)",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2789%20(2)"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24435.json
+++ b/2023/24xxx/CVE-2023-24435.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24435",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins GitHub Pull Request Builder Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.42.2",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.42.2",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins GitHub Pull Request Builder Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2789%20(2)",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2789%20(2)",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2789%20(2)"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24436.json
+++ b/2023/24xxx/CVE-2023-24436.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24436",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins GitHub Pull Request Builder Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.42.2",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.42.2",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins GitHub Pull Request Builder Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2789%20(1)",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2789%20(1)",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2789%20(1)"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24437.json
+++ b/2023/24xxx/CVE-2023-24437.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24437",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins JIRA Pipeline Steps Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.0.165.v8846cf59f3db",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.0.165.v8846cf59f3db",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins JIRA Pipeline Steps Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2786",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2786",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2786"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24438.json
+++ b/2023/24xxx/CVE-2023-24438.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24438",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins JIRA Pipeline Steps Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.0.165.v8846cf59f3db",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.0.165.v8846cf59f3db",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins JIRA Pipeline Steps Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2786",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2786",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2786"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24439.json
+++ b/2023/24xxx/CVE-2023-24439.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24439",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins JIRA Pipeline Steps Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.0.165.v8846cf59f3db",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.0.165.v8846cf59f3db",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins JIRA Pipeline Steps Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2774",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2774",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2774"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24440.json
+++ b/2023/24xxx/CVE-2023-24440.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24440",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins JIRA Pipeline Steps Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.0.165.v8846cf59f3db",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.0.165.v8846cf59f3db",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins JIRA Pipeline Steps Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2774",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2774",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2774"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24441.json
+++ b/2023/24xxx/CVE-2023-24441.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24441",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins MSTest Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.0.0",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.0.0",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins MSTest Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2292",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2292",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2292"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24442.json
+++ b/2023/24xxx/CVE-2023-24442.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24442",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins GitHub Pull Request Coverage Status Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.2.0",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.2.0",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins GitHub Pull Request Coverage Status Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2767",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2767",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2767"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24443.json
+++ b/2023/24xxx/CVE-2023-24443.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24443",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins TestComplete support Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.8.1",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.8.1",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins TestComplete support Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2741",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2741",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2741"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24444.json
+++ b/2023/24xxx/CVE-2023-24444.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24444",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins OpenID Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.4",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.4",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins OpenID Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2996",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2996",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2996"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24445.json
+++ b/2023/24xxx/CVE-2023-24445.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24445",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins OpenID Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.4",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.4",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins OpenID Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2997",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2997",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2997"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24446.json
+++ b/2023/24xxx/CVE-2023-24446.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24446",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins OpenID Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.4",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.4",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins OpenID Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2995",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2995",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2995"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24447.json
+++ b/2023/24xxx/CVE-2023-24447.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24447",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins RabbitMQ Consumer Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.8",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.8",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins RabbitMQ Consumer Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2778",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2778",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2778"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24448.json
+++ b/2023/24xxx/CVE-2023-24448.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24448",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins RabbitMQ Consumer Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.8",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.8",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins RabbitMQ Consumer Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2778",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2778",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2778"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24449.json
+++ b/2023/24xxx/CVE-2023-24449.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24449",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins PWauth Security Realm Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "0.4",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "0.4",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins PWauth Security Realm Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2985",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2985",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2985"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24450.json
+++ b/2023/24xxx/CVE-2023-24450.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24450",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins view-cloner Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.1",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.1",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins view-cloner Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2787",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2787",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2787"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24451.json
+++ b/2023/24xxx/CVE-2023-24451.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24451",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Cisco Spark Notifier Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.1.1",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.1.1",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Cisco Spark Notifier Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2803",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2803",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2803"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24452.json
+++ b/2023/24xxx/CVE-2023-24452.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24452",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins TestQuality Updater Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.3",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.3",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins TestQuality Updater Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2800",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2800",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2800"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24453.json
+++ b/2023/24xxx/CVE-2023-24453.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24453",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins TestQuality Updater Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.3",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.3",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins TestQuality Updater Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2800",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2800",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2800"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24454.json
+++ b/2023/24xxx/CVE-2023-24454.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24454",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins TestQuality Updater Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.3",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.3",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins TestQuality Updater Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2091",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2091",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2091"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24455.json
+++ b/2023/24xxx/CVE-2023-24455.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24455",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins visualexpert Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "1.3",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "1.3",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins visualexpert Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2709",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2709",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2709"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24456.json
+++ b/2023/24xxx/CVE-2023-24456.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24456",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Keycloak Authentication Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.3.0",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.3.0",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Keycloak Authentication Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2987",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2987",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2987"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24457.json
+++ b/2023/24xxx/CVE-2023-24457.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24457",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins Keycloak Authentication Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "2.3.0",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "2.3.0",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins Keycloak Authentication Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2986",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2986",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2986"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24458.json
+++ b/2023/24xxx/CVE-2023-24458.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24458",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins BearyChat Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "3.0.2",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "3.0.2",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins BearyChat Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2745",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2745",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2745"
+                "refsource": "CONFIRM"
             }
         ]
     }

--- a/2023/24xxx/CVE-2023-24459.json
+++ b/2023/24xxx/CVE-2023-24459.json
@@ -1,12 +1,39 @@
 {
-    "data_version": "4.0",
-    "data_type": "CVE",
-    "data_format": "MITRE",
     "CVE_data_meta": {
         "ID": "CVE-2023-24459",
-        "ASSIGNER": "jenkinsci-cert@googlegroups.com",
-        "STATE": "PUBLIC"
+        "ASSIGNER": "jenkinsci-cert@googlegroups.com"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "vendor_name": "Jenkins Project",
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Jenkins BearyChat Plugin",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "3.0.2",
+                                            "version_affected": "<="
+                                        },
+                                        {
+                                            "version_value": "3.0.2",
+                                            "version_affected": "?>"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
@@ -27,36 +54,12 @@
             }
         ]
     },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "Jenkins Project",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "Jenkins BearyChat Plugin",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "0",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
     "references": {
         "reference_data": [
             {
+                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2745",
                 "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2745",
-                "refsource": "MISC",
-                "name": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2745"
+                "refsource": "CONFIRM"
             }
         ]
     }


### PR DESCRIPTION
Fixes up affected version ranges due to item 1 in https://cveproject.github.io/automation-cve-services-known-issues#immediate-priority-issues

We didn't notice in December because back then we were affected by item 2 as well, so no down-conversion result existed that we could have checked (since we no longer provide CWE in v5).

Also fixes up `"refsource":"MISC"` to `"refsource":"CONFIRM"` from `"tags":["vendor-advisory"]`.