### PR TITLE
Revoke CVE-2022-23529

### DIFF
--- a/2022/23xxx/CVE-2022-23529.json
+++ b/2022/23xxx/CVE-2022-23529.json
@@ -5,86 +5,13 @@
     "CVE_data_meta": {
         "ID": "CVE-2022-23529",
         "ASSIGNER": "security-advisories@github.com",
-        "STATE": "PUBLIC"
+        "STATE": "REJECT"
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "node-jsonwebtoken is a JsonWebToken implementation for node.js. For versions `<= 8.5.1` of `jsonwebtoken` library, if a malicious actor has the ability to modify the key retrieval parameter (referring to the `secretOrPublicKey` argument from the readme link of the `jwt.verify()` function, they can write arbitrary files on the host machine. Users are affected only if untrusted entities are allowed to modify the key retrieval parameter of the `jwt.verify()` on a host that you control. This issue has been fixed, please update to version 9.0.0."
-            }
-        ]
-    },
-    "problemtype": {
-        "problemtype_data": [
-            {
-                "description": [
-                    {
-                        "lang": "eng",
-                        "value": "CWE-20: Improper Input Validation",
-                        "cweId": "CWE-20"
-                    }
-                ]
-            }
-        ]
-    },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "auth0",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "node-jsonwebtoken",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_value": "<= 8.5.1",
-                                            "version_affected": "="
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "references": {
-        "reference_data": [
-            {
-                "url": "https://github.com/auth0/node-jsonwebtoken/security/advisories/GHSA-27h2-hvpr-p74q",
-                "refsource": "MISC",
-                "name": "https://github.com/auth0/node-jsonwebtoken/security/advisories/GHSA-27h2-hvpr-p74q"
-            },
-            {
-                "url": "https://github.com/auth0/node-jsonwebtoken/commit/e1fa9dcc12054a8681db4e6373da1b30cf7016e3",
-                "refsource": "MISC",
-                "name": "https://github.com/auth0/node-jsonwebtoken/commit/e1fa9dcc12054a8681db4e6373da1b30cf7016e3"
-            }
-        ]
-    },
-    "source": {
-        "advisory": "GHSA-27h2-hvpr-p74q",
-        "discovery": "UNKNOWN"
-    },
-    "impact": {
-        "cvss": [
-            {
-                "attackComplexity": "LOW",
-                "attackVector": "NETWORK",
-                "availabilityImpact": "LOW",
-                "baseScore": 7.6,
-                "baseSeverity": "HIGH",
-                "confidentialityImpact": "LOW",
-                "integrityImpact": "HIGH",
-                "privilegesRequired": "LOW",
-                "scope": "UNCHANGED",
-                "userInteraction": "NONE",
-                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:H/A:L",
-                "version": "3.1"
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: The issue is not a vulnerability. Notes: none."
             }
         ]
     }


### PR DESCRIPTION
Revoking this CVE after collaborating with the maintainers and researchers. More information can be found in [this](https://github.com/github/advisory-database/pull/1595#issuecomment-1407111987) thread. The [corresponding advisory](https://github.com/advisories/GHSA-27h2-hvpr-p74q) has since been withdrawn. 