### PR TITLE
Modify CVE-2023-23616 for GHSA-6xff-p329-9pgf

### DIFF
--- a/2023/23xxx/CVE-2023-23616.json
+++ b/2023/23xxx/CVE-2023-23616.json
@@ -1,18 +1,111 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "security-advisories@github.com",
         "ID": "CVE-2023-23616",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Discourse membership requests lack character limit"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "discourse",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "3.0.1",
+                                            "version_value": "3.0.1"
+                                        },
+                                        {
+                                            "version_affected": "=",
+                                            "version_name": "3.1.0.beta1",
+                                            "version_value": "3.1.0.beta1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "discourse"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Discourse is an open-source discussion platform. Prior to version 3.0.1 on the `stable` branch and 3.1.0.beta2 on the `beta` and `tests-passed` branches, when submitting a membership request, there is no character limit for the reason provided with the request. This could potentially allow a user to flood the database with a large amount of data. However it is unlikely this could be used as part of a DoS attack, as the paths reading back the reasons are only available to administrators. Starting in version 3.0.1 on the `stable` branch and 3.1.0.beta2 on the `beta` and `tests-passed` branches, a limit of 280 characters has been introduced for membership requests."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 3.5,
+            "baseSeverity": "LOW",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-400 Uncontrolled Resource Consumption"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/discourse/discourse/security/advisories/GHSA-6xff-p329-9pgf",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/discourse/discourse/security/advisories/GHSA-6xff-p329-9pgf"
+            },
+            {
+                "name": "https://github.com/discourse/discourse/commit/d5745d34c20c31a221039d8913f33064433003ea",
+                "refsource": "MISC",
+                "url": "https://github.com/discourse/discourse/commit/d5745d34c20c31a221039d8913f33064433003ea"
+            },
+            {
+                "name": "https://github.com/discourse/discourse/pull/19993",
+                "refsource": "MISC",
+                "url": "https://github.com/discourse/discourse/pull/19993"
+            },
+            {
+                "name": "https://github.com/discourse/discourse/commit/3e0cc4a5d9ef44ad902f6985d046ebb32f0a14ee",
+                "refsource": "MISC",
+                "url": "https://github.com/discourse/discourse/commit/3e0cc4a5d9ef44ad902f6985d046ebb32f0a14ee"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "GHSA-6xff-p329-9pgf",
+        "defect": [
+            "GHSA-6xff-p329-9pgf"
+        ],
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
Correct vulnerable version ranges and modify description to reflect the correction