### PR TITLE
Add CVE-2023-22380

### DIFF
--- a/2023/22xxx/CVE-2023-22380.json
+++ b/2023/22xxx/CVE-2023-22380.json
@@ -1,18 +1,73 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2023-22380",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "product-cna@github.com",
+    "ID": "CVE-2023-22380",
+    "STATE": "PUBLIC",
+    "TITLE": "Path traversal in GitHub Enterprise Server leading to arbitrary file reading when building a GitHub Pages site"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "GitHub Enterprise Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.7",
+                      "version_value": "3.7.6"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "GitHub"
+        }
+      ]
     }
+  },
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "yvvdwf"
+    }
+  ],
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "A path traversal vulnerability was identified in GitHub Enterprise Server that allowed arbitrary file reading when building a GitHub Pages site. To exploit this vulnerability, an attacker would need permission to create and build a GitHub Pages site on the GitHub Enterprise Server instance. This vulnerability affected all versions of GitHub Enterprise Server since 3.7 and was fixed in version 3.7.6. This vulnerability was reported via the GitHub Bug Bounty program."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-22: Path Traversal"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.7/admin/release-notes#3.7.6"
+      }
+    ]
+  },
+  "source": {
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
This pull request adds `CVE-2023-22380` for GitHub Enterprise Server.