### PR TITLE
Adding ClamAV CVE-2022-20803

### DIFF
--- a/2022/20xxx/CVE-2022-20803.json
+++ b/2022/20xxx/CVE-2022-20803.json
@@ -1,18 +1,107 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-20803",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+  "dataType": "CVE_RECORD",
+  "dataVersion": "5.0",
+  "cveMetadata": {
+      "cveId": "CVE-2022-20803",
+      "assignerOrgId": "00000000-0000-4000-9000-000000000000",
+      "requesterUserId": "00000000-0000-4000-9000-000000000000",
+      "serial": 1,
+      "state": "PUBLISHED"
     },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "containers": {
+      "cna": {
+            "providerMetadata": {
+                    "orgId": "00000000-0000-4000-9000-000000000000"
+                  },
+            "title": "ClamAV Double-free Vulnerability in the OLE2 File Parser",
+            "datePublic": "2023-02-15T16:40:00.000Z",
+            "problemTypes": [
+                    {
+                              "descriptions": [
+                                          {
+                                                        "lang": "en",
+                                                        "cweId": "CWE-415",
+                                                        "description": "CWE-415 Double Free",
+                                                        "type": "CWE"
+                                                      }
+                                        ]
+                            }
+                  ],
+            "impacts": [
+                    {
+                              "capecId": "CAPEC-153",
+                              "descriptions": [
+                                          {
+                                                        "lang": "en",
+                                                        "value": "CAPEC-153 Input Data Manipulation"
+                                                      }
+                                        ]
+                            }
+                  ],
+            "affected": [
+                    {
+                              "vendor": "Cisco",
+                              "product": "ClamAV",
+                              "versions": [
+                                          {
+                                                        "status": "affected",
+                                                        "version": "0.104.0",
+                                                        "lessThanOrEqual": "0.104.2",
+                                                        "versionType": "custom"
+                                                      }
+                                        ],
+                              "defaultStatus": "unaffected"
+                            }
+                  ],
+            "descriptions": [
+                    {
+                              "lang": "en",
+                              "value": "[PROBLEMTYPE] in [COMPONENT] in [VENDOR] [PRODUCT] [VERSION] on [PLATFORMS] allows [ATTACKER] to [IMPACT] via [VECTOR]",
+                              "supportingMedia": [
+                                          {
+                                                        "type": "text/html",
+                                                        "base64": false,
+                                                        "value": "[PROBLEMTYPE] in [COMPONENT] in [VENDOR] [PRODUCT] [VERSION] on [PLATFORMS] allows [ATTACKER] to [IMPACT] via [VECTOR]"
+                                                      }
+                                        ]
+                            }
+                  ],
+            "references": [
+                    {
+                              "url": "https://https://blog.clamav.net/2022/05/clamav-01050-01043-01036-released.html"
+                            }
+                  ],
+            "metrics": [
+                    {
+                              "format": "CVSS",
+                              "scenarios": [
+                                          {
+                                                        "lang": "en",
+                                                        "value": "GENERAL"
+                                                      }
+                                        ],
+                              "cvssV3_1": {
+                                          "version": "3.1",
+                                          "attackVector": "NETWORK",
+                                          "attackComplexity": "LOW",
+                                          "privilegesRequired": "NONE",
+                                          "userInteraction": "NONE",
+                                          "scope": "CHANGED",
+                                          "confidentialityImpact": "NONE",
+                                          "integrityImpact": "NONE",
+                                          "availabilityImpact": "HIGH",
+                                          "baseSeverity": "HIGH",
+                                          "baseScore": 8.6,
+                                          "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:H"
+                                        }
+                            }
+                  ],
+            "source": {
+                    "discovery": "UNKNOWN"
+                  },
+            "x_generator": {
+                    "engine": "TVCE"
+                  }
+          }
     }
 }

--- a/2022/20xxx/CVE-2022-20803.json
+++ b/2022/20xxx/CVE-2022-20803.json
@@ -1,107 +1,88 @@
 {
-  "dataType": "CVE_RECORD",
-  "dataVersion": "5.0",
-  "cveMetadata": {
-      "cveId": "CVE-2022-20803",
-      "assignerOrgId": "00000000-0000-4000-9000-000000000000",
-      "requesterUserId": "00000000-0000-4000-9000-000000000000",
-      "serial": 1,
-      "state": "PUBLISHED"
+    "CVE_data_meta": {
+        "ASSIGNER": "psirt@cisco.com",
+        "DATE_PUBLIC": "2022-05-04T16:08:00.000Z",
+        "ID": "CVE-2022-20803",
+        "STATE": "PUBLIC",
+        "TITLE": "ClamAV Double-free Vulnerability in the OLE2 File Parser"
     },
-  "containers": {
-      "cna": {
-            "providerMetadata": {
-                    "orgId": "00000000-0000-4000-9000-000000000000"
-                  },
-            "title": "ClamAV Double-free Vulnerability in the OLE2 File Parser",
-            "datePublic": "2023-02-15T16:40:00.000Z",
-            "problemTypes": [
-                    {
-                              "descriptions": [
-                                          {
-                                                        "lang": "en",
-                                                        "cweId": "CWE-415",
-                                                        "description": "CWE-415 Double Free",
-                                                        "type": "CWE"
-                                                      }
-                                        ]
-                            }
-                  ],
-            "impacts": [
-                    {
-                              "capecId": "CAPEC-153",
-                              "descriptions": [
-                                          {
-                                                        "lang": "en",
-                                                        "value": "CAPEC-153 Input Data Manipulation"
-                                                      }
-                                        ]
-                            }
-                  ],
-            "affected": [
-                    {
-                              "vendor": "Cisco",
-                              "product": "ClamAV",
-                              "versions": [
-                                          {
-                                                        "status": "affected",
-                                                        "version": "0.104.0",
-                                                        "lessThanOrEqual": "0.104.2",
-                                                        "versionType": "custom"
-                                                      }
-                                        ],
-                              "defaultStatus": "unaffected"
-                            }
-                  ],
-            "descriptions": [
-                    {
-                              "lang": "en",
-                              "value": "[PROBLEMTYPE] in [COMPONENT] in [VENDOR] [PRODUCT] [VERSION] on [PLATFORMS] allows [ATTACKER] to [IMPACT] via [VECTOR]",
-                              "supportingMedia": [
-                                          {
-                                                        "type": "text/html",
-                                                        "base64": false,
-                                                        "value": "[PROBLEMTYPE] in [COMPONENT] in [VENDOR] [PRODUCT] [VERSION] on [PLATFORMS] allows [ATTACKER] to [IMPACT] via [VECTOR]"
-                                                      }
-                                        ]
-                            }
-                  ],
-            "references": [
-                    {
-                              "url": "https://https://blog.clamav.net/2022/05/clamav-01050-01043-01036-released.html"
-                            }
-                  ],
-            "metrics": [
-                    {
-                              "format": "CVSS",
-                              "scenarios": [
-                                          {
-                                                        "lang": "en",
-                                                        "value": "GENERAL"
-                                                      }
-                                        ],
-                              "cvssV3_1": {
-                                          "version": "3.1",
-                                          "attackVector": "NETWORK",
-                                          "attackComplexity": "LOW",
-                                          "privilegesRequired": "NONE",
-                                          "userInteraction": "NONE",
-                                          "scope": "CHANGED",
-                                          "confidentialityImpact": "NONE",
-                                          "integrityImpact": "NONE",
-                                          "availabilityImpact": "HIGH",
-                                          "baseSeverity": "HIGH",
-                                          "baseScore": 8.6,
-                                          "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:H"
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "ClamAV",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "=",
+                                            "version_value": "0.104.0"
                                         }
+                                    ]
+                                }
                             }
-                  ],
-            "source": {
-                    "discovery": "UNKNOWN"
-                  },
-            "x_generator": {
-                    "engine": "TVCE"
-                  }
-          }
+                        ]
+                    },
+                    "vendor_name": "Cisco"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "A vulnerability in the OLE2 file parser of Clam AntiVirus (ClamAV) versions 0.104.0 through 0.104.2 could allow an unauthenticated, remote attacker to cause a denial of service condition on an affected device.The vulnerability is due to incorrect use of the realloc function that may result in a double-free. An attacker could exploit this vulnerability by submitting a crafted OLE2 file to be scanned by ClamAV on the affected device. An exploit could allow the attacker to cause the ClamAV scanning process to crash, resulting in a denial of service condition."
+            }
+        ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.6,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-415 Double Free"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://blog.clamav.net/2022/05/clamav-01050-01043-01036-released.html",
+                "refsource": "CISCO",
+                "url": "https://blog.clamav.net/2022/05/clamav-01050-01043-01036-released.html"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "clamav-01050-01043-01036",
+        "discovery": "UNKNOWN"
     }
 }


### PR DESCRIPTION
A vulnerability in the OLE2 file parser of Clam AntiVirus (ClamAV) versions 0.104.0 through 0.104.2 could allow an unauthenticated, remote attacker to cause a denial of service condition on an affected device.The vulnerability is due to incorrect use of the realloc function that may result in a double-free. An attacker could exploit this vulnerability by submitting a crafted OLE2 file to be scanned by ClamAV on the affected device. An exploit could allow the attacker to cause the ClamAV scanning process to crash, resulting in a denial of service condition.