### PR TITLE
Add CVE-2022-46257 for GitHub Enterprise Server

### DIFF
--- a/2022/46xxx/CVE-2022-46257.json
+++ b/2022/46xxx/CVE-2022-46257.json
@@ -1,18 +1,100 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-46257",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "product-cna@github.com",
+    "ID": "CVE-2022-46257",
+    "STATE": "PUBLIC",
+    "TITLE": "Information disclosure in GitHub Enterprise Server leading to unauthorized viewing of private repository names"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "GitHub Enterprise Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.3",
+                      "version_value": "3.3.17"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.4",
+                      "version_value": "3.4.12"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.5",
+                      "version_value": "3.5.9"
+                    },
+                    {
+                      "version_affected": "<",
+                      "version_name": "3.6",
+                      "version_value": "3.6.5"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "GitHub"
+        }
+      ]
     }
+  },
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "Anthony Bouvet (Kuromatae)"
+    }
+  ],
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "An information disclosure vulnerability was identified in GitHub Enterprise Server that allowed private repositories to be added to a GitHub Actions runner group via the API by a user who did not have access to those repositories, resulting in the repository names being shown in the UI. To exploit this vulnerability, an attacker would need access to the GHES instance, permissions to modify GitHub Actions runner groups, and successfully guess the obfuscated ID of private repositories. This vulnerability affected all versions of GitHub Enterprise Server prior to 3.7 and was fixed in versions 3.3.17, 3.4.12, 3.5.9, 3.6.5. This vulnerability was reported via the GitHub Bug Bounty program."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-200: Information Disclosure"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.3/admin/release-notes#3.3.17"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.4/admin/release-notes#3.4.12"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.5/admin/release-notes#3.5.9"
+      },
+      {
+        "refsource": "CONFIRM",
+        "url": "https://docs.github.com/en/enterprise-server@3.6/admin/release-notes#3.6.5"
+      }
+    ]
+  },
+  "source": {
+    "discovery": "EXTERNAL"
+  }
 }


### PR DESCRIPTION
This pull request adds CVE-2022-46257 for GitHub Enterprise Server ✌️ 