### PR TITLE
Update CVE-2023-27477

### DIFF
--- a/2023/27xxx/CVE-2023-27477.json
+++ b/2023/27xxx/CVE-2023-27477.json
@@ -41,7 +41,7 @@
                                     "version_data": [
                                         {
                                             "version_affected": "=",
-                                            "version_value": "cranelift-codegen: >= 0.84.0, < 0.91.1"
+                                            "version_value": "cranelift-codegen: >= 0.88.0, < 0.91.1"
                                         },
                                         {
                                             "version_affected": "=",


### PR DESCRIPTION
Update the lower bound version on CVE-2023-27477 / GHSA-xm67-587q-r2vw This resolves a typo made during initial CVE submission