### PR TITLE
Modify CVE-2023-25803 description

### DIFF
--- a/2023/25xxx/CVE-2023-25803.json
+++ b/2023/25xxx/CVE-2023-25803.json
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Roxy-WI is a Web interface for managing Haproxy, Nginx, Apache, and Keepalived servers. Versions prior to 6.3.5.0 have a directory traversal vulnerability allows the inclusion of server-side files. This issue is fixed in version 6.3.5.0."
+                "value": "Roxy-WI is a Web interface for managing Haproxy, Nginx, Apache, and Keepalived servers. Versions prior to 6.3.5.0 have a directory traversal vulnerability that allows the inclusion of server-side files. This issue is fixed in version 6.3.5.0."
             }
         ]
     },


### PR DESCRIPTION
Adds missing "that" to description