### PR TITLE
Modify CVE-2023-27585 description

### DIFF
--- a/2023/27xxx/CVE-2023-27585.json
+++ b/2023/27xxx/CVE-2023-27585.json
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "PJSIP is a free and open source multimedia communication library written in C. A buffer overflow vulnerability in versions 2.13 and prior affects applications that use PJSIP DNS resolver. It doesn't affect PJSIP users who do not utilise PJSIP DNS resolver. This vulnerability is related to CVE-2022-24793. A patch is available as commit `d1c5e4d` in the `master` branch. A workaround is to disable DNS resolution in PJSIP config (by setting `nameserver_count` to zero) or use an external resolver implementation instead."
+                "value": "PJSIP is a free and open source multimedia communication library written in C. A buffer overflow vulnerability in versions 2.13 and prior affects applications that use PJSIP DNS resolver. It doesn't affect PJSIP users who do not utilise PJSIP DNS resolver. This vulnerability is related to CVE-2022-24793. The difference is that this issue is in parsing the query record `parse_query()`, while the issue in CVE-2022-24793 is in `parse_rr()`. A patch is available as commit `d1c5e4d` in the `master` branch. A workaround is to disable DNS resolution in PJSIP config (by setting `nameserver_count` to zero) or use an external resolver implementation instead."
             }
         ]
     },


### PR DESCRIPTION
Add description of the difference between CVE-2023-27585 and CVE-2022-24793.