### PR TITLE
Modify CVE-2022-24793 description

### DIFF
--- a/2022/24xxx/CVE-2022-24793.json
+++ b/2022/24xxx/CVE-2022-24793.json
@@ -35,7 +35,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "PJSIP is a free and open source multimedia communication library written in C. A buffer overflow vulnerability in versions 2.12 and prior affects applications that uses PJSIP DNS resolution. It doesn't affect PJSIP users who utilize an external resolver. A patch is available in the `master` branch of the `pjsip/pjproject` GitHub repository. A workaround is to disable DNS resolution in PJSIP config (by setting `nameserver_count` to zero) or use an external resolver instead."
+                "value": "PJSIP is a free and open source multimedia communication library written in C. A buffer overflow vulnerability in versions 2.12 and prior affects applications that use PJSIP DNS resolution. It doesn't affect PJSIP users who utilize an external resolver. This vulnerability is related to CVE-2023-27585. The difference is that this issue is in parsing the query record `parse_rr()`, while the issue in CVE-2023-27585 is in `parse_query()`. A patch is available in the `master` branch of the `pjsip/pjproject` GitHub repository. A workaround is to disable DNS resolution in PJSIP config (by setting `nameserver_count` to zero) or use an external resolver instead."
             }
         ]
     },


### PR DESCRIPTION
Add description of the difference between CVE-2022-24793 and CVE-2023-27585.