### PR TITLE
XSA-427 CVE-2022-42332

### DIFF
--- a/2022/42xxx/CVE-2022-42332.json
+++ b/2022/42xxx/CVE-2022-42332.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-42332",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-42332"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-427"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "All Xen versions from at least 3.2 onwards are vulnerable.  Earlier\nversions have not been inspected.\n\nOnly x86 systems are vulnerable.  The vulnerability is limited to\nmigration and snapshotting of guests, and only to PV ones as well as\nHVM or PVH ones run with shadow paging."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Jan Beulich of SUSE."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "x86 shadow plus log-dirty mode use-after-free\n\nIn environments where host assisted address translation is necessary\nbut Hardware Assisted Paging (HAP) is unavailable, Xen will run guests\nin so called shadow mode.  Shadow mode maintains a pool of memory used\nfor both shadow page tables as well as auxiliary data structures.  To\nmigrate or snapshot guests, Xen additionally runs them in so called\nlog-dirty mode.  The data structures needed by the log-dirty tracking\nare part of aformentioned auxiliary data.\n\nIn order to keep error handling efforts within reasonable bounds, for\noperations which may require memory allocations shadow mode logic\nensures up front that enough memory is available for the worst case\nrequirements.  Unfortunately, while page table memory is properly\naccounted for on the code path requiring the potential establishing of\nnew shadows, demands by the log-dirty infrastructure were not taken into\nconsideration.  As a result, just established shadow page tables could\nbe freed again immediately, while other code is still accessing them on\nthe assumption that they would remain allocated."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Guests running in shadow mode and being subject to migration or\nsnapshotting may be able to cause Denial of Service and other problems,\nincluding escalation of privilege."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-427.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Not migrating or snapshotting guests will avoid the vulnerability.\n\nRunning only HVM or PVH guests and only in HAP (Hardware Assisted\nPaging) mode will also avoid the vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-427 CVE-2022-42332

CVE data entry for:
  CVE-2022-42332

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
