### PR TITLE
Reject CVE 2023 28426

### DIFF
--- a/2023/28xxx/CVE-2023-28426.json
+++ b/2023/28xxx/CVE-2023-28426.json
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: GHSA-xrqq-wqh4-5hg2. Reason: This candidate was withdrawn. Further investigation showed that this CVE was assigned in error. Notes: See https://github.com/darylldoyle/svg-sanitizer/issues/88 for a technical discussion."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: GHSA-xrqq-wqh4-5hg2. Reason: Further investigation showed that this CVE was assigned in error. Notes: See https://github.com/darylldoyle/svg-sanitizer/issues/88 for a technical discussion."
             }
         ]
     },

--- a/2023/28xxx/CVE-2023-28426.json
+++ b/2023/28xxx/CVE-2023-28426.json
@@ -14,5 +14,5 @@
                 "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: GHSA-xrqq-wqh4-5hg2. Reason: Further investigation showed that this CVE was assigned in error. Notes: See https://github.com/darylldoyle/svg-sanitizer/issues/88 for a technical discussion."
             }
         ]
-    },
+    }
 }

--- a/2023/28xxx/CVE-2023-28426.json
+++ b/2023/28xxx/CVE-2023-28426.json
@@ -5,87 +5,14 @@
     "CVE_data_meta": {
         "ID": "CVE-2023-28426",
         "ASSIGNER": "security-advisories@github.com",
-        "STATE": "PUBLIC"
+        "STATE": "REJECT"
     },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "savg-sanitizer is a PHP SVG/XML Sanitizer. A bypass has been found in versions prior to 0.16.0 that allows an attacker to upload an SVG with persistent cross-site scripting. HTML elements within CDATA needed to be sanitized correctly, as we were converting them to a textnode and therefore, the library wasn't seeing them as DOM elements. This issue is fixed in version 0.16.0. Any data within a CDATA node will now be sanitised using HTMLPurifier. The maintainers have also removed many of the HTML and MathML elements from the allowed element list, as without ForiegnObject, they're not legal within the SVG context. There are no known workarounds."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: GHSA-xrqq-wqh4-5hg2. Reason: This candidate was withdrawn. Further investigation showed that this CVE was assigned in error. Notes: See https://github.com/darylldoyle/svg-sanitizer/issues/88 for a technical discussion."
             }
         ]
     },
-    "problemtype": {
-        "problemtype_data": [
-            {
-                "description": [
-                    {
-                        "lang": "eng",
-                        "value": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
-                        "cweId": "CWE-79"
-                    }
-                ]
-            }
-        ]
-    },
-    "affects": {
-        "vendor": {
-            "vendor_data": [
-                {
-                    "vendor_name": "darylldoyle",
-                    "product": {
-                        "product_data": [
-                            {
-                                "product_name": "svg-sanitizer",
-                                "version": {
-                                    "version_data": [
-                                        {
-                                            "version_affected": "=",
-                                            "version_value": "< 0.16.0"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "references": {
-        "reference_data": [
-            {
-                "url": "https://github.com/darylldoyle/svg-sanitizer/security/advisories/GHSA-xrqq-wqh4-5hg2",
-                "refsource": "MISC",
-                "name": "https://github.com/darylldoyle/svg-sanitizer/security/advisories/GHSA-xrqq-wqh4-5hg2"
-            },
-            {
-                "url": "https://github.com/darylldoyle/svg-sanitizer/commit/cce18bc237c05c6e093e9672db7926788da9b322",
-                "refsource": "MISC",
-                "name": "https://github.com/darylldoyle/svg-sanitizer/commit/cce18bc237c05c6e093e9672db7926788da9b322"
-            }
-        ]
-    },
-    "source": {
-        "advisory": "GHSA-xrqq-wqh4-5hg2",
-        "discovery": "UNKNOWN"
-    },
-    "impact": {
-        "cvss": [
-            {
-                "attackComplexity": "LOW",
-                "attackVector": "NETWORK",
-                "availabilityImpact": "NONE",
-                "baseScore": 5.3,
-                "baseSeverity": "MEDIUM",
-                "confidentialityImpact": "LOW",
-                "integrityImpact": "NONE",
-                "privilegesRequired": "NONE",
-                "scope": "UNCHANGED",
-                "userInteraction": "NONE",
-                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-                "version": "3.1"
-            }
-        ]
-    }
 }


### PR DESCRIPTION
https://github.com/advisories/GHSA-xrqq-wqh4-5hg2 was assigned to [https://github.com/advisories/GHSA-xrqq-wqh4-5hg2]([GHSA-xrqq-wqh4-5hg2](https://github.com/darylldoyle/svg-sanitizer/security/advisories/GHSA-xrqq-wqh4-5hg2)) at the request of the project maintainer
The maintainer subsequently discovered that the CVE request had been in error and has since asked for the CVE to be rejected.
Technical discussion of the issue can be seen here: https://github.com/darylldoyle/svg-sanitizer/issues/88
The request for the CVE to be rejected can be seen here: https://github.com/github/advisory-database/pull/1806