### PR TITLE
ZDI assigns the following 2022 CVEs:

### DIFF
--- a/2022/0xxx/CVE-2022-0194.json
+++ b/2022/0xxx/CVE-2022-0194.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-0194",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-0194",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Netatalk",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.1.12"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Netatalk"
+        }
+      ]
     }
+  },
+  "credit": "Theori (@theori_io)",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Netatalk. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the ad_addcomment function. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a fixed-length stack-based buffer. An attacker can leverage this vulnerability to execute code in the context of root.\n Was ZDI-CAN-15876."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121: Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-530/"
+      },
+      {
+        "url": "https://netatalk.sourceforge.io/3.1/ReleaseNotes3.1.13.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/0xxx/CVE-2022-0650.json
+++ b/2022/0xxx/CVE-2022-0650.json
@@ -1,18 +1,67 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-0650",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-0650",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "TL-WR940N",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.20.1 Build 200316 Rel.34392n (5553)"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "TP-Link"
+        }
+      ]
     }
+  },
+  "credit": "Vadym Kolisnichenko",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows network-adjacent attackers to execute arbitrary code on affected installations of TP-Link TL-WR940N 3.20.1 Build 200316 Rel.34392n (5553) routers. Authentication is required to exploit this vulnerability.\n\nThe specific flaw exists within the httpd service, which listens on TCP port 80 by default. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a fixed-length stack-based buffer. An attacker can leverage this vulnerability to execute code in the context of root.\n Was ZDI-CAN-13993."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121: Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-407/"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:A/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/1xxx/CVE-2022-1229.json
+++ b/2022/1xxx/CVE-2022-1229.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-1229",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-1229",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "MicroStation CONNECT",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "10.16.2.034"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Bentley"
+        }
+      ]
     }
+  },
+  "credit": "Anonymous",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Bentley MicroStation CONNECT 10.16.2.034. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of IFC files. Crafted data in an IFC file can trigger a write past the end of an allocated buffer. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-16581."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-787: Out-of-bounds Write"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-615/"
+      },
+      {
+        "url": "https://www.bentley.com/en/common-vulnerability-exposure/be-2022-0006"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/1xxx/CVE-2022-1230.json
+++ b/2022/1xxx/CVE-2022-1230.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-1230",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-1230",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Galaxy S21",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "prior to 4.5.40.5"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Samsung"
+        }
+      ]
     }
+  },
+  "credit": "Sam Thomas (@_s_n_t) of Pentest Ltd (@pentestltd)",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows local attackers to execute arbitrary code on affected installations of Samsung Galaxy S21 prior to 4.5.40.5 phones. An attacker must first obtain the ability to execute low-privileged code on the target system in order to exploit this vulnerability.\n\nThe specific flaw exists within the handling of redirections. An attacker can force a redirection to a site that serves malicious content. An attacker can leverage this in conjunction with other vulnerabilities to escalate privileges and execute arbitrary code in the context of the current user. Was ZDI-CAN-15918."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-601: URL Redirection to Untrusted Site ('Open Redirect')"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-621/"
+      },
+      {
+        "url": "https://security.samsungmobile.com/serviceWeb.smsb"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/23xxx/CVE-2022-23121.json
+++ b/2022/23xxx/CVE-2022-23121.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23121",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-23121",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Netatalk",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.1.12"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Netatalk"
+        }
+      ]
     }
+  },
+  "credit": "NCC Group EDG (Alex Plaskett, Cedric Halbronn, Aaron Adams) ",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Netatalk. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the parse_entries function. The issue results from the lack of proper error handling when parsing AppleDouble entries. An attacker can leverage this vulnerability to execute code in the context of root. Was ZDI-CAN-15819."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-755: Improper Handling of Exceptional Conditions"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-527/"
+      },
+      {
+        "url": "https://netatalk.sourceforge.io/3.1/ReleaseNotes3.1.13.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/23xxx/CVE-2022-23122.json
+++ b/2022/23xxx/CVE-2022-23122.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23122",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-23122",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Netatalk",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.1.12"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Netatalk"
+        }
+      ]
     }
+  },
+  "credit": "Orange Tsai (@orange_8361) from DEVCORE Research Team",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": " This vulnerability allows remote attackers to execute arbitrary code on affected installations of Netatalk. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the setfilparams function. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a fixed-length stack-based buffer. An attacker can leverage this vulnerability to execute code in the context of root. Was ZDI-CAN-15837."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121: Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-529/"
+      },
+      {
+        "url": "https://netatalk.sourceforge.io/3.1/ReleaseNotes3.1.13.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/23xxx/CVE-2022-23123.json
+++ b/2022/23xxx/CVE-2022-23123.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23123",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-23123",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Netatalk",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.1.12"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Netatalk"
+        }
+      ]
     }
+  },
+  "credit": "Orange Tsai (@orange_8361) from DEVCORE Research Team",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Netatalk. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the getdirparams method. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated buffer. An attacker can leverage this in conjunction with other vulnerabilities to execute arbitrary code in the context of root. Was ZDI-CAN-15830."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-528/"
+      },
+      {
+        "url": "https://netatalk.sourceforge.io/3.1/ReleaseNotes3.1.13.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/23xxx/CVE-2022-23124.json
+++ b/2022/23xxx/CVE-2022-23124.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23124",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-23124",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Netatalk",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.1.12"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Netatalk"
+        }
+      ]
     }
+  },
+  "credit": "Theori (@theori_io)",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to disclose sensitive information on affected installations of Netatalk. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the get_finderinfo method. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated buffer. An attacker can leverage this in conjunction with other vulnerabilities to execute arbitrary code in the context of root. Was ZDI-CAN-15870."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-525/"
+      },
+      {
+        "url": "https://netatalk.sourceforge.io/3.1/ReleaseNotes3.1.13.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/23xxx/CVE-2022-23125.json
+++ b/2022/23xxx/CVE-2022-23125.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-23125",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-23125",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Netatalk",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "5.18.117"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Netatalk"
+        }
+      ]
     }
+  },
+  "credit": "Theori (@theori_io)",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Netatalk. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the copyapplfile function. When parsing the len element, the process does not properly validate the length of user-supplied data prior to copying it to a fixed-length stack-based buffer. An attacker can leverage this vulnerability to execute code in the context of root. Was ZDI-CAN-15869."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121: Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-526/"
+      },
+      {
+        "url": "https://netatalk.sourceforge.io/3.1/ReleaseNotes3.1.13.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/24xxx/CVE-2022-24352.json
+++ b/2022/24xxx/CVE-2022-24352.json
@@ -1,18 +1,67 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-24352",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-24352",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "AC1750",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "prior to 211210"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "TP-Link"
+        }
+      ]
     }
+  },
+  "credit": "trichimtrich and nyancat0131",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows network-adjacent attackers to execute arbitrary code on affected installations of TP-Link AC1750 prior to 211210 routers. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the NetUSB.ko kernel module. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated buffer. An attacker can leverage this vulnerability to execute code in the context of root. Was ZDI-CAN-15773."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-262/"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/24xxx/CVE-2022-24353.json
+++ b/2022/24xxx/CVE-2022-24353.json
@@ -1,18 +1,67 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-24353",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-24353",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "AC1750",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "1.1.4 Build 20211022 rel.59103(5553)"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "TP-Link"
+        }
+      ]
     }
+  },
+  "credit": "Bien Pham (@bienpnn) from Team Orca of Sea Security (security.sea.com)",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows network-adjacent attackers to execute arbitrary code on affected installations of TP-Link AC1750 1.1.4 Build 20211022 rel.59103(5553) routers. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the NetUSB.ko module. The issue results from the lack of proper validation of user-supplied data, which can result in a read past the end of an allocated buffer. An attacker can leverage this vulnerability to execute code in the context of the root user. Was ZDI-CAN-15769."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-263/"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/24xxx/CVE-2022-24672.json
+++ b/2022/24xxx/CVE-2022-24672.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-24672",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-24672",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "imageCLASS MF644Cdw",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "10.02"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Canon"
+        }
+      ]
     }
+  },
+  "credit": "Mehdi Talbi (@abu_y0ussef), Remi Jullian (@netsecurity1), Thomas Jeunet (@cleptho), from @Synacktiv",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows network-adjacent attackers to execute arbitrary code on affected installations of Canon imageCLASS MF644Cdw 10.02 printers. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the CADM service. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a fixed-length heap-based buffer. An attacker can leverage this vulnerability to execute code in the context of the service account. Was ZDI-CAN-15802."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-122: Heap-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-514/"
+      },
+      {
+        "url": "https://www.usa.canon.com/support/canon-product-advisories/canon-laser-printer-inkjet-printer-and-small-office-multifunctio"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/24xxx/CVE-2022-24673.json
+++ b/2022/24xxx/CVE-2022-24673.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-24673",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-24673",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "imageCLASS MF644Cdw",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "10.02"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Canon"
+        }
+      ]
     }
+  },
+  "credit": "Angelboy (@scwuaptx) from DEVCORE Research Team",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Canon imageCLASS MF644Cdw 10.02 printers. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the implementation of the SLP protocol. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a fixed-length stack-based buffer. An attacker can leverage this vulnerability to execute code in the context of root. Was ZDI-CAN-15845."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121: Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-515/"
+      },
+      {
+        "url": "https://www.usa.canon.com/support/canon-product-advisories/canon-laser-printer-inkjet-printer-and-small-office-multifunctional-printer-measure-against-buffer-overflow"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/24xxx/CVE-2022-24674.json
+++ b/2022/24xxx/CVE-2022-24674.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-24674",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-24674",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "imageCLASS MF644Cdw",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "10.02"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Canon"
+        }
+      ]
     }
+  },
+  "credit": "Nicolas Devillers ( @nikaiw ), Jean-Romain Garnier and Raphael Rigo ( @_trou_ )",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows network-adjacent attackers to execute arbitrary code on affected installations of Canon imageCLASS MF644Cdw 10.02 printers. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the privet API. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a fixed-length stack-based buffer. An attacker can leverage this vulnerability to execute code in the context of root. Was ZDI-CAN-15834."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121: Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-516/"
+      },
+      {
+        "url": "https://www.usa.canon.com/internet/portal/us/home/support/product-advisories/detail/canon-laser-printer-and-small-office-multifunctional-printer-measure-against-buffer-overflow/"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/24xxx/CVE-2022-24907.json
+++ b/2022/24xxx/CVE-2022-24907.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-24907",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-24907",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PDF Reader",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "11.1.0.52543"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Anonymous",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PDF Reader 11.1.0.52543. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of JP2 images. Crafted data in a JP2 image can trigger a read past the end of an allocated buffer. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-16186."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-350/"
+      },
+      {
+        "url": "https://www.foxit.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/24xxx/CVE-2022-24908.json
+++ b/2022/24xxx/CVE-2022-24908.json
@@ -1,18 +1,70 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-24908",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-24908",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "PDF Reader",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "11.1.0.52543"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "Foxit"
+        }
+      ]
     }
+  },
+  "credit": "Anonymous",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Foxit PDF Reader 11.1.0.52543. User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file.\n\nThe specific flaw exists within the parsing of JP2 images. Crafted data in a JP2 image can trigger a read past the end of an allocated buffer. An attacker can leverage this vulnerability to execute code in the context of the current process. Was ZDI-CAN-16187."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-125: Out-of-bounds Read"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-351/"
+      },
+      {
+        "url": "https://www.foxit.com/support/security-bulletins.html"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/24xxx/CVE-2022-24972.json
+++ b/2022/24xxx/CVE-2022-24972.json
@@ -1,18 +1,67 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-24972",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-24972",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "TL-WR940N",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.20.1 Build 200316 Rel.34392n (5553)"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "TP-Link"
+        }
+      ]
     }
+  },
+  "credit": "Vadym Kolisnichenko",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows network-adjacent attackers to disclose sensitive information on affected installations of TP-Link TL-WR940N 3.20.1 Build 200316 Rel.34392n (5553) routers. Authentication is not required to exploit this vulnerability.\n\nThe specific flaw exists within the httpd service, which listens on TCP port 80 by default. The issue results from the lack of proper access control. An attacker can leverage this vulnerability to disclose stored credentials, leading to further compromise.\n\n Was ZDI-CAN-13911."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-284: Improper Access Control"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-405/"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "version": "3.0"
+    }
+  }
 }

--- a/2022/24xxx/CVE-2022-24973.json
+++ b/2022/24xxx/CVE-2022-24973.json
@@ -1,18 +1,67 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-24973",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "CVE_data_meta": {
+    "ASSIGNER": "zdi-disclosures@trendmicro.com",
+    "ID": "CVE-2022-24973",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "product": {
+            "product_data": [
+              {
+                "product_name": "TL-WR940N",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_value": "3.20.1 Build 200316 Rel.34392n (5553)"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "vendor_name": "TP-Link"
+        }
+      ]
     }
+  },
+  "credit": "Vadym Kolisnichenko",
+  "data_format": "MITRE",
+  "data_type": "CVE",
+  "data_version": "4.0",
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "This vulnerability allows network-adjacent attackers to execute arbitrary code on affected installations of TP-Link TL-WR940N 3.20.1 Build 200316 Rel.34392n (5553) routers. Authentication is required to exploit this vulnerability.\n\nThe specific flaw exists within the httpd service, which listens on TCP port 80 by default. The issue results from the lack of proper validation of the length of user-supplied data prior to copying it to a fixed-length stack-based buffer. An attacker can leverage this vulnerability to execute code in the context of root.\n Was ZDI-CAN-13992."
+      }
+    ]
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121: Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-22-406/"
+      }
+    ]
+  },
+  "impact": {
+    "cvss": {
+      "vectorString": "CVSS:3.0/AV:A/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.0"
+    }
+  }
 }


### PR DESCRIPTION
M  2022/0xxx/CVE-2022-0194.json
M  2022/0xxx/CVE-2022-0650.json
M  2022/1xxx/CVE-2022-1229.json
M  2022/1xxx/CVE-2022-1230.json
M  2022/23xxx/CVE-2022-23121.json
M  2022/23xxx/CVE-2022-23122.json
M  2022/23xxx/CVE-2022-23123.json
M  2022/23xxx/CVE-2022-23124.json
M  2022/23xxx/CVE-2022-23125.json
M  2022/24xxx/CVE-2022-24352.json
M  2022/24xxx/CVE-2022-24353.json
M  2022/24xxx/CVE-2022-24672.json
M  2022/24xxx/CVE-2022-24673.json
M  2022/24xxx/CVE-2022-24674.json
M  2022/24xxx/CVE-2022-24907.json
M  2022/24xxx/CVE-2022-24908.json
M  2022/24xxx/CVE-2022-24972.json
M  2022/24xxx/CVE-2022-24973.json