### PR TITLE
XSA-431 CVE-2022-42336

### DIFF
--- a/2022/42xxx/CVE-2022-42336.json
+++ b/2022/42xxx/CVE-2022-42336.json
@@ -1,18 +1,96 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-42336",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2022-42336"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-431"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Only Xen version 4.17 is vulnerable.\n\nOnly x86 AMD systems are vulnerable.  The vulnerability can be leveraged\nby and affects only HVM guests."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "Mishandling of guest SSBD selection on AMD hardware\n\nThe current logic to set SSBD on AMD Family 17h and Hygon Family 18h\nprocessors requires that the setting of SSBD is coordinated at a core\nlevel, as the setting is shared between threads.  Logic was introduced\nto keep track of how many threads require SSBD active in order to\ncoordinate it, such logic relies on using a per-core counter of threads\nthat have SSBD active.\n\nWhen running on the mentioned hardware, it's possible for a guest to\nunder or overflow the thread counter, because each write to\nVIRT_SPEC_CTRL.SSBD by the guest gets propagated to the helper that does\nthe per-core active accounting.  Underflowing the counter causes the\nvalue to get saturated, and thus attempts for guests running on the same\ncore to set SSBD won't have effect because the hypervisor assumes it's\nalready active."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "An attacker with control over a guest can mislead other guests into\nobserving SSBD active when it is not."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-431.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Running PV guests only will prevent the vulnerability.\n\nSetting `spec-ctrl=ssbd` on the hypervisor command line will force SSBD\nto be unconditionally active."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-431 CVE-2022-42336

CVE data entry for:
  CVE-2022-42336

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
