### PR TITLE
XSA-444 CVE-2023-34327 CVE-2023-34328

### DIFF
--- a/2023/34xxx/CVE-2023-34327.json
+++ b/2023/34xxx/CVE-2023-34327.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2023-34327",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2023-34327"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-444"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Only AMD/Hygon hardware supporting the DBEXT feature are vulnerable.\nThis is believed to be the Steamroller microarchitecture and later.\n\nFor CVE-2023-34327, Xen versions 4.5 and later are vulnerable.\n\nFor CVE-2023-34328, Xen version between 4.5 and 4.13 are vulnerable.\nThe issue is benign in Xen 4.14 and later owing to an unrelated change."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Andrew Cooper of XenServer."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "x86/AMD: Debug Mask handling\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nAMD CPUs since ~2014 have extensions to normal x86 debugging functionality.\nXen supports guests using these extensions.\n\nUnfortunately there are errors in Xen's handling of the guest state, leading\nto denials of service.\n\n 1) CVE-2023-34327 - An HVM vCPU can end up operating in the context of\n    a previous vCPUs debug mask state.\n\n 2) CVE-2023-34328 - A PV vCPU can place a breakpoint over the live GDT.\n    This allows the PV vCPU to exploit XSA-156 / CVE-2015-8104 and lock\n    up the CPU entirely."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "For CVE-2023-34327, any guest (PV or HVM) using Debug Masks normally for\nit's own purposes can cause incorrect behaviour in an unrelated HVM\nvCPU, most likely resulting in a guest crash.\n\nFor CVE-2023-34328, a buggy or malicious PV guest kernel can lock up the\nhost."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-444.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "For CVE-2023-34327, HVM VMs which can see the DBEXT feature are not\nsusceptible to running in the wrong state.  By default, VMs will see the\nDBEXT feature on capable hardware, and when not explicitly levelled for\nmigration compatibility.\n\nFor CVE-2023-34328, PV VMs which cannot see the DBEXT feature cannot\nleverage the vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }

--- a/2023/34xxx/CVE-2023-34328.json
+++ b/2023/34xxx/CVE-2023-34328.json
@@ -1,18 +1,108 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2023-34328",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
+   "CVE_data_meta" : {
+      "ASSIGNER" : "security@xenproject.org",
+      "ID" : "CVE-2023-34328"
+   },
+   "affects" : {
+      "vendor" : {
+         "vendor_data" : [
             {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+               "product" : {
+                  "product_data" : [
+                     {
+                        "product_name" : "xen",
+                        "version" : {
+                           "version_data" : [
+                              {
+                                 "version_affected" : "?",
+                                 "version_value" : "consult Xen advisory XSA-444"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name" : "Xen"
             }
-        ]
-    }
+         ]
+      }
+   },
+   "configuration" : {
+      "configuration_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "Only AMD/Hygon hardware supporting the DBEXT feature are vulnerable.\nThis is believed to be the Steamroller microarchitecture and later.\n\nFor CVE-2023-34327, Xen versions 4.5 and later are vulnerable.\n\nFor CVE-2023-34328, Xen version between 4.5 and 4.13 are vulnerable.\nThe issue is benign in Xen 4.14 and later owing to an unrelated change."
+               }
+            ]
+         }
+      }
+   },
+   "credit" : {
+      "credit_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "This issue was discovered by Andrew Cooper of XenServer."
+               }
+            ]
+         }
+      }
+   },
+   "data_format" : "MITRE",
+   "data_type" : "CVE",
+   "data_version" : "4.0",
+   "description" : {
+      "description_data" : [
+         {
+            "lang" : "eng",
+            "value" : "x86/AMD: Debug Mask handling\n\nT[his CNA information record relates to multiple CVEs; the\ntext explains which aspects/vulnerabilities correspond to which CVE.]\n\nAMD CPUs since ~2014 have extensions to normal x86 debugging functionality.\nXen supports guests using these extensions.\n\nUnfortunately there are errors in Xen's handling of the guest state, leading\nto denials of service.\n\n 1) CVE-2023-34327 - An HVM vCPU can end up operating in the context of\n    a previous vCPUs debug mask state.\n\n 2) CVE-2023-34328 - A PV vCPU can place a breakpoint over the live GDT.\n    This allows the PV vCPU to exploit XSA-156 / CVE-2015-8104 and lock\n    up the CPU entirely."
+         }
+      ]
+   },
+   "impact" : {
+      "impact_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "For CVE-2023-34327, any guest (PV or HVM) using Debug Masks normally for\nit's own purposes can cause incorrect behaviour in an unrelated HVM\nvCPU, most likely resulting in a guest crash.\n\nFor CVE-2023-34328, a buggy or malicious PV guest kernel can lock up the\nhost."
+               }
+            ]
+         }
+      }
+   },
+   "problemtype" : {
+      "problemtype_data" : [
+         {
+            "description" : [
+               {
+                  "lang" : "eng",
+                  "value" : "unknown"
+               }
+            ]
+         }
+      ]
+   },
+   "references" : {
+      "reference_data" : [
+         {
+            "url" : "https://xenbits.xenproject.org/xsa/advisory-444.txt"
+         }
+      ]
+   },
+   "workaround" : {
+      "workaround_data" : {
+         "description" : {
+            "description_data" : [
+               {
+                  "lang" : "eng",
+                  "value" : "For CVE-2023-34327, HVM VMs which can see the DBEXT feature are not\nsusceptible to running in the wrong state.  By default, VMs will see the\nDBEXT feature on capable hardware, and when not explicitly levelled for\nmigration compatibility.\n\nFor CVE-2023-34328, PV VMs which cannot see the DBEXT feature cannot\nleverage the vulnerability."
+               }
+            ]
+         }
+      }
+   }
 }


### PR DESCRIPTION
XSA-444 CVE-2023-34327 CVE-2023-34328

CVE data entry for:
  CVE-2023-34327

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
  CVE-2023-34328

(This MR was automatically generated by the Xen Project Security Team's
xensec-internal-tools.  Please let us know if anything could be better.)
