### PR TITLE
Update CVE-2022-31630.json

### DIFF
--- a/2022/31xxx/CVE-2022-31630.json
+++ b/2022/31xxx/CVE-2022-31630.json
@@ -11,7 +11,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "In PHP versions prior to 7.4.33, 8.0.25 and 8.2.12, when using imageloadfont() function in gd extension, it is possible to supply a specially crafted font file, such as if the loaded font is used with imagechar() function, the read outside allocated buffer will be used. This can lead to crashes or disclosure of confidential information."
+                "value": "In PHP versions prior to 7.4.33, 8.0.25 and 8.1.12, when using imageloadfont() function in gd extension, it is possible to supply a specially crafted font file, such as if the loaded font is used with imagechar() function, the read outside allocated buffer will be used. This can lead to crashes or disclosure of confidential information."
             }
         ]
     },


### PR DESCRIPTION
Fix typo in version number.

## Do Not submit PRs to this repo.


The CVE Program Git Hub Pilot is Deprecated as of 30 June 2023. 


Your PR will Not generate a CVE Record. 


Please see CVE.org for more info.
