### PR TITLE
Missing CVSS Vector Info

### DIFF
--- a/2024/30xxx/CVE-2024-30896.json
+++ b/2024/30xxx/CVE-2024-30896.json
@@ -66,14 +66,17 @@
     },
     "impact": {
         "cvss": {
+            "attackVector": "NETWORK",
             "attackComplexity": "LOW",
-            "availabilityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "userInteraction": "NONE",
+            "scope": "CHANGED",
             "confidentialityImpact": "HIGH",
             "integrityImpact": "HIGH",
-            "privilegesRequired": "HIGH",
-            "scope": "CHANGED",
-            "userInteraction": "NONE",
-            "vectorString": "CVSS:3.1/AC:L/A:H/C:H/I:H/PR:H/S:C/UI:N",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9.1,
+            "baseSeverity": "CRITICAL",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:H",
             "version": "3.1"
         }
     }


### PR DESCRIPTION
The missing CVSS vector was completed by using the URL in the references and the deficiencies in other CVSS information were corrected

## Do Not submit PRs to this repo.


The CVE Program Git Hub Pilot is Deprecated as of 30 June 2023. 


Your PR will Not generate a CVE Record. 


Please see CVE.org for more info.
